### PR TITLE
Add gradient accumulation option to train.py

### DIFF
--- a/timm/utils/cuda.py
+++ b/timm/utils/cuda.py
@@ -17,12 +17,13 @@ from .clip_grad import dispatch_clip_grad
 class ApexScaler:
     state_dict_key = "amp"
 
-    def __call__(self, loss, optimizer, clip_grad=None, clip_mode='norm', parameters=None, create_graph=False):
+    def __call__(self, loss, optimizer, clip_grad=None, clip_mode='norm', parameters=None, create_graph=False, need_step=True):
         with amp.scale_loss(loss, optimizer) as scaled_loss:
             scaled_loss.backward(create_graph=create_graph)
         if clip_grad is not None:
             dispatch_clip_grad(amp.master_params(optimizer), clip_grad, mode=clip_mode)
-        optimizer.step()
+        if need_step:
+            optimizer.step()
 
     def state_dict(self):
         if 'state_dict' in amp.__dict__:
@@ -39,14 +40,15 @@ class NativeScaler:
     def __init__(self):
         self._scaler = torch.cuda.amp.GradScaler()
 
-    def __call__(self, loss, optimizer, clip_grad=None, clip_mode='norm', parameters=None, create_graph=False):
+    def __call__(self, loss, optimizer, clip_grad=None, clip_mode='norm', parameters=None, create_graph=False, need_step=True):
         self._scaler.scale(loss).backward(create_graph=create_graph)
         if clip_grad is not None:
             assert parameters is not None
             self._scaler.unscale_(optimizer)  # unscale the gradients of optimizer's assigned params in-place
             dispatch_clip_grad(parameters, clip_grad, mode=clip_mode)
-        self._scaler.step(optimizer)
-        self._scaler.update()
+        if need_step:
+            self._scaler.step(optimizer)
+            self._scaler.update()
 
     def state_dict(self):
         return self._scaler.state_dict()


### PR DESCRIPTION
option: iters-to-accum(iterations to accmulate)

Gradient accumulation improves training performance(samples/s). It can reduce the number of parameter sharing between each node. This option can be helpful when large model needs to be trained with multiple nodes and network is bottleneck.

ex)
maxvit_large_tf_384.in21k_ft_in1k model, batch-size 8
env) 10Gbps network

**Total number of GPU: 3**
1. Three GPUs in **single** node (iters-to-accum: X)
    - 50.3 samples/s
2. Three GPUs in **single** node (iters-to-accum: 32)
    - 59.5 samples/s
3. Single GPU in **three** nodes (iters-to-accum: X)
    - **21.6 samples/s **(network bottleneck)****
4. Single GPU in **three** nodes (iters-to-accum: 32)
    - **57.1 samples/s**

Even if single node is used, the performance of 2 is better than 1. That's because it reduces the number of gradient updates.
4 resolves the network bottleneck issue in 3, because it reduces the number of parameter sharing to 1/32.

Signed-off-by: Taeksang Kim <voidbag@puzzle-ai.com>