### PR TITLE
HF iterable datasets support (HFIDS)

### DIFF
--- a/timm/data/dataset.py
+++ b/timm/data/dataset.py
@@ -131,7 +131,7 @@ class IterableImageDataset(data.IterableDataset):
             return 0
 
     def set_epoch(self, count):
-        # TFDS and WDS need external epoch count for deterministic cross process shuffle
+        # TFDS, WDS and HFIDS need external epoch count for deterministic cross process shuffle
         if hasattr(self.reader, 'set_epoch'):
             self.reader.set_epoch(count)
 
@@ -139,7 +139,7 @@ class IterableImageDataset(data.IterableDataset):
             self,
             num_workers: Optional[int] = None,
     ):
-        # TFDS and WDS readers need # workers for correct # samples estimate before loader processes created
+        # TFDS, WDS and HFIDS readers need # workers for correct # samples estimate before loader processes created
         if hasattr(self.reader, 'set_loader_cfg'):
             self.reader.set_loader_cfg(num_workers=num_workers)
 

--- a/timm/data/dataset_factory.py
+++ b/timm/data/dataset_factory.py
@@ -149,9 +149,19 @@ def create_dataset(
         else:
             assert False, f"Unknown torchvision dataset {name}"
     elif name.startswith('hfds/'):
-        # NOTE right now, HF datasets default arrow format is a random-access Dataset,
-        # There will be a IterableDataset variant too, TBD
         ds = ImageDataset(root, reader=name, split=split, class_map=class_map, **kwargs)
+    elif name.startswith('hfids/'):
+        ds = IterableImageDataset(
+            root,
+            reader=name,
+            split=split,
+            class_map=class_map,
+            is_training=is_training,
+            download=download,
+            batch_size=batch_size,
+            seed=seed,
+            **kwargs
+        )
     elif name.startswith('tfds/'):
         ds = IterableImageDataset(
             root,

--- a/timm/data/dataset_factory.py
+++ b/timm/data/dataset_factory.py
@@ -79,6 +79,7 @@ def create_dataset(
       * folder - default, timm folder (or tar) based ImageDataset
       * torch - torchvision based datasets
       * HFDS - Hugging Face Datasets
+      * HFIDS - Hugging Face Datasets using IterableDataset (from streaming or local)
       * TFDS - Tensorflow-datasets wrapper in IterabeDataset interface via IterableImageDataset
       * WDS - Webdataset
       * all - any of the above
@@ -91,12 +92,12 @@ def create_dataset(
             `imagenet/` instead of `/imagenet/val`, etc on cmd line / config. (folder, torch/folder)
         class_map: specify class -> index mapping via text file or dict (folder)
         load_bytes: load data, return images as undecoded bytes (folder)
-        download: download dataset if not present and supported (HFDS, TFDS, torch)
+        download: download dataset if not present and supported (HFDS, HFIDS, TFDS, torch)
         is_training: create dataset in train mode, this is different from the split.
-            For Iterable / TDFS it enables shuffle, ignored for other datasets. (TFDS, WDS)
-        batch_size: batch size hint for (TFDS, WDS)
-        seed: seed for iterable datasets (TFDS, WDS)
-        repeats: dataset repeats per iteration i.e. epoch (TFDS, WDS)
+            For Iterable / TDFS / HFIDS it enables shuffle, ignored for other datasets. (TFDS, WDS)
+        batch_size: batch size hint for (TFDS, WDS, HFIDS)
+        seed: seed for iterable datasets (TFDS, WDS, HFIDS)
+        repeats: dataset repeats per iteration i.e. epoch (TFDS, WDS, HFIDS)
         **kwargs: other args to pass to dataset
 
     Returns:
@@ -159,6 +160,7 @@ def create_dataset(
             is_training=is_training,
             download=download,
             batch_size=batch_size,
+            repeats=repeats,
             seed=seed,
             **kwargs
         )

--- a/timm/data/readers/reader_factory.py
+++ b/timm/data/readers/reader_factory.py
@@ -15,8 +15,11 @@ def create_reader(name, root, split='train', **kwargs):
     # FIXME improve the selection right now just tfds prefix or fallback path, will need options to
     # explicitly select other options shortly
     if prefix == 'hfds':
-        from .reader_hfds import ReaderHfds  # defer tensorflow import
+        from .reader_hfds import ReaderHfds  # defer HF datasets import
         reader = ReaderHfds(root, name, split=split, **kwargs)
+    elif prefix == 'hfids':
+        from .reader_hfids import ReaderHfids  # defer HF datasets import
+        reader = ReaderHfids(root, name, split=split, **kwargs)
     elif prefix == 'tfds':
         from .reader_tfds import ReaderTfds  # defer tensorflow import
         reader = ReaderTfds(root, name, split=split, **kwargs)

--- a/timm/data/readers/reader_hfids.py
+++ b/timm/data/readers/reader_hfids.py
@@ -53,7 +53,7 @@ class ReaderHfids(Reader):
 
         self.input_name = input_name
         self.input_img_mode = input_img_mode
-        self.target_key = target_name
+        self.target_name = target_name
         self.target_img_mode = target_img_mode
 
         self.builder = datasets.load_dataset_builder(name, cache_dir=root)
@@ -143,7 +143,7 @@ class ReaderHfids(Reader):
         if self.ds is None:
             self._lazy_init()
 
-        # TODO(lhoestq): take batch_size into account to use to unsure total samples % batch_size == 0 in training across all dis nodes
+        # TODO(lhoestq): take batch_size into account to use to make sure total samples % batch_size == 0 in training across all dis nodes
         for sample in self.ds:
             input_data: Image.Image = sample[self.input_name]
             if self.input_img_mode and input_data.mode != self.input_img_mode:

--- a/timm/data/readers/reader_hfids.py
+++ b/timm/data/readers/reader_hfids.py
@@ -99,8 +99,7 @@ class ReaderHfids(Reader):
         self.global_worker_id = 0
         self.global_num_workers = 1
 
-        # DataPipeline is lazy init, majority of WDS DataPipeline could be init here, BUT, shuffle seed
-        # is not handled in manner where it can be deterministic for each worker AND initialized up front
+        # Initialized lazily on each dataloader worker process
         self.ds: Optional[datasets.IterableDataset] = None
 
     def set_epoch(self, count):
@@ -132,10 +131,10 @@ class ReaderHfids(Reader):
         if self.download:
             dataset = self.builder.as_dataset(split=self.split)
             # to distribute evenly to workers
-            ds: datasets.IterableDataset = dataset.to_iterable_dataset(num_shards=self.global_num_workers)
+            ds = dataset.to_iterable_dataset(num_shards=self.global_num_workers)
         else:
             # in this case the number of shard is determined by the number of remote files
-            ds: datasets.IterableDataset = self.builder.as_streaming_dataset(split=self.split)
+            ds = self.builder.as_streaming_dataset(split=self.split)
 
         if self.is_training:
             # will shuffle the list of shards and use a shuffle buffer

--- a/timm/data/readers/reader_hfids.py
+++ b/timm/data/readers/reader_hfids.py
@@ -1,0 +1,185 @@
+""" Dataset reader for HF IterableDataset
+"""
+import os
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+from PIL import Image
+
+try:
+    import datasets
+    from datasets.distributed import split_dataset_by_node
+except ImportError:
+    print("Please install Hugging Face datasets package `pip install datasets`.")
+    exit(1)
+
+
+from .class_map import load_class_map
+from .reader import Reader
+
+
+SHUFFLE_SIZE = int(os.environ.get('HFIDS_SHUFFLE_SIZE', 8192))
+
+
+class ReaderHfids(Reader):
+    def __init__(
+            self,
+            root: str,
+            name: str,
+            split: str,
+            is_training: bool = False,
+            batch_size: Optional[int] = None,
+            download: bool =False,
+            repeats: int = 0,
+            seed: int = 42,
+            class_map: Optional[dict] = None,
+            input_name: str = 'image',
+            input_img_mode: str = 'RGB',
+            target_name: str = 'label',
+            target_img_mode: str = '',
+            shuffle_size: Optional[int] = None,
+            num_samples: Optional[int] = None,
+    ):
+        super().__init__()
+        self.root = root
+        self.split = split
+        self.is_training = is_training
+        self.batch_size = batch_size
+        self.download = download
+        self.repeats = repeats
+        self.common_seed = seed  # a seed that's fixed across all worker / distributed instances
+        self.shuffle_size = shuffle_size or SHUFFLE_SIZE
+
+        self.input_name = input_name
+        self.input_img_mode = input_img_mode
+        self.target_key = target_name
+        self.target_img_mode = target_img_mode
+
+        self.builder = datasets.load_dataset_builder(name, cache_dir=root)
+        if download:
+            self.builder.download_and_prepare()
+        
+        self.num_samples = num_samples
+        if self.builder.info.splits and split in self.builder.info.splits:
+            self.num_samples = self.builder.info.splits[split].num_examples
+
+        self.remap_class = False
+        if class_map:
+            self.class_to_idx = load_class_map(class_map)
+            self.remap_class = True
+        else:
+            self.class_to_idx = {}
+
+        # Distributed world state
+        self.dist_rank = 0
+        self.dist_num_replicas = 1
+        if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+            self.dist_rank = dist.get_rank()
+            self.dist_num_replicas = dist.get_world_size()
+
+        # Attributes that are updated in _lazy_init
+        self.worker_info = None
+        self.worker_id = 0
+        self.num_workers = 1
+        self.global_worker_id = 0
+        self.global_num_workers = 1
+
+        # DataPipeline is lazy init, majority of WDS DataPipeline could be init here, BUT, shuffle seed
+        # is not handled in manner where it can be deterministic for each worker AND initialized up front
+        self.ds: Optional[datasets.IterableDataset] = None
+
+    def set_epoch(self, count):
+        self.ds.set_epoch(self.epoch_count.value)
+
+    def set_loader_cfg(
+            self,
+            num_workers: Optional[int] = None,
+    ):
+        if self.ds is not None:
+            return
+        if num_workers is not None:
+            self.num_workers = num_workers
+            self.global_num_workers = self.dist_num_replicas * self.num_workers
+
+    def _lazy_init(self):
+        """ Lazily initialize worker (in worker processes)
+        """
+        if self.worker_info is None:
+            worker_info = torch.utils.data.get_worker_info()
+            if worker_info is not None:
+                self.worker_info = worker_info
+                self.worker_id = worker_info.id
+                self.num_workers = worker_info.num_workers
+            self.global_num_workers = self.dist_num_replicas * self.num_workers
+            self.global_worker_id = self.dist_rank * self.num_workers + self.worker_id
+
+        if self.download:
+            dataset = self.builder.as_dataset(split=self.split)
+            self.num_samples = len(dataset)
+            # optimized to distribute evenly to workers
+            ds: datasets.IterableDataset = dataset.to_iterable_dataset(num_shards=self.global_num_workers)
+        else:
+            # in this case the number of shard is fixed, and it may be less optimized
+            ds: datasets.IterableDataset = self.builder.as_streaming_dataset(split=self.split)
+
+        if self.is_training:
+            # will shuffle the list of shards and use shuffle buffer
+            ds = ds.shuffle(seed=self.common_seed, buffer_size=self.shuffle_size)
+
+        # Distributed:
+
+        # The dataset has a number of shards that is a factor of `dist_num_replicas` (i.e. if `ds.n_shards % dist_num_replicas == 0`),
+        # so the shards are evenly assigned across the nodes, which is the most optimized.
+        # If it's not the case for dataset streaming, each node keeps 1 example out of `dist_num_replicas`, skipping the other examples.
+
+        # Workers:
+
+        # In a node, datasets.IterableDataset assigns the shards assigned to the node as evenly as possible to workers.
+
+        self.ds = split_dataset_by_node(ds, rank=self.dist_rank, world_size=self.dist_num_replicas)
+
+    def __iter__(self):
+        if self.ds is None:
+            self._lazy_init()
+
+        # TODO(lhoestq): take batch_size into account to use to unsure total samples % batch_size == 0 in training across all dis nodes
+        for sample in self.ds:
+            input_data: Image.Image = sample[self.input_name]
+            if self.input_img_mode and input_data.mode != self.input_img_mode:
+                input_data = input_data.convert(self.input_img_mode)
+            target_data = sample[self.target_name]
+            if self.target_img_mode:
+                assert isinstance(target_data, Image.Image), "target_img_mode is specified but target is not an image"
+                if target_data.mode != self.target_img_mode:
+                    target_data = target_data.convert(self.target_img_mode)
+            elif self.remap_class:
+                target_data = self.class_to_idx[target_data]
+            yield input_data, target_data
+
+    def __len__(self):
+        if self.num_samples is None:
+            raise RuntimeError("Dataset length is unknown, please pass `num_samples` explicitely")
+        return self.num_samples
+
+    def _filename(self, index, basename=False, absolute=False):
+        assert False, "Not supported"  # no random access to examples
+
+    def filenames(self, basename=False, absolute=False):
+        """ Return all filenames in dataset, overrides base"""
+        if self.ds is None:
+            self._lazy_init()
+        names = []
+        for sample in self.ds:
+            if len(names) > self.num_samples:
+                break  # safety for ds.repeat() case
+            if 'file_name' in sample:
+                name = sample['file_name']
+            elif 'filename' in sample:
+                name = sample['filename']
+            elif 'id' in sample:
+                name = sample['id']
+            else:
+                assert False, "No supported name field present"
+            names.append(name)
+        return names

--- a/timm/data/readers/reader_hfids.py
+++ b/timm/data/readers/reader_hfids.py
@@ -152,7 +152,8 @@ class ReaderHfids(Reader):
         self.ds = split_dataset_by_node(ds, rank=self.dist_rank, world_size=self.dist_num_replicas)
 
     def _num_samples_per_worker(self):
-        num_worker_samples = self.num_samples / max(self.global_num_workers, self.dist_num_replicas)
+        num_worker_samples = \
+            max(1, self.repeats) * self.num_samples / max(self.global_num_workers, self.dist_num_replicas)
         if self.is_training or self.dist_num_replicas > 1:
             num_worker_samples = math.ceil(num_worker_samples)
         if self.is_training and self.batch_size is not None:

--- a/train.py
+++ b/train.py
@@ -93,7 +93,7 @@ group.add_argument('--train-split', metavar='NAME', default='train',
 group.add_argument('--val-split', metavar='NAME', default='validation',
                    help='dataset validation split (default: validation)')
 group.add_argument('--dataset-download', action='store_true', default=False,
-                   help='Allow download of dataset for torch/ and tfds/ datasets that support it.')
+                   help='Allow download of dataset for torch/, tfds/ and hfids/ datasets that support it.')
 group.add_argument('--class-map', default='', type=str, metavar='FILENAME',
                    help='path to class to idx mapping file (default: "")')
 

--- a/validate.py
+++ b/validate.py
@@ -62,7 +62,7 @@ parser.add_argument('--dataset', metavar='NAME', default='',
 parser.add_argument('--split', metavar='NAME', default='validation',
                     help='dataset split (default: validation)')
 parser.add_argument('--dataset-download', action='store_true', default=False,
-                    help='Allow download of dataset for torch/ and tfds/ datasets that support it.')
+                    help='Allow download of dataset for torch/, tfds/ and hfids/ datasets that support it.')
 parser.add_argument('--model', '-m', metavar='NAME', default='dpn92',
                     help='model architecture (default: dpn92)')
 parser.add_argument('-j', '--workers', default=4, type=int, metavar='N',


### PR DESCRIPTION
Added `ReaderHfids` to load an iterable dataset using the Hugging Face `datasets` library.

To use it you must pass `--dataset-name hfids/<dataset-name>`.

You can use it to load a dataset from the Hugging Face Hub or from a local dataset repository.

By default the dataset is loaded in streaming mode, but if you pass `--dataset-download` the dataset is downloaded and prepared as Arrow files locally and the iterable dataset is loaded from the local files.

I also included distributed support using `datasets.distributed`.

You can use it to stream [ImageNet 1K](https://huggingface.co/datasets/imagenet-1k) to train a model for example:
```
--dataset-name hfids/imagenet-1k
```