### PR TITLE
Add type annotations to _registry.py

### DIFF
--- a/timm/models/_pretrained.py
+++ b/timm/models/_pretrained.py
@@ -93,7 +93,7 @@ class DefaultCfg:
         return tag, self.cfgs[tag]
 
 
-def split_model_name_tag(model_name: str, no_tag=''):
+def split_model_name_tag(model_name: str, no_tag: str = '') -> Tuple[str, str]:
     model_name, *tag_list = model_name.split('.', 1)
     tag = tag_list[0] if tag_list else no_tag
     return model_name, tag


### PR DESCRIPTION
## Description

Add type annotations to `_registry.py` so that it will pass `mypy --strict`.

## Comment

I was reading the code and felt that this module would be easier to understand with type annotations. Therefore, I went ahead and added the annotations.

The idea with this PR is to start small to see if we can align on _how_ to annotate types. I've seen people in the past disagree on how strictly to annotate the code base, so before spending too much time on this, I wanted to check if you agree @rwightman.

Most of the added types should be straightforward. Some notes on the non-trivial changes:

- I made no assumption about the fn passed to `register_model`, but maybe the type could be stricter. Are all models `nn.Module`s?
- If I'm not mistaken, the type hint for `get_arch_name` was incorrect
- I had to add a `# type: ignore` to `mod.__all__ = ...`
- I made some minor code changes to `list_models` to facilitate the typing. I think the changes should not affect the logic of the function.
- I removed `list` from `list(sorted(...))` because sorted returns always a list.