### PR TITLE
add simplenet architecture

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -142,6 +142,10 @@ NOTE: I am deprecating this version of the networks, the new ones are part of `r
 * Paper: `Squeeze-and-Excitation Networks` - https://arxiv.org/abs/1709.01507
 * Code: https://github.com/Cadene/pretrained-models.pytorch 
 
+## SimpleNet [[simplenet.py](https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/simplenet.py)]
+* Paper: `Lets Keep it simple, Using simple architectures to outperform deeper and more complex architectures` - https://arxiv.org/abs/1608.06037
+* Code: https://github.com/Coderx7/SimpleNet_Pytorch
+
 ## TResNet [[tresnet.py](https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/tresnet.py)]
 * Paper: `TResNet: High Performance GPU-Dedicated Architecture` - https://arxiv.org/abs/2003.13630
 * Code: https://github.com/mrT23/TResNet

--- a/docs/models/simplenet.md
+++ b/docs/models/simplenet.md
@@ -1,0 +1,96 @@
+# SimpleNet v1
+
+**SimpleNetV1** is a convolutional neural network that is designed with simplicity in mind and outperforms much deeper and more complex architectures. The network design includes the most basic operators in a plain CNN network and is completely comprised of just Convolutional layers followed by BatchNormalization and ReLU activation function.  
+
+## How do I use this model on an image?
+To load a pretrained model:
+simply choose a variant among available ones and do as follows:
+```python
+import timm
+model = timm.create_model('simplenetv1_5m_m2', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# Samoyed 0.8442415595054626
+# Pomeranian 0.09159677475690842
+# Great Pyrenees 0.013929242268204689
+# Arctic fox 0.00913404393941164
+# white wolf 0.008576451800763607
+```
+
+Replace the model name with the variant you want to use, e.g. `simplenetv1_9m_m2`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('simplenetv1_5m_m2', pretrained=True, num_classes=NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/HasanPourRVS16,
+  author    = {Seyyed Hossein HasanPour and
+               Mohammad Rouhani and
+               Mohsen Fayyaz and
+               Mohammad Sabokrou},
+  title     = {Lets keep it simple, Using simple architectures to outperform deeper
+               and more complex architectures},
+  journal   = {CoRR},
+  volume    = {abs/1608.06037},
+  year      = {2016},
+  url       = {http://arxiv.org/abs/1608.06037},
+  eprinttype = {arXiv},
+  eprint    = {1608.06037},
+  timestamp = {Mon, 13 Aug 2018 16:48:25 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/HasanPourRVS16.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```

--- a/docs/models/simplenet.md
+++ b/docs/models/simplenet.md
@@ -50,11 +50,11 @@ top5_prob, top5_catid = torch.topk(probabilities, 5)
 for i in range(top5_prob.size(0)):
     print(categories[top5_catid[i]], top5_prob[i].item())
 # prints class names and probabilities like:
-# Samoyed 0.8442415595054626
-# Pomeranian 0.09159677475690842
-# Great Pyrenees 0.013929242268204689
-# Arctic fox 0.00913404393941164
-# white wolf 0.008576451800763607
+# Samoyed    0.9452909231185913
+# Pomeranian 0.04509485140442848
+# white wolf 0.0029849212151020765
+# Arctic fox 0.0020403596572577953
+# keeshond   0.0009282337850891054
 ```
 
 Replace the model name with the variant you want to use, e.g. `simplenetv1_9m_m2`. You can find the IDs in the model summaries at the top of this page.

--- a/timm/models/__init__.py
+++ b/timm/models/__init__.py
@@ -48,6 +48,7 @@ from .rexnet import *
 from .selecsls import *
 from .senet import *
 from .sequencer import *
+from .simplenet import *
 from .sknet import *
 from .swin_transformer import *
 from .swin_transformer_v2 import *

--- a/timm/models/simplenet.py
+++ b/timm/models/simplenet.py
@@ -1,0 +1,496 @@
+""" SimpleNet
+
+Paper: `Lets Keep it simple, Using simple architectures to outperform deeper and more complex architectures`
+    - https://arxiv.org/abs/1608.06037
+
+@article{hasanpour2016lets,
+  title={Lets keep it simple, Using simple architectures to outperform deeper and more complex architectures},
+  author={Hasanpour, Seyyed Hossein and Rouhani, Mohammad and Fayyaz, Mohsen and Sabokrou, Mohammad},
+  journal={arXiv preprint arXiv:1608.06037},
+  year={2016}
+}
+
+Official Caffe impl at https://github.com/Coderx7/SimpleNet
+Official Pythorch impl at https://github.com/Coderx7/SimpleNet_Pytorch
+Seyyed Hossein Hasanpour
+"""
+import math
+from typing import Union, Tuple, List, Dict, Any, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from ._builder import build_model_with_cfg
+from ._registry import register_model
+from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
+
+__all__ = [
+    "simplenet",
+    "simplenetv1_small_m1_05",  # 1.5m
+    "simplenetv1_small_m2_05",  # 1.5m
+    "simplenetv1_small_m1_075",  # 3m
+    "simplenetv1_small_m2_075",  # 3m
+    "simplenetv1_5m_m1",  # 5m
+    "simplenetv1_5m_m2",  # 5m
+    "simplenetv1_9m_m1",  # 9m
+    "simplenetv1_9m_m2",  # 9m
+]  # model_registry will add each entrypoint fn to this
+
+
+def _cfg(url="", **kwargs):
+    return {
+        "url": url,
+        "num_classes": 1000,
+        "input_size": (3, 224, 224),
+        "crop_pct": 0.875,
+        "interpolation": "bicubic",
+        "mean": IMAGENET_DEFAULT_MEAN,
+        "std": IMAGENET_DEFAULT_STD,
+        **kwargs,
+    }
+
+
+default_cfgs: Dict[str, Dict[str, Any]] = {
+    "simplenetv1_small_m1_05": _cfg(
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_small_m1_05-a7ec600b.pth"
+    ),
+    "simplenetv1_small_m2_05": _cfg(
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_small_m2_05-62617ea1.pth"
+    ),
+    "simplenetv1_small_m1_075": _cfg(
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_small_m1_075-8427bf60.pth"
+    ),
+    "simplenetv1_small_m2_075": _cfg(
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_small_m2_075-da714eb5.pth"
+    ),
+    "simplenetv1_5m_m1": _cfg(
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_5m_m1-cc6b3ad1.pth"
+    ),
+    "simplenetv1_5m_m2": _cfg(
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_5m_m2-c35297bf.pth"
+    ),
+    "simplenetv1_9m_m1": _cfg(
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_9m_m1-8c98a0a5.pth"
+    ),
+    "simplenetv1_9m_m2": _cfg(
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_9m_m2-6b01be1e.pth"
+    ),
+}
+
+
+class View(nn.Module):
+    def forward(self, x):
+        print(f"{x.shape}")
+        return x
+
+
+class SimpleNet(nn.Module):
+    def __init__(
+        self,
+        num_classes: int = 1000,
+        in_chans: int = 3,
+        scale: float = 1,
+        network_idx: int = 0,
+        mode: int = 2,
+        drop_rates: Dict[int, float] = {},
+    ):
+        """Instantiates a SimpleNet model. SimpleNet is comprised of the most basic building blocks of a CNN architecture.
+        It uses basic principles to maximize the network performance both in terms of feature representation and speed without
+        resorting to complex design or operators.
+
+        Args:
+            num_classes (int, optional): number of classes. Defaults to 1000.
+            in_chans (int, optional): number of input channels. Defaults to 3.
+            scale (float, optional): scale of the architecture width. Defaults to 1.0.
+            network_idx (int, optional): the network index indicating the 5 million or 8 million version(0 and 1 respectively). Defaults to 0.
+            mode (int, optional): stride mode of the architecture. specifies how fast the input shrinks.
+                This is used for larger input sizes such as the 224x224 in imagenet training where the
+                input size incurs a lot of overhead if not downsampled properly.
+                you can choose between 0 meaning no change and 4. where each number denotes a specific
+                downsampling strategy. For imagenet use 1-4.
+                the larger the stride mode, usually the higher accuracy and the slower
+                the network gets. stride mode 1 is the fastest and achives very good accuracy.
+                Defaults to 2.
+            drop_rates (Dict[int,float], optional): custom drop out rates specified per layer.
+                each rate should be paired with the corrosponding layer index(pooling and cnn layers are counted only). Defaults to {}.
+        """
+        super(SimpleNet, self).__init__()
+        # (channels or layer-type, stride=1, drp=0.)
+        self.cfg: Dict[str, List[Tuple[Union(int, str), int, Union(float, None), Optional[str]]]] = {
+            "simplenetv1_imagenet": [
+                (64, 1, 0.0),
+                (128, 1, 0.0),
+                (128, 1, 0.0),
+                (128, 1, 0.0),
+                (128, 1, 0.0),
+                (128, 1, 0.0),
+                ("p", 2, 0.0),
+                (256, 1, 0.0),
+                (256, 1, 0.0),
+                (256, 1, 0.0),
+                (512, 1, 0.0),
+                ("p", 2, 0.0),
+                (2048, 1, 0.0, "k1"),
+                (256, 1, 0.0, "k1"),
+                (256, 1, 0.0),
+            ],
+            "simplenetv1_imagenet_9m": [
+                (128, 1, 0.0),
+                (192, 1, 0.0),
+                (192, 1, 0.0),
+                (192, 1, 0.0),
+                (192, 1, 0.0),
+                (192, 1, 0.0),
+                ("p", 2, 0.0),
+                (320, 1, 0.0),
+                (320, 1, 0.0),
+                (320, 1, 0.0),
+                (640, 1, 0.0),
+                ("p", 2, 0.0),
+                (2560, 1, 0.0, "k1"),
+                (320, 1, 0.0, "k1"),
+                (320, 1, 0.0),
+            ],
+        }
+
+        self.dropout_rates = drop_rates
+        # 15 is the last layer of the network(including two previous pooling layers)
+        # basically specifying the dropout rate for the very last layer to be used after the pooling
+        self.last_dropout_rate = self.dropout_rates.get(15, 0.0)
+        self.strides = {
+            0: {},
+            1: {0: 2, 1: 2, 2: 2},
+            2: {0: 2, 1: 2, 2: 1, 3: 2},
+            3: {0: 2, 1: 2, 2: 1, 3: 1, 4: 2},
+            4: {0: 2, 1: 1, 2: 2, 3: 1, 4: 2, 5: 1},
+        }
+
+        self.num_classes = num_classes
+        self.in_chans = in_chans
+        self.scale = scale
+        self.networks = [
+            "simplenetv1_imagenet",  # 0
+            "simplenetv1_imagenet_9m",  # 1
+            # other archs
+        ]
+        self.network_idx = network_idx
+        self.mode = mode
+
+        self.features = self._make_layers(scale)
+        self.classifier = nn.Linear(round(self.cfg[self.networks[network_idx]][-1][0] * scale), num_classes)
+
+    def forward(self, x: torch.Tensor):
+        out = self.features(x)
+        out = F.max_pool2d(out, kernel_size=out.size()[2:])
+        out = F.dropout2d(out, self.last_dropout_rate, training=self.training)
+        out = out.view(out.size(0), -1)
+        out = self.classifier(out)
+        return out
+
+    def _make_layers(self, scale: float):
+        layers: List[nn.Module] = []
+        input_channel = self.in_chans
+        stride_list = self.strides[self.mode]
+        for idx, (layer, stride, defaul_dropout_rate, *layer_type) in enumerate(
+            self.cfg[self.networks[self.network_idx]]
+        ):
+            stride = stride_list[idx] if len(stride_list) > idx else stride
+            # check if any custom dropout rate is specified
+            # for this layer, note that pooling also counts as 1 layer
+            custom_dropout = self.dropout_rates.get(idx, None)
+            custom_dropout = defaul_dropout_rate if custom_dropout is None else custom_dropout
+            # dropout values must be strictly decimal. while 0 doesnt introduce any issues here
+            # i.e. during training and inference, if you try to jit trace your model it will crash
+            # due to using 0 as dropout value(this applies up to 1.13.1) so here is an explicit
+            # check to convert any possible integer value to its decimal counterpart.
+            custom_dropout = None if custom_dropout is None else float(custom_dropout)
+            kernel_size = 3 if layer_type == [] else 1
+
+            if layer == "p":
+                layers += [
+                    nn.MaxPool2d(kernel_size=(2, 2), stride=(stride, stride)),
+                    nn.Dropout2d(p=custom_dropout, inplace=True),
+                ]
+            else:
+                filters = round(layer * scale)
+                if custom_dropout is None:
+                    layers += [
+                        nn.Conv2d(input_channel, filters, kernel_size=kernel_size, stride=stride, padding=1),
+                        nn.BatchNorm2d(filters, eps=1e-05, momentum=0.05, affine=True),
+                        nn.ReLU(inplace=True),
+                    ]
+                else:
+                    layers += [
+                        nn.Conv2d(input_channel, filters, kernel_size=kernel_size, stride=stride, padding=1),
+                        nn.BatchNorm2d(filters, eps=1e-05, momentum=0.05, affine=True),
+                        nn.ReLU(inplace=True),
+                        nn.Dropout2d(p=custom_dropout, inplace=False),
+                    ]
+
+                input_channel = filters
+
+        model = nn.Sequential(*layers)
+        for m in model.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.xavier_uniform_(m.weight.data, gain=nn.init.calculate_gain("relu"))
+        return model
+
+    @torch.jit.ignore
+    def group_matcher(self, coarse=False):
+        # this treats BN layers as separate groups for bn variants, a lot of effort to fix that
+        return dict(stem=r"^features\.0", blocks=r"^features\.(\d+)")
+
+    @torch.jit.ignore
+    def set_grad_checkpointing(self, enable=True):
+        assert not enable, "gradient checkpointing not supported"
+
+    @torch.jit.ignore
+    def get_classifier(self):
+        return self.classifier
+
+    def reset_classifier(self, num_classes: int):
+        self.num_classes = num_classes
+        self.classifier = nn.Linear(round(self.cfg[self.networks[self.network_idx]][-1][0] * self.scale), num_classes)
+
+    def forward_features(self, x: torch.Tensor) -> torch.Tensor:
+        return self.features(x)
+
+    def forward_head(self, x: torch.Tensor, pre_logits: bool = False):
+        x = self.forward_features(x)
+        if pre_logits:
+            return x
+        else:
+            x = F.max_pool2d(x, kernel_size=x.size()[2:])
+            x = F.dropout2d(x, self.last_dropout_rate, training=self.training)
+            x = x.view(x.size(0), -1)
+        return self.classifier(x)
+
+
+def _gen_simplenet(
+    model_variant: str = "simplenetv1_m2",
+    num_classes: int = 1000,
+    in_chans: int = 3,
+    scale: float = 1.0,
+    network_idx: int = 0,
+    mode: int = 2,
+    pretrained: bool = False,
+    drop_rates: Dict[int, float] = {},
+    **kwargs,
+) -> SimpleNet:
+    model_args = dict(
+        in_chans=in_chans,
+        scale=scale,
+        network_idx=network_idx,
+        mode=mode,
+        drop_rates=drop_rates,
+        **kwargs,
+    )
+    # to allow for seemless finetuning, remove the num_classes
+    # and load the model intact, we apply the changes afterward!
+    if "num_classes" in kwargs:
+        kwargs.pop("num_classes")
+    model = build_model_with_cfg(SimpleNet, model_variant, pretrained, **model_args)
+    # if the num_classes is different than imagenet's, it
+    # means its going to be finetuned, so only create a
+    # new classifier after the whole model is loaded!
+    if num_classes != 1000:
+        model.reset_classifier(num_classes)
+    return model
+
+
+@register_model
+def simplenet(pretrained: bool = False, **kwargs: Any) -> SimpleNet:
+    """Generic simplenet model builder. by default it returns `simplenetv1_5m_m2` model
+    but specifying different arguments such as `netidx`, `scale` or `mode` will result in
+    the corrosponding network variant.
+
+    when pretrained is specified, if the combination of settings resemble any known variants
+    specified in the `default_cfg`, their respective pretrained weights will be loaded, otherwise
+    an exception will be thrown denoting Unknown model variant being specified.
+
+    Args:
+        pretrained (bool, optional): loads the model with pretrained weights only if the model is a known variant specified in default_cfg. Defaults to False.
+
+    Raises:
+        Exception: if pretrained is used with an unknown/custom model variant and exception is raised.
+
+    Returns:
+        SimpleNet: a SimpleNet model instance is returned upon successful instantiation.
+    """
+    num_classes = kwargs.get("num_classes", 1000)
+    in_chans = kwargs.get("in_chans", 3)
+    scale = kwargs.get("scale", 1.0)
+    network_idx = kwargs.get("network_idx", 0)
+    mode = kwargs.get("mode", 2)
+    drop_rates = kwargs.get("drop_rates", {})
+    model_variant = "simplenetv1_5m_m2"
+    if pretrained:
+        # check if the model specified is a known variant
+        model_base = None
+        if network_idx == 0:
+            model_base = 5
+        elif network_idx == 1:
+            model_base = 9
+        config = ""
+        if math.isclose(scale, 1.0):
+            config = f"{model_base}m_m{mode}"
+        elif math.isclose(scale, 0.75):
+            config = f"small_m{mode}_075"
+        elif math.isclose(scale, 0.5):
+            config = f"small_m{mode}_05"
+        else:
+            config = f"m{mode}_{scale:.2f}".replace(".", "")
+        model_variant = f"simplenetv1_{config}"
+
+        cfg = default_cfgs.get(model_variant, None)
+        if cfg is None:
+            raise Exception(f"Unknown model variant ('{model_variant}') specified!")
+
+    return _gen_simplenet(model_variant, num_classes, in_chans, scale, network_idx, mode, pretrained, drop_rates)
+
+
+def remove_network_settings(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Removes network related settings passed in kwargs for predefined network configruations below
+
+    Returns:
+        Dict[str,Any]: cleaned kwargs
+    """
+    model_args = {k: v for k, v in kwargs.items() if k not in ["scale", "network_idx", "mode", "drop_rate"]}
+    return model_args
+
+
+# imagenet models
+@register_model
+def simplenetv1_small_m1_05(pretrained: bool = False, **kwargs: Any) -> SimpleNet:
+    """Creates a small variant of simplenetv1_5m, with 1.5m parameters. This uses m1 stride mode
+    which makes it the fastest variant available.
+
+    Args:
+        pretrained (bool, optional): loads the model with pretrained weights. Defaults to False.
+
+    Returns:
+        SimpleNet: a SimpleNet model instance is returned upon successful instantiation.
+    """
+    model_variant = "simplenetv1_small_m1_05"
+    model_args = remove_network_settings(kwargs)
+    return _gen_simplenet(model_variant, scale=0.5, network_idx=0, mode=1, pretrained=pretrained, **model_args)
+
+
+@register_model
+def simplenetv1_small_m2_05(pretrained: bool = False, **kwargs: Any) -> SimpleNet:
+    """Creates a second small variant of simplenetv1_5m, with 1.5m parameters. This uses m2 stride mode
+    which makes it the second fastest variant available.
+
+    Args:
+        pretrained (bool, optional): loads the model with pretrained weights. Defaults to False.
+
+    Returns:
+        SimpleNet: a SimpleNet model instance is returned upon successful instantiation.
+    """
+    model_variant = "simplenetv1_small_m2_05"
+    model_args = remove_network_settings(kwargs)
+    return _gen_simplenet(model_variant, scale=0.5, network_idx=0, mode=2, pretrained=pretrained, **model_args)
+
+
+@register_model
+def simplenetv1_small_m1_075(pretrained: bool = False, **kwargs: Any) -> SimpleNet:
+    """Creates a third small variant of simplenetv1_5m, with 3m parameters. This uses m1 stride mode
+    which makes it the third fastest variant available.
+
+    Args:
+        pretrained (bool, optional): loads the model with pretrained weights. Defaults to False.
+
+    Returns:
+        SimpleNet: a SimpleNet model instance is returned upon successful instantiation.
+    """
+    model_variant = "simplenetv1_small_m1_075"
+    model_args = remove_network_settings(kwargs)
+    return _gen_simplenet(model_variant, scale=0.75, network_idx=0, mode=1, pretrained=pretrained, **model_args)
+
+
+@register_model
+def simplenetv1_small_m2_075(pretrained: bool = False, **kwargs: Any) -> SimpleNet:
+    """Creates a forth small variant of simplenetv1_5m, with 3m parameters. This uses m2 stride mode
+    which makes it the forth fastest variant available.
+
+    Args:
+        pretrained (bool, optional): loads the model with pretrained weights. Defaults to False.
+
+    Returns:
+        SimpleNet: a SimpleNet model instance is returned upon successful instantiation.
+    """
+    model_variant = "simplenetv1_small_m2_075"
+    model_args = remove_network_settings(kwargs)
+    return _gen_simplenet(model_variant, scale=0.75, network_idx=0, mode=2, pretrained=pretrained, **model_args)
+
+
+@register_model
+def simplenetv1_5m_m1(pretrained: bool = False, **kwargs: Any) -> SimpleNet:
+    """Creates the base simplement model known as simplenetv1_5m, with 5m parameters. This variant uses m1 stride mode
+    which makes it a fast and performant model.
+
+    Args:
+        pretrained (bool, optional): loads the model with pretrained weights. Defaults to False.
+
+    Returns:
+        SimpleNet: a SimpleNet model instance is returned upon successful instantiation.
+    """
+    model_variant = "simplenetv1_5m_m1"
+    model_args = remove_network_settings(kwargs)
+    return _gen_simplenet(model_variant, scale=1.0, network_idx=0, mode=1, pretrained=pretrained, **model_args)
+
+
+@register_model
+def simplenetv1_5m_m2(pretrained: bool = False, **kwargs: Any) -> SimpleNet:
+    """Creates the base simplement model known as simplenetv1_5m, with 5m parameters. This variant uses m2 stride mode
+    which makes it a bit more performant model compared to the m1 variant of the same variant at the expense of a bit slower inference.
+
+    Args:
+        pretrained (bool, optional): loads the model with pretrained weights. Defaults to False.
+
+    Returns:
+        SimpleNet: a SimpleNet model instance is returned upon successful instantiation.
+    """
+    model_variant = "simplenetv1_5m_m2"
+    model_args = remove_network_settings(kwargs)
+    return _gen_simplenet(model_variant, scale=1.0, network_idx=0, mode=2, pretrained=pretrained, **model_args)
+
+
+@register_model
+def simplenetv1_9m_m1(pretrained: bool = False, **kwargs: Any) -> SimpleNet:
+    """Creates a variant of the simplenetv1_5m, with 9m parameters. This variant uses m1 stride mode
+    which makes it run faster.
+
+    Args:
+        pretrained (bool, optional): loads the model with pretrained weights. Defaults to False.
+
+    Returns:
+        SimpleNet: a SimpleNet model instance is returned upon successful instantiation.
+    """
+    model_variant = "simplenetv1_9m_m1"
+    model_args = remove_network_settings(kwargs)
+    return _gen_simplenet(model_variant, scale=1.0, network_idx=1, mode=1, pretrained=pretrained, **model_args)
+
+
+@register_model
+def simplenetv1_9m_m2(pretrained: bool = False, **kwargs: Any) -> SimpleNet:
+    """Creates a variant of the simplenetv1_5m, with 9m parameters. This variant uses m2 stride mode
+    which makes it a bit more performant model compared to the m1 variant of the same variant at the expense of a bit slower inference.
+
+    Args:
+        pretrained (bool, optional): loads the model with pretrained weights. Defaults to False.
+
+    Returns:
+        SimpleNet: a SimpleNet model instance is returned upon successful instantiation.
+    """
+    model_variant = "simplenetv1_9m_m2"
+    model_args = remove_network_settings(kwargs)
+    return _gen_simplenet(model_variant, scale=1.0, network_idx=1, mode=2, pretrained=pretrained, **model_args)
+
+
+if __name__ == "__main__":
+    model = simplenet(num_classes=1000, pretrained=True)
+    input_dummy = torch.randn(size=(1, 224, 224, 3))
+    out = model(input_dummy)
+    print(f"output: {out.size()}")

--- a/timm/models/simplenet.py
+++ b/timm/models/simplenet.py
@@ -59,28 +59,28 @@ def _cfg(url="", **kwargs):
 
 default_cfgs: Dict[str, Dict[str, Any]] = {
     "simplenetv1_small_m1_05": _cfg(
-        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_small_m1_05-a7ec600b.pth"
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_small_m1_05-be804903.pth"
     ),
     "simplenetv1_small_m2_05": _cfg(
-        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_small_m2_05-62617ea1.pth"
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_small_m2_05-ca4b3e2b.pth"
     ),
     "simplenetv1_small_m1_075": _cfg(
-        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_small_m1_075-8427bf60.pth"
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_small_m1_075-098acbff.pth"
     ),
     "simplenetv1_small_m2_075": _cfg(
-        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_small_m2_075-da714eb5.pth"
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_small_m2_075-609ff4da.pth"
     ),
     "simplenetv1_5m_m1": _cfg(
-        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_5m_m1-cc6b3ad1.pth"
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_5m_m1-36c4ca4d.pth"
     ),
     "simplenetv1_5m_m2": _cfg(
-        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_5m_m2-c35297bf.pth"
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_5m_m2-9bd6bb36.pth"
     ),
     "simplenetv1_9m_m1": _cfg(
-        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_9m_m1-8c98a0a5.pth"
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_9m_m1-524f9972.pth"
     ),
     "simplenetv1_9m_m2": _cfg(
-        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_9m_m2-6b01be1e.pth"
+        url="https://github.com/Coderx7/SimpleNet_Pytorch/releases/download/v1.0.0/simplenetv1_9m_m2-59e8733b.pth"
     ),
 }
 


### PR DESCRIPTION
This pull request add [SimpleNet architecture](https://arxiv.org/abs/1608.06037). Simplenetv1 is a 2016 architecture comprised of only the most basic operators that comprises a plain CNN network. It outperformed many deeper and more complex architectures such as VGGNet,ResNet,etc on several benchmark datasets. This is its results on ImageNet dataset. 

-added simplenet.py to timm/models
-added simplenet.md to docs/models
-added an entry to docs/models.md

Here are some more information concerning how they perform taken from our official [pytorch repository](https://github.com/Coderx7/SimpleNet_Pytorch/):
|       **Model**                  | **\#Params** |  **ImageNet**   | **ImageNet-Real-Labels**  |
| :---------------------------     | :----------: | :-----------:   |   :------------------:    |  
| simplenetv1_9m_m2(36.3 MB)       |     9.5m     | 74.23 / 91.748  |      81.22 / 94.756         |  
| simplenetv1_5m_m2(22 MB)         |     5.7m     | 72.03 / 90.324  |      79.328/ 93.714        |         
| simplenetv1_small_m2_075(12.6 MB)|     3m       | 68.506/ 88.15   |      76.283/ 92.02         |  
| simplenetv1_small_m2_05(5.78 MB) |     1.5m     | 61.67 / 83.488  |      69.31 / 88.195        |  

SimpleNet performs very decently, it outperforms VGGNet, variants of ResNet and MobileNets(1-3)   
and its pretty fast as well! and its all using plain old CNN!.  

Here's an example of benchmark run on small variants of simplenet and some other known architectures such as mobilenets.    
Small variants of simplenet consistently achieve high performance/accuracy:    

|       model                       | samples_per_sec   |  param_count  | top1   | top5   |
|:----------------------------------| :--------------:  | :-----------: | :--:   | :---:  |  
|**simplenetv1_small_m1_05**        |     3100.26       | **1.51**      | **61.122** | **82.988** |
|mobilenetv3_small_050              |     3082.85       | 1.59          | 57.89  | 80.194 |
|lcnet_050                          |     2713.02       | 1.88          | 63.1   | 84.382 |
|**simplenetv1_small_m2_05**        |     2536.16       | **1.51**      | **61.67** | **83.488** |
|mobilenetv3_small_075              |     1793.42       | 2.04          | 65.242 | 85.438 |
|tf_mobilenetv3_small_075           |     1689.53       | 2.04          | 65.714 | 86.134 |
|**simplenetv1_small_m1_075**       |     1626.87       | **3.29**      | **67.784** | **87.718** |
|tf_mobilenetv3_small_minimal_100   |     1316.91       | 2.04          | 62.908 | 84.234 |
|**simplenetv1_small_m2_075**       |     1313.6        | **3.29**      | **68.506** | **88.15**  |
|mobilenetv3_small_100              |     1261.09       | 2.54          | 67.656 | 87.634 |
|tf_mobilenetv3_small_100           |     1213.03       | 2.54          | 67.924 | 87.664 |
|mnasnet_small                      |     1089.33       | 2.03          | 66.206 | 86.508 |
|mobilenetv2_050                    |     857.66        | 1.97          | 65.942 | 86.082 |
|dla46_c                            |     537.08        | 1.3           | 64.866 | 86.294 |
|dla46x_c                           |     323.03        | 1.07          | 65.97  | 86.98  |
|dla60x_c                           |     301.71        | 1.32          | 67.892 | 88.426 |

and this is a sample for larger models: 

|               model               |  samples_per_sec |  param_count  |  top1  |  top5   |
|:----------------------------------| :--------------: | :-----------: | :----: | :----:  |  
| **simplenetv1_small_m1_075**      |     2893.91      |     **3.29**  | **67.784** | **87.718**  |
| **simplenetv1_small_m2_075**      |     2478.41      |     **3.29**  | **68.506** | **88.15**   |
| vit_tiny_r_s16_p8_224             |     2337.23      |     6.34      | 71.792 | 90.822  |
| **simplenetv1_5m_m1**             |     2105.06      |     **5.75**  | **71.548** | **89.94**   |
| **simplenetv1_5m_m2**             |     1754.25      |     **5.75**  | **72.03**  | **90.324**  |
| resnet18                          |     1750.38      |     11.69     | 69.744 | 89.082  |
| regnetx_006                       |     1620.25      |     6.2       | 73.86  | 91.672  |
| mobilenetv3_large_100             |     1491.86      |     5.48      | 75.766 | 92.544  |
| tf_mobilenetv3_large_minimal_100  |     1476.29      |     3.92      | 72.25  | 90.63   |
| tf_mobilenetv3_large_075          |     1474.77      |     3.99      | 73.436 | 91.344  |
| ghostnet_100                      |     1390.19      |     5.18      | 73.974 | 91.46   |
| tinynet_b                         |     1345.82      |     3.73      | 74.976 | 92.184  |
| tf_mobilenetv3_large_100          |     1325.06      |     5.48      | 75.518 | 92.604  |
| mnasnet_100                       |     1183.69      |     4.38      | 74.658 | 92.112  |
| mobilenetv2_100                   |     1101.58      |     3.5       | 72.97  | 91.02   |
| **simplenetv1_9m_m1**             |     1048.91      |     **9.51**  | **73.792** | **91.486**  |
| resnet34                          |     1030.4       |     21.8      | 75.114 | 92.284  |
| deit_tiny_patch16_224             |     990.85       |     5.72      | 72.172 | 91.114  |
| efficientnet_lite0                |     977.76       |     4.65      | 75.476 | 92.512  |
| **simplenetv1_9m_m2**             |     900.45       |     **9.51**  | **74.23**  | **91.748**  |
| tf_efficientnet_lite0             |     876.66       |     4.65      | 74.832 | 92.174  |
| dla34                             |     834.35       |     15.74     | 74.62  | 92.072  |
| mobilenetv2_110d                  |     824.4        |     4.52      | 75.038 | 92.184  |
| resnet26                          |     771.1        |     16        | 75.3   | 92.578  |
| repvgg_b0                         |     751.01       |     15.82     | 75.16  | 92.418  |
| crossvit_9_240                    |     606.2        |     8.55      | 73.96  | 91.968  |
| vgg11                             |     576.32       |     132.86    | 69.028 | 88.626  |
| vit_base_patch32_224_sam          |     561.99       |     88.22     | 73.694 | 91.01   |
| vgg11_bn                          |     504.29       |     132.87    | 70.36  | 89.802  |
| densenet121                       |     435.3        |     7.98      | 75.584 | 92.652  |
| vgg13                             |     363.69       |     133.05    | 69.926 | 89.246  |
| vgg13_bn                          |     315.85       |     133.05    | 71.594 | 90.376  |
| vgg16                             |     302.84       |     138.36    | 71.59  | 90.382  |
| vgg16_bn                          |     265.99       |     138.37    | 73.35  | 91.504  |
| vgg19                             |     259.82       |     143.67    | 72.366 | 90.87   |
| vgg19_bn                          |     229.77       |     143.68    | 74.214 | 91.848  |

Note:   
These benchmarks are run on a PC with GTX1080, Pytorch 1.11, fp32 and nchw configuration.   

I hope this is useful for the community.