### PR TITLE
Fix MultiEpochsDataLoader when not all is consumed

### DIFF
--- a/timm/data/loader.py
+++ b/timm/data/loader.py
@@ -5,6 +5,7 @@ https://github.com/NVIDIA/apex/commit/d5e2bb4bdeedd27b1dfaf5bb2b24d6c000dee9be#d
 
 Hacked together by / Copyright 2020 Ross Wightman
 """
+import warnings
 
 import torch.utils.data
 import numpy as np
@@ -246,6 +247,8 @@ class MultiEpochsDataLoader(torch.utils.data.DataLoader):
         # It's inefficient but I can't come up with a better way to do this.
         # Probably avoiding this class completely is more efficient if you're skipping a bunch of items in every epoch.
         for _ in range(self._items_to_consume - 1 - self._last_consumed_item):
+            warnings.warn("Consuming the rest of the sampler items from a previous call. "
+                          "Consider not using MultiEpochsDataLoader as it may take a lot of time.")
             next(self.iterator)
 
         self._items_to_consume = len(self)


### PR DESCRIPTION
If for some reason `MultiEpochsDataLoader.__iter__` gets called but in a previous call the caller didn't consume all its items, then it's gonna continue the previous one, which is incorrect. I propose this arguably inefficient solution as I can't think of another one, that's still better than an incorrect behavior.

An example of when this happens is when you just want to overfit the first batch of the dataset. For example, by using PyTorch Lightning's Trainer `overfit_batches` argument.