### PR TITLE
Add CUDA Graph and AOT Autograd support

### DIFF
--- a/timm/utils/cuda.py
+++ b/timm/utils/cuda.py
@@ -17,7 +17,7 @@ from .clip_grad import dispatch_clip_grad
 class ApexScaler:
     state_dict_key = "amp"
 
-    def __call__(self, loss, optimizer, clip_grad=None, clip_mode='norm', parameters=None, create_graph=False):
+    def __call__(self, loss, optimizer, clip_grad=None, clip_mode='norm', parameters=None, create_graph=False, step_and_update=True):
         with amp.scale_loss(loss, optimizer) as scaled_loss:
             scaled_loss.backward(create_graph=create_graph)
         if clip_grad is not None:
@@ -32,6 +32,8 @@ class ApexScaler:
         if 'load_state_dict' in amp.__dict__:
             amp.load_state_dict(state_dict)
 
+    def step_and_update(self):
+        pass
 
 class NativeScaler:
     state_dict_key = "amp_scaler"
@@ -39,17 +41,25 @@ class NativeScaler:
     def __init__(self):
         self._scaler = torch.cuda.amp.GradScaler()
 
-    def __call__(self, loss, optimizer, clip_grad=None, clip_mode='norm', parameters=None, create_graph=False):
+    def __call__(self, loss, optimizer, clip_grad=None, clip_mode='norm', parameters=None, create_graph=False, step_and_update=True):
         self._scaler.scale(loss).backward(create_graph=create_graph)
+        self._optimizer = optimizer
         if clip_grad is not None:
             assert parameters is not None
             self._scaler.unscale_(optimizer)  # unscale the gradients of optimizer's assigned params in-place
             dispatch_clip_grad(parameters, clip_grad, mode=clip_mode)
-        self._scaler.step(optimizer)
-        self._scaler.update()
+        if step_and_update:
+            self._scaler.step(optimizer)
+            self._scaler.update()
 
     def state_dict(self):
         return self._scaler.state_dict()
 
     def load_state_dict(self, state_dict):
         self._scaler.load_state_dict(state_dict)
+
+    def step_and_update(self):
+        # need to separate this step from "scaler.scale(loss)" since scalar.step() syncs GPU with CPU,
+        # which is not allowed for cuda graph capture
+        self._scaler.step(self._optimizer)
+        self._scaler.update()


### PR DESCRIPTION
Add CUDA Graph support with `--cuda-graph` and AOT Autograd support with `--aot-autograd` to **benchmark.py** and **train.py**

The workflow for cuda graph in train.py might be a bit overcomplicated.

Related: https://github.com/rwightman/pytorch-image-models/issues/1244