### PR TITLE
In load_pretrained helper: Fail if cannot find pretrained model

### DIFF
--- a/timm/models/helpers.py
+++ b/timm/models/helpers.py
@@ -248,7 +248,7 @@ def load_pretrained(
         _logger.info(f'Loading pretrained weights from Hugging Face hub ({pretrained_loc})')
         state_dict = load_state_dict_from_hf(pretrained_loc)
     else:
-        _logger.warning("No pretrained weights exist or were found for this model. Using random initialization.")
+        raise ValueError("No pretrained weights exist or were found for this model.")
         return
 
     if filter_fn is not None:

--- a/timm/models/helpers.py
+++ b/timm/models/helpers.py
@@ -249,7 +249,6 @@ def load_pretrained(
         state_dict = load_state_dict_from_hf(pretrained_loc)
     else:
         raise ValueError("No pretrained weights exist or were found for this model.")
-        return
 
     if filter_fn is not None:
         # for backwards compat with filter fn that take one arg, try one first, the two


### PR DESCRIPTION
Previously, this would only log a warning.

## Motivation

Calling e.g. `timm.create_model('mobilenetv3_small_075', pretrained=True)` to retrieve a pre-trained model will sometimes fail silently (or: only with a warning), potentially leading to hard-to-debug cases where you use a supposedly pretrained model downstream and get unexpected results.  (Consider that I was using Git master while my colleague used the latest timm release; the call to `create_model` didn't fail for both of us, yet my colleague's version behaved differently for less than obvious reasons.)

I believe it would be much less surprising if the call to `timm.create_model(name, pretrained=True)` actually failed in case a pretrained version wasn't available.  Retrieving a randomly initialized version instead is I think not what the user wants when they explicitly set `pretrained=True`.