### PR TITLE
Implement patch dropout for eva / vision_transformer, refactor dropout args

### DIFF
--- a/timm/layers/__init__.py
+++ b/timm/layers/__init__.py
@@ -5,8 +5,8 @@ from .attention_pool2d import AttentionPool2d, RotAttentionPool2d, RotaryEmbeddi
 from .blur_pool import BlurPool2d
 from .classifier import ClassifierHead, create_classifier, NormMlpClassifierHead
 from .cond_conv2d import CondConv2d, get_condconv_initializer
-from .config import is_exportable, is_scriptable, is_no_jit, set_exportable, set_scriptable, set_no_jit,\
-    set_layer_config
+from .config import is_exportable, is_scriptable, is_no_jit, use_fused_attn, \
+    set_exportable, set_scriptable, set_no_jit, set_layer_config, set_fused_attn
 from .conv2d_same import Conv2dSame, conv2d_same
 from .conv_bn_act import ConvNormAct, ConvNormActAa, ConvBnAct
 from .create_act import create_act_layer, get_act_layer, get_act_fn

--- a/timm/layers/__init__.py
+++ b/timm/layers/__init__.py
@@ -33,12 +33,14 @@ from .norm import GroupNorm, GroupNorm1, LayerNorm, LayerNorm2d, RmsNorm
 from .norm_act import BatchNormAct2d, GroupNormAct, GroupNorm1Act, LayerNormAct, LayerNormAct2d,\
     SyncBatchNormAct, convert_sync_batchnorm, FrozenBatchNormAct2d, freeze_batch_norm_2d, unfreeze_batch_norm_2d
 from .padding import get_padding, get_same_padding, pad_same
+from .patch_dropout import PatchDropout
 from .patch_embed import PatchEmbed, resample_patch_embed
 from .pool2d_same import AvgPool2dSame, create_pool2d
 from .pos_embed import resample_abs_pos_embed
 from .pos_embed_rel import RelPosMlp, RelPosBias, RelPosBiasTf, gen_relative_position_index, gen_relative_log_coords
 from .pos_embed_sincos import pixel_freq_bands, freq_bands, build_sincos2d_pos_embed, build_fourier_pos_embed, \
-    build_rotary_pos_embed, apply_rot_embed, apply_rot_embed_cat, FourierEmbed, RotaryEmbedding, RotaryEmbeddingCat
+    build_rotary_pos_embed, apply_rot_embed, apply_rot_embed_cat, apply_rot_embed_list, apply_keep_indices_nlc, \
+    FourierEmbed, RotaryEmbedding, RotaryEmbeddingCat
 from .squeeze_excite import SEModule, SqueezeExcite, EffectiveSEModule, EffectiveSqueezeExcite
 from .selective_kernel import SelectiveKernel
 from .separable_conv import SeparableConv2d, SeparableConvNormAct

--- a/timm/layers/patch_dropout.py
+++ b/timm/layers/patch_dropout.py
@@ -1,0 +1,53 @@
+from typing import Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+
+
+class PatchDropout(nn.Module):
+    """
+    https://arxiv.org/abs/2212.00794
+    """
+    return_indices: torch.jit.Final[bool]
+
+    def __init__(
+            self,
+            prob: float = 0.5,
+            num_prefix_tokens: int = 1,
+            ordered: bool = False,
+            return_indices: bool = False,
+    ):
+        super().__init__()
+        assert 0 <= prob < 1.
+        self.prob = prob
+        self.num_prefix_tokens = num_prefix_tokens  # exclude CLS token (or other prefix tokens)
+        self.ordered = ordered
+        self.return_indices = return_indices
+
+    def forward(self, x) -> Union[torch.Tensor, Tuple[torch.Tensor, Optional[torch.Tensor]]]:
+        if not self.training or self.prob == 0.:
+            if self.return_indices:
+                return x, None
+            return x
+
+        if self.num_prefix_tokens:
+            prefix_tokens, x = x[:, :self.num_prefix_tokens], x[:, self.num_prefix_tokens:]
+        else:
+            prefix_tokens = None
+
+        B = x.shape[0]
+        L = x.shape[1]
+        num_keep = max(1, int(L * (1. - self.prob)))
+        keep_indices = torch.argsort(torch.randn(B, L, device=x.device), dim=-1)[:, :num_keep]
+        if self.ordered:
+            # NOTE does not need to maintain patch order in typical transformer use,
+            # but possibly useful for debug / visualization
+            keep_indices = keep_indices.sort(dim=-1)[0]
+        x = x.gather(1, keep_indices.unsqueeze(-1).expand((-1, -1) + x.shape[2:]))
+
+        if prefix_tokens is not None:
+            x = torch.cat((prefix_tokens, x), dim=1)
+
+        if self.return_indices:
+            return x, keep_indices
+        return x

--- a/timm/layers/pos_embed_sincos.py
+++ b/timm/layers/pos_embed_sincos.py
@@ -194,6 +194,8 @@ def rot(x):
 
 
 def apply_rot_embed(x: torch.Tensor, sin_emb, cos_emb):
+    if sin_emb.ndim == 3:
+        return x * cos_emb.unsqueeze(1).expand_as(x) + rot(x) * sin_emb.unsqueeze(1).expand_as(x)
     return x * cos_emb + rot(x) * sin_emb
 
 
@@ -205,7 +207,15 @@ def apply_rot_embed_list(x: List[torch.Tensor], sin_emb, cos_emb):
 
 def apply_rot_embed_cat(x: torch.Tensor, emb):
     sin_emb, cos_emb = emb.tensor_split(2, -1)
+    if sin_emb.ndim == 3:
+        return x * cos_emb.unsqueeze(1).expand_as(x) + rot(x) * sin_emb.unsqueeze(1).expand_as(x)
     return x * cos_emb + rot(x) * sin_emb
+
+
+def apply_keep_indices_nlc(x, pos_embed, keep_indices):
+    pos_embed = pos_embed.unsqueeze(0).expand(x.shape[0], -1, -1)
+    pos_embed = pos_embed.gather(1, keep_indices.unsqueeze(-1).expand(-1, -1, pos_embed.shape[-1]))
+    return pos_embed
 
 
 def build_rotary_pos_embed(

--- a/timm/models/_factory.py
+++ b/timm/models/_factory.py
@@ -81,7 +81,7 @@ def create_model(
         pretrained_cfg, model_name = load_model_config_from_hf(model_name)
     else:
         model_name, pretrained_tag = split_model_name_tag(model_name)
-        if not pretrained_cfg:
+        if pretrained_tag and not pretrained_cfg:
             # a valid pretrained_cfg argument takes priority over tag in model name
             pretrained_cfg = pretrained_tag
 

--- a/timm/models/_hub.py
+++ b/timm/models/_hub.py
@@ -50,6 +50,8 @@ __all__ = ['get_cache_dir', 'download_cached_file', 'has_hf_hub', 'hf_split', 'l
 # Default name for a weights file hosted on the Huggingface Hub.
 HF_WEIGHTS_NAME = "pytorch_model.bin"  # default pytorch pkl
 HF_SAFE_WEIGHTS_NAME = "model.safetensors"  # safetensors version
+HF_OPEN_CLIP_WEIGHTS_NAME = "open_clip_pytorch_model.bin"  # default pytorch pkl
+HF_OPEN_CLIP_SAFE_WEIGHTS_NAME = "open_clip_model.safetensors"  # safetensors version
 
 
 def get_cache_dir(child_dir=''):
@@ -374,5 +376,7 @@ def _get_safe_alternatives(filename: str) -> Iterable[str]:
     """
     if filename == HF_WEIGHTS_NAME:
         yield HF_SAFE_WEIGHTS_NAME
-    if filename != HF_WEIGHTS_NAME and filename.endswith(".bin"):
-        return filename[:-4] + ".safetensors"
+    # if filename == HF_OPEN_CLIP_WEIGHTS_NAME:  # FIXME tracking safetensors yet
+    #     yield HF_OPEN_CLIP_SAFE_WEIGHTS_NAME
+    if filename not in (HF_WEIGHTS_NAME, HF_OPEN_CLIP_WEIGHTS_NAME) and filename.endswith(".bin"):
+        yield filename[:-4] + ".safetensors"

--- a/timm/models/cait.py
+++ b/timm/models/cait.py
@@ -110,17 +110,38 @@ class LayerScaleBlockClassAttn(nn.Module):
     # taken from https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/vision_transformer.py
     # with slight modifications to add CA and LayerScale
     def __init__(
-            self, dim, num_heads, mlp_ratio=4., qkv_bias=False, drop=0., attn_drop=0.,
-            drop_path=0., act_layer=nn.GELU, norm_layer=nn.LayerNorm, attn_block=ClassAttn,
-            mlp_block=Mlp, init_values=1e-4):
+            self,
+            dim,
+            num_heads,
+            mlp_ratio=4.,
+            qkv_bias=False,
+            proj_drop=0.,
+            attn_drop=0.,
+            drop_path=0.,
+            act_layer=nn.GELU,
+            norm_layer=nn.LayerNorm,
+            attn_block=ClassAttn,
+            mlp_block=Mlp,
+            init_values=1e-4,
+    ):
         super().__init__()
         self.norm1 = norm_layer(dim)
         self.attn = attn_block(
-            dim, num_heads=num_heads, qkv_bias=qkv_bias, attn_drop=attn_drop, proj_drop=drop)
+            dim,
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            attn_drop=attn_drop,
+            proj_drop=proj_drop,
+        )
         self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
         self.norm2 = norm_layer(dim)
         mlp_hidden_dim = int(dim * mlp_ratio)
-        self.mlp = mlp_block(in_features=dim, hidden_features=mlp_hidden_dim, act_layer=act_layer, drop=drop)
+        self.mlp = mlp_block(
+            in_features=dim,
+            hidden_features=mlp_hidden_dim,
+            act_layer=act_layer,
+            drop=proj_drop,
+        )
         self.gamma_1 = nn.Parameter(init_values * torch.ones(dim))
         self.gamma_2 = nn.Parameter(init_values * torch.ones(dim))
 
@@ -177,17 +198,38 @@ class LayerScaleBlock(nn.Module):
     # taken from https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/vision_transformer.py
     # with slight modifications to add layerScale
     def __init__(
-            self, dim, num_heads, mlp_ratio=4., qkv_bias=False, drop=0., attn_drop=0.,
-            drop_path=0., act_layer=nn.GELU, norm_layer=nn.LayerNorm, attn_block=TalkingHeadAttn,
-            mlp_block=Mlp, init_values=1e-4):
+            self,
+            dim,
+            num_heads,
+            mlp_ratio=4.,
+            qkv_bias=False,
+            proj_drop=0.,
+            attn_drop=0.,
+            drop_path=0.,
+            act_layer=nn.GELU,
+            norm_layer=nn.LayerNorm,
+            attn_block=TalkingHeadAttn,
+            mlp_block=Mlp,
+            init_values=1e-4,
+    ):
         super().__init__()
         self.norm1 = norm_layer(dim)
         self.attn = attn_block(
-            dim, num_heads=num_heads, qkv_bias=qkv_bias, attn_drop=attn_drop, proj_drop=drop)
+            dim,
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            attn_drop=attn_drop,
+            proj_drop=proj_drop,
+        )
         self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
         self.norm2 = norm_layer(dim)
         mlp_hidden_dim = int(dim * mlp_ratio)
-        self.mlp = mlp_block(in_features=dim, hidden_features=mlp_hidden_dim, act_layer=act_layer, drop=drop)
+        self.mlp = mlp_block(
+            in_features=dim,
+            hidden_features=mlp_hidden_dim,
+            act_layer=act_layer,
+            drop=proj_drop,
+        )
         self.gamma_1 = nn.Parameter(init_values * torch.ones(dim))
         self.gamma_2 = nn.Parameter(init_values * torch.ones(dim))
 
@@ -201,9 +243,22 @@ class Cait(nn.Module):
     # taken from https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/vision_transformer.py
     # with slight modifications to adapt to our cait models
     def __init__(
-            self, img_size=224, patch_size=16, in_chans=3, num_classes=1000, global_pool='token',
-            embed_dim=768, depth=12, num_heads=12, mlp_ratio=4., qkv_bias=True,
-            drop_rate=0., attn_drop_rate=0., drop_path_rate=0.,
+            self,
+            img_size=224,
+            patch_size=16,
+            in_chans=3,
+            num_classes=1000,
+            global_pool='token',
+            embed_dim=768,
+            depth=12,
+            num_heads=12,
+            mlp_ratio=4.,
+            qkv_bias=True,
+            drop_rate=0.,
+            pos_drop_rate=0.,
+            proj_drop_rate=0.,
+            attn_drop_rate=0.,
+            drop_path_rate=0.,
             block_layers=LayerScaleBlock,
             block_layers_token=LayerScaleBlockClassAttn,
             patch_layer=PatchEmbed,
@@ -226,33 +281,50 @@ class Cait(nn.Module):
         self.grad_checkpointing = False
 
         self.patch_embed = patch_layer(
-            img_size=img_size, patch_size=patch_size, in_chans=in_chans, embed_dim=embed_dim)
+            img_size=img_size,
+            patch_size=patch_size,
+            in_chans=in_chans,
+            embed_dim=embed_dim,
+        )
 
         num_patches = self.patch_embed.num_patches
 
         self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
         self.pos_embed = nn.Parameter(torch.zeros(1, num_patches, embed_dim))
-        self.pos_drop = nn.Dropout(p=drop_rate)
+        self.pos_drop = nn.Dropout(p=pos_drop_rate)
 
         dpr = [drop_path_rate for i in range(depth)]
-        self.blocks = nn.Sequential(*[
-            block_layers(
-                dim=embed_dim, num_heads=num_heads, mlp_ratio=mlp_ratio, qkv_bias=qkv_bias,
-                drop=drop_rate, attn_drop=attn_drop_rate, drop_path=dpr[i], norm_layer=norm_layer,
-                act_layer=act_layer, attn_block=attn_block, mlp_block=mlp_block, init_values=init_values)
-            for i in range(depth)])
+        self.blocks = nn.Sequential(*[block_layers(
+            dim=embed_dim,
+            num_heads=num_heads,
+            mlp_ratio=mlp_ratio,
+            qkv_bias=qkv_bias,
+            proj_drop=proj_drop_rate,
+            attn_drop=attn_drop_rate,
+            drop_path=dpr[i],
+            norm_layer=norm_layer,
+            act_layer=act_layer,
+            attn_block=attn_block,
+            mlp_block=mlp_block,
+            init_values=init_values,
+        ) for i in range(depth)])
 
-        self.blocks_token_only = nn.ModuleList([
-            block_layers_token(
-                dim=embed_dim, num_heads=num_heads, mlp_ratio=mlp_ratio_token_only, qkv_bias=qkv_bias,
-                drop=0.0, attn_drop=0.0, drop_path=0.0, norm_layer=norm_layer,
-                act_layer=act_layer, attn_block=attn_block_token_only,
-                mlp_block=mlp_block_token_only, init_values=init_values)
-            for i in range(depth_token_only)])
+        self.blocks_token_only = nn.ModuleList([block_layers_token(
+            dim=embed_dim,
+            num_heads=num_heads,
+            mlp_ratio=mlp_ratio_token_only,
+            qkv_bias=qkv_bias,
+            norm_layer=norm_layer,
+            act_layer=act_layer,
+            attn_block=attn_block_token_only,
+            mlp_block=mlp_block_token_only,
+            init_values=init_values,
+        ) for _ in range(depth_token_only)])
 
         self.norm = norm_layer(embed_dim)
 
         self.feature_info = [dict(num_chs=embed_dim, reduction=0, module='head')]
+        self.head_drop = nn.Dropout(drop_rate)
         self.head = nn.Linear(embed_dim, num_classes) if num_classes > 0 else nn.Identity()
 
         trunc_normal_(self.pos_embed, std=.02)
@@ -322,6 +394,7 @@ class Cait(nn.Module):
     def forward_head(self, x, pre_logits: bool = False):
         if self.global_pool:
             x = x[:, 1:].mean(dim=1) if self.global_pool == 'avg' else x[:, 0]
+        x = self.head_drop(x)
         return x if pre_logits else self.head(x)
 
     def forward(self, x):
@@ -344,77 +417,80 @@ def _create_cait(variant, pretrained=False, **kwargs):
         raise RuntimeError('features_only not implemented for Vision Transformer models.')
 
     model = build_model_with_cfg(
-        Cait, variant, pretrained,
+        Cait,
+        variant,
+        pretrained,
         pretrained_filter_fn=checkpoint_filter_fn,
-        **kwargs)
+        **kwargs,
+    )
     return model
 
 
 @register_model
 def cait_xxs24_224(pretrained=False, **kwargs):
-    model_args = dict(patch_size=16, embed_dim=192, depth=24, num_heads=4, init_values=1e-5, **kwargs)
-    model = _create_cait('cait_xxs24_224', pretrained=pretrained, **model_args)
+    model_args = dict(patch_size=16, embed_dim=192, depth=24, num_heads=4, init_values=1e-5)
+    model = _create_cait('cait_xxs24_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def cait_xxs24_384(pretrained=False, **kwargs):
-    model_args = dict(patch_size=16, embed_dim=192, depth=24, num_heads=4, init_values=1e-5, **kwargs)
-    model = _create_cait('cait_xxs24_384', pretrained=pretrained, **model_args)
+    model_args = dict(patch_size=16, embed_dim=192, depth=24, num_heads=4, init_values=1e-5)
+    model = _create_cait('cait_xxs24_384', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def cait_xxs36_224(pretrained=False, **kwargs):
-    model_args = dict(patch_size=16, embed_dim=192, depth=36, num_heads=4, init_values=1e-5, **kwargs)
-    model = _create_cait('cait_xxs36_224', pretrained=pretrained, **model_args)
+    model_args = dict(patch_size=16, embed_dim=192, depth=36, num_heads=4, init_values=1e-5)
+    model = _create_cait('cait_xxs36_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def cait_xxs36_384(pretrained=False, **kwargs):
-    model_args = dict(patch_size=16, embed_dim=192, depth=36, num_heads=4, init_values=1e-5, **kwargs)
-    model = _create_cait('cait_xxs36_384', pretrained=pretrained, **model_args)
+    model_args = dict(patch_size=16, embed_dim=192, depth=36, num_heads=4, init_values=1e-5)
+    model = _create_cait('cait_xxs36_384', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def cait_xs24_384(pretrained=False, **kwargs):
-    model_args = dict(patch_size=16, embed_dim=288, depth=24, num_heads=6, init_values=1e-5, **kwargs)
-    model = _create_cait('cait_xs24_384', pretrained=pretrained, **model_args)
+    model_args = dict(patch_size=16, embed_dim=288, depth=24, num_heads=6, init_values=1e-5)
+    model = _create_cait('cait_xs24_384', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def cait_s24_224(pretrained=False, **kwargs):
-    model_args = dict(patch_size=16, embed_dim=384, depth=24, num_heads=8, init_values=1e-5, **kwargs)
-    model = _create_cait('cait_s24_224', pretrained=pretrained, **model_args)
+    model_args = dict(patch_size=16, embed_dim=384, depth=24, num_heads=8, init_values=1e-5)
+    model = _create_cait('cait_s24_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def cait_s24_384(pretrained=False, **kwargs):
-    model_args = dict(patch_size=16, embed_dim=384, depth=24, num_heads=8, init_values=1e-5, **kwargs)
-    model = _create_cait('cait_s24_384', pretrained=pretrained, **model_args)
+    model_args = dict(patch_size=16, embed_dim=384, depth=24, num_heads=8, init_values=1e-5)
+    model = _create_cait('cait_s24_384', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def cait_s36_384(pretrained=False, **kwargs):
-    model_args = dict(patch_size=16, embed_dim=384, depth=36, num_heads=8, init_values=1e-6, **kwargs)
-    model = _create_cait('cait_s36_384', pretrained=pretrained, **model_args)
+    model_args = dict(patch_size=16, embed_dim=384, depth=36, num_heads=8, init_values=1e-6)
+    model = _create_cait('cait_s36_384', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def cait_m36_384(pretrained=False, **kwargs):
-    model_args = dict(patch_size=16, embed_dim=768, depth=36, num_heads=16, init_values=1e-6, **kwargs)
-    model = _create_cait('cait_m36_384', pretrained=pretrained, **model_args)
+    model_args = dict(patch_size=16, embed_dim=768, depth=36, num_heads=16, init_values=1e-6)
+    model = _create_cait('cait_m36_384', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def cait_m48_448(pretrained=False, **kwargs):
-    model_args = dict(patch_size=16, embed_dim=768, depth=48, num_heads=16, init_values=1e-6, **kwargs)
-    model = _create_cait('cait_m48_448', pretrained=pretrained, **model_args)
+    model_args = dict(patch_size=16, embed_dim=768, depth=48, num_heads=16, init_values=1e-6)
+    model = _create_cait('cait_m48_448', pretrained=pretrained, **dict(model_args, **kwargs))
     return model

--- a/timm/models/coat.py
+++ b/timm/models/coat.py
@@ -54,7 +54,7 @@ default_cfgs = {
 
 class ConvRelPosEnc(nn.Module):
     """ Convolutional relative position encoding. """
-    def __init__(self, Ch, h, window):
+    def __init__(self, head_chs, num_heads, window):
         """
         Initialization.
             Ch: Channels per head.
@@ -70,7 +70,7 @@ class ConvRelPosEnc(nn.Module):
 
         if isinstance(window, int):
             # Set the same window size for all attention heads.
-            window = {window: h}
+            window = {window: num_heads}
             self.window = window
         elif isinstance(window, dict):
             self.window = window
@@ -84,18 +84,20 @@ class ConvRelPosEnc(nn.Module):
             # Determine padding size.
             # Ref: https://discuss.pytorch.org/t/how-to-keep-the-shape-of-input-and-output-same-when-dilation-conv/14338
             padding_size = (cur_window + (cur_window - 1) * (dilation - 1)) // 2
-            cur_conv = nn.Conv2d(cur_head_split*Ch, cur_head_split*Ch,
+            cur_conv = nn.Conv2d(
+                cur_head_split * head_chs,
+                cur_head_split * head_chs,
                 kernel_size=(cur_window, cur_window), 
                 padding=(padding_size, padding_size),
                 dilation=(dilation, dilation),                          
-                groups=cur_head_split*Ch,
+                groups=cur_head_split * head_chs,
             )
             self.conv_list.append(cur_conv)
             self.head_splits.append(cur_head_split)
-        self.channel_splits = [x*Ch for x in self.head_splits]
+        self.channel_splits = [x * head_chs for x in self.head_splits]
 
     def forward(self, q, v, size: Tuple[int, int]):
-        B, h, N, Ch = q.shape
+        B, num_heads, N, C = q.shape
         H, W = size
         _assert(N == 1 + H * W, '')
 
@@ -103,13 +105,13 @@ class ConvRelPosEnc(nn.Module):
         q_img = q[:, :, 1:, :]  # [B, h, H*W, Ch]
         v_img = v[:, :, 1:, :]  # [B, h, H*W, Ch]
 
-        v_img = v_img.transpose(-1, -2).reshape(B, h * Ch, H, W)
+        v_img = v_img.transpose(-1, -2).reshape(B, num_heads * C, H, W)
         v_img_list = torch.split(v_img, self.channel_splits, dim=1)  # Split according to channels
         conv_v_img_list = []
         for i, conv in enumerate(self.conv_list):
             conv_v_img_list.append(conv(v_img_list[i]))
         conv_v_img = torch.cat(conv_v_img_list, dim=1)
-        conv_v_img = conv_v_img.reshape(B, h, Ch, H * W).transpose(-1, -2)
+        conv_v_img = conv_v_img.reshape(B, num_heads, C, H * W).transpose(-1, -2)
 
         EV_hat = q_img * conv_v_img
         EV_hat = F.pad(EV_hat, (0, 0, 1, 0, 0, 0))  # [B, h, N, Ch].
@@ -118,7 +120,15 @@ class ConvRelPosEnc(nn.Module):
 
 class FactorAttnConvRelPosEnc(nn.Module):
     """ Factorized attention with convolutional relative position encoding class. """
-    def __init__(self, dim, num_heads=8, qkv_bias=False, attn_drop=0., proj_drop=0., shared_crpe=None):
+    def __init__(
+            self,
+            dim,
+            num_heads=8,
+            qkv_bias=False,
+            attn_drop=0.,
+            proj_drop=0.,
+            shared_crpe=None,
+    ):
         super().__init__()
         self.num_heads = num_heads
         head_dim = dim // num_heads
@@ -188,8 +198,20 @@ class ConvPosEnc(nn.Module):
 class SerialBlock(nn.Module):
     """ Serial block class.
         Note: In this implementation, each serial block only contains a conv-attention and a FFN (MLP) module. """
-    def __init__(self, dim, num_heads, mlp_ratio=4., qkv_bias=False, drop=0., attn_drop=0.,
-                 drop_path=0., act_layer=nn.GELU, norm_layer=nn.LayerNorm, shared_cpe=None, shared_crpe=None):
+    def __init__(
+            self,
+            dim,
+            num_heads,
+            mlp_ratio=4.,
+            qkv_bias=False,
+            proj_drop=0.,
+            attn_drop=0.,
+            drop_path=0.,
+            act_layer=nn.GELU,
+            norm_layer=nn.LayerNorm,
+            shared_cpe=None,
+            shared_crpe=None,
+    ):
         super().__init__()
 
         # Conv-Attention.
@@ -197,13 +219,24 @@ class SerialBlock(nn.Module):
 
         self.norm1 = norm_layer(dim)
         self.factoratt_crpe = FactorAttnConvRelPosEnc(
-            dim, num_heads=num_heads, qkv_bias=qkv_bias, attn_drop=attn_drop, proj_drop=drop, shared_crpe=shared_crpe)
+            dim,
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            attn_drop=attn_drop,
+            proj_drop=proj_drop,
+            shared_crpe=shared_crpe,
+        )
         self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
 
         # MLP.
         self.norm2 = norm_layer(dim)
         mlp_hidden_dim = int(dim * mlp_ratio)
-        self.mlp = Mlp(in_features=dim, hidden_features=mlp_hidden_dim, act_layer=act_layer, drop=drop)
+        self.mlp = Mlp(
+            in_features=dim,
+            hidden_features=mlp_hidden_dim,
+            act_layer=act_layer,
+            drop=proj_drop,
+        )
 
     def forward(self, x, size: Tuple[int, int]):
         # Conv-Attention.
@@ -222,8 +255,19 @@ class SerialBlock(nn.Module):
 
 class ParallelBlock(nn.Module):
     """ Parallel block class. """
-    def __init__(self, dims, num_heads, mlp_ratios=[], qkv_bias=False, drop=0., attn_drop=0.,
-                 drop_path=0., act_layer=nn.GELU, norm_layer=nn.LayerNorm, shared_crpes=None):
+    def __init__(
+            self,
+            dims,
+            num_heads,
+            mlp_ratios=[],
+            qkv_bias=False,
+            proj_drop=0.,
+            attn_drop=0.,
+            drop_path=0.,
+            act_layer=nn.GELU,
+            norm_layer=nn.LayerNorm,
+            shared_crpes=None,
+    ):
         super().__init__()
 
         # Conv-Attention.
@@ -231,16 +275,28 @@ class ParallelBlock(nn.Module):
         self.norm13 = norm_layer(dims[2])
         self.norm14 = norm_layer(dims[3])
         self.factoratt_crpe2 = FactorAttnConvRelPosEnc(
-            dims[1], num_heads=num_heads, qkv_bias=qkv_bias, attn_drop=attn_drop, proj_drop=drop, 
-            shared_crpe=shared_crpes[1]
+            dims[1],
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            attn_drop=attn_drop,
+            proj_drop=proj_drop,
+            shared_crpe=shared_crpes[1],
         )
         self.factoratt_crpe3 = FactorAttnConvRelPosEnc(
-            dims[2], num_heads=num_heads, qkv_bias=qkv_bias, attn_drop=attn_drop, proj_drop=drop, 
-            shared_crpe=shared_crpes[2]
+            dims[2],
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            attn_drop=attn_drop,
+            proj_drop=proj_drop,
+            shared_crpe=shared_crpes[2],
         )
         self.factoratt_crpe4 = FactorAttnConvRelPosEnc(
-            dims[3], num_heads=num_heads, qkv_bias=qkv_bias, attn_drop=attn_drop, proj_drop=drop, 
-            shared_crpe=shared_crpes[3]
+            dims[3],
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            attn_drop=attn_drop,
+            proj_drop=proj_drop,
+            shared_crpe=shared_crpes[3],
         )
         self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
 
@@ -253,7 +309,11 @@ class ParallelBlock(nn.Module):
         assert mlp_ratios[1] == mlp_ratios[2] == mlp_ratios[3]
         mlp_hidden_dim = int(dims[1] * mlp_ratios[1])
         self.mlp2 = self.mlp3 = self.mlp4 = Mlp(
-            in_features=dims[1], hidden_features=mlp_hidden_dim, act_layer=act_layer, drop=drop)
+            in_features=dims[1],
+            hidden_features=mlp_hidden_dim,
+            act_layer=act_layer,
+            drop=proj_drop,
+        )
 
     def upsample(self, x, factor: float, size: Tuple[int, int]):
         """ Feature map up-sampling. """
@@ -319,10 +379,27 @@ class ParallelBlock(nn.Module):
 class CoaT(nn.Module):
     """ CoaT class. """
     def __init__(
-            self, img_size=224, patch_size=16, in_chans=3, num_classes=1000, embed_dims=(0, 0, 0, 0),
-            serial_depths=(0, 0, 0, 0), parallel_depth=0, num_heads=0, mlp_ratios=(0, 0, 0, 0), qkv_bias=True,
-            drop_rate=0., attn_drop_rate=0., drop_path_rate=0., norm_layer=partial(nn.LayerNorm, eps=1e-6),
-            return_interm_layers=False, out_features=None, crpe_window=None, global_pool='token'):
+            self,
+            img_size=224,
+            patch_size=16,
+            in_chans=3,
+            num_classes=1000,
+            embed_dims=(0, 0, 0, 0),
+            serial_depths=(0, 0, 0, 0),
+            parallel_depth=0,
+            num_heads=0,
+            mlp_ratios=(0, 0, 0, 0),
+            qkv_bias=True,
+            drop_rate=0.,
+            proj_drop_rate=0.,
+            attn_drop_rate=0.,
+            drop_path_rate=0.,
+            norm_layer=partial(nn.LayerNorm, eps=1e-6),
+            return_interm_layers=False,
+            out_features=None,
+            crpe_window=None,
+            global_pool='token',
+    ):
         super().__init__()
         assert global_pool in ('token', 'avg')
         crpe_window = crpe_window or {3: 2, 5: 3, 7: 3}
@@ -361,21 +438,31 @@ class CoaT(nn.Module):
         self.cpe4 = ConvPosEnc(dim=embed_dims[3], k=3)
 
         # Convolutional relative position encodings.
-        self.crpe1 = ConvRelPosEnc(Ch=embed_dims[0] // num_heads, h=num_heads, window=crpe_window)
-        self.crpe2 = ConvRelPosEnc(Ch=embed_dims[1] // num_heads, h=num_heads, window=crpe_window)
-        self.crpe3 = ConvRelPosEnc(Ch=embed_dims[2] // num_heads, h=num_heads, window=crpe_window)
-        self.crpe4 = ConvRelPosEnc(Ch=embed_dims[3] // num_heads, h=num_heads, window=crpe_window)
+        self.crpe1 = ConvRelPosEnc(head_chs=embed_dims[0] // num_heads, num_heads=num_heads, window=crpe_window)
+        self.crpe2 = ConvRelPosEnc(head_chs=embed_dims[1] // num_heads, num_heads=num_heads, window=crpe_window)
+        self.crpe3 = ConvRelPosEnc(head_chs=embed_dims[2] // num_heads, num_heads=num_heads, window=crpe_window)
+        self.crpe4 = ConvRelPosEnc(head_chs=embed_dims[3] // num_heads, num_heads=num_heads, window=crpe_window)
 
         # Disable stochastic depth.
         dpr = drop_path_rate
         assert dpr == 0.0
-        
+        skwargs = dict(
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            proj_drop=proj_drop_rate,
+            attn_drop=attn_drop_rate,
+            drop_path=dpr,
+            norm_layer=norm_layer,
+        )
+
         # Serial blocks 1.
         self.serial_blocks1 = nn.ModuleList([
             SerialBlock(
-                dim=embed_dims[0], num_heads=num_heads, mlp_ratio=mlp_ratios[0], qkv_bias=qkv_bias,
-                drop=drop_rate, attn_drop=attn_drop_rate, drop_path=dpr, norm_layer=norm_layer, 
-                shared_cpe=self.cpe1, shared_crpe=self.crpe1
+                dim=embed_dims[0],
+                mlp_ratio=mlp_ratios[0],
+                shared_cpe=self.cpe1,
+                shared_crpe=self.crpe1,
+                **skwargs,
             )
             for _ in range(serial_depths[0])]
         )
@@ -383,9 +470,11 @@ class CoaT(nn.Module):
         # Serial blocks 2.
         self.serial_blocks2 = nn.ModuleList([
             SerialBlock(
-                dim=embed_dims[1], num_heads=num_heads, mlp_ratio=mlp_ratios[1], qkv_bias=qkv_bias,
-                drop=drop_rate, attn_drop=attn_drop_rate, drop_path=dpr, norm_layer=norm_layer, 
-                shared_cpe=self.cpe2, shared_crpe=self.crpe2
+                dim=embed_dims[1],
+                mlp_ratio=mlp_ratios[1],
+                shared_cpe=self.cpe2,
+                shared_crpe=self.crpe2,
+                **skwargs,
             )
             for _ in range(serial_depths[1])]
         )
@@ -393,9 +482,11 @@ class CoaT(nn.Module):
         # Serial blocks 3.
         self.serial_blocks3 = nn.ModuleList([
             SerialBlock(
-                dim=embed_dims[2], num_heads=num_heads, mlp_ratio=mlp_ratios[2], qkv_bias=qkv_bias,
-                drop=drop_rate, attn_drop=attn_drop_rate, drop_path=dpr, norm_layer=norm_layer, 
-                shared_cpe=self.cpe3, shared_crpe=self.crpe3
+                dim=embed_dims[2],
+                mlp_ratio=mlp_ratios[2],
+                shared_cpe=self.cpe3,
+                shared_crpe=self.crpe3,
+                **skwargs,
             )
             for _ in range(serial_depths[2])]
         )
@@ -403,9 +494,11 @@ class CoaT(nn.Module):
         # Serial blocks 4.
         self.serial_blocks4 = nn.ModuleList([
             SerialBlock(
-                dim=embed_dims[3], num_heads=num_heads, mlp_ratio=mlp_ratios[3], qkv_bias=qkv_bias,
-                drop=drop_rate, attn_drop=attn_drop_rate, drop_path=dpr, norm_layer=norm_layer, 
-                shared_cpe=self.cpe4, shared_crpe=self.crpe4
+                dim=embed_dims[3],
+                mlp_ratio=mlp_ratios[3],
+                shared_cpe=self.cpe4,
+                shared_crpe=self.crpe4,
+                **skwargs,
             )
             for _ in range(serial_depths[3])]
         )
@@ -415,9 +508,10 @@ class CoaT(nn.Module):
         if self.parallel_depth > 0:
             self.parallel_blocks = nn.ModuleList([
                 ParallelBlock(
-                    dims=embed_dims, num_heads=num_heads, mlp_ratios=mlp_ratios, qkv_bias=qkv_bias,
-                    drop=drop_rate, attn_drop=attn_drop_rate, drop_path=dpr, norm_layer=norm_layer,
-                    shared_crpes=(self.crpe1, self.crpe2, self.crpe3, self.crpe4)
+                    dims=embed_dims,
+                    mlp_ratios=mlp_ratios,
+                    shared_crpes=(self.crpe1, self.crpe2, self.crpe3, self.crpe4),
+                    **skwargs,
                 )
                 for _ in range(parallel_depth)]
             )
@@ -437,10 +531,12 @@ class CoaT(nn.Module):
                 # CoaT series: Aggregate features of last three scales for classification.
                 assert embed_dims[1] == embed_dims[2] == embed_dims[3]
                 self.aggregate = torch.nn.Conv1d(in_channels=3, out_channels=1, kernel_size=1)
+                self.head_drop = nn.Dropout(drop_rate)
                 self.head = nn.Linear(self.num_features, num_classes) if num_classes > 0 else nn.Identity()
             else:
                 # CoaT-Lite series: Use feature of last scale for classification.
                 self.aggregate = None
+                self.head_drop = nn.Dropout(drop_rate)
                 self.head = nn.Linear(self.num_features, num_classes) if num_classes > 0 else nn.Identity()
 
         # Initialize weights.
@@ -587,6 +683,7 @@ class CoaT(nn.Module):
             x = self.aggregate(x).squeeze(dim=1)  # Shape: [B, C]
         else:
             x = x_feat[:, 1:].mean(dim=1) if self.global_pool == 'avg' else x_feat[:, 0]
+        x = self.head_drop(x)
         return x if pre_logits else self.head(x)
 
     def forward(self, x) -> torch.Tensor:

--- a/timm/models/davit.py
+++ b/timm/models/davit.py
@@ -468,7 +468,6 @@ class DaViT(nn.Module):
             ffn=True,
             cpe_act=False,
             drop_rate=0.,
-            attn_drop_rate=0.,
             drop_path_rate=0.,
             num_classes=1000,
             global_pool='avg',

--- a/timm/models/edgenext.py
+++ b/timm/models/edgenext.py
@@ -21,47 +21,9 @@ from timm.layers import trunc_normal_tf_, DropPath, LayerNorm2d, Mlp, SelectAdap
 from ._builder import build_model_with_cfg
 from ._features_fx import register_notrace_module
 from ._manipulate import named_apply, checkpoint_seq
-from ._registry import register_model
+from ._registry import register_model, generate_default_cfgs
 
 __all__ = ['EdgeNeXt']  # model_registry will add each entrypoint fn to this
-
-
-def _cfg(url='', **kwargs):
-    return {
-        'url': url,
-        'num_classes': 1000, 'input_size': (3, 256, 256), 'pool_size': (8, 8),
-        'crop_pct': 0.9, 'interpolation': 'bicubic',
-        'mean': IMAGENET_DEFAULT_MEAN, 'std': IMAGENET_DEFAULT_STD,
-        'first_conv': 'stem.0', 'classifier': 'head.fc',
-        **kwargs
-    }
-
-
-default_cfgs = dict(
-    edgenext_xx_small=_cfg(
-        url="https://github.com/mmaaz60/EdgeNeXt/releases/download/v1.0/edgenext_xx_small.pth",
-        test_input_size=(3, 288, 288), test_crop_pct=1.0),
-    edgenext_x_small=_cfg(
-        url="https://github.com/mmaaz60/EdgeNeXt/releases/download/v1.0/edgenext_x_small.pth",
-        test_input_size=(3, 288, 288), test_crop_pct=1.0),
-    # edgenext_small=_cfg(
-    #     url="https://github.com/mmaaz60/EdgeNeXt/releases/download/v1.0/edgenext_small.pth"),
-    edgenext_small=_cfg(  # USI weights
-        url="https://github.com/mmaaz60/EdgeNeXt/releases/download/v1.1/edgenext_small_usi.pth",
-        crop_pct=0.95, test_input_size=(3, 320, 320), test_crop_pct=1.0,
-    ),
-    # edgenext_base=_cfg(
-    #     url="https://github.com/mmaaz60/EdgeNeXt/releases/download/v1.2/edgenext_base_usi.pth"),
-    edgenext_base=_cfg(  # USI weights
-        url="https://github.com/mmaaz60/EdgeNeXt/releases/download/v1.2/edgenext_base_usi.pth",
-        crop_pct=0.95, test_input_size=(3, 320, 320), test_crop_pct=1.0,
-    ),
-
-    edgenext_small_rw=_cfg(
-        url='https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-attn-weights/edgenext_small_rw-sw-b00041bb.pth',
-        test_input_size=(3, 320, 320), test_crop_pct=1.0,
-    ),
-)
 
 
 @register_notrace_module  # reason: FX can't symbolically trace torch.arange in forward method
@@ -517,6 +479,43 @@ def _create_edgenext(variant, pretrained=False, **kwargs):
         feature_cfg=dict(out_indices=(0, 1, 2, 3), flatten_sequential=True),
         **kwargs)
     return model
+
+
+def _cfg(url='', **kwargs):
+    return {
+        'url': url,
+        'num_classes': 1000, 'input_size': (3, 256, 256), 'pool_size': (8, 8),
+        'crop_pct': 0.9, 'interpolation': 'bicubic',
+        'mean': IMAGENET_DEFAULT_MEAN, 'std': IMAGENET_DEFAULT_STD,
+        'first_conv': 'stem.0', 'classifier': 'head.fc',
+        **kwargs
+    }
+
+
+default_cfgs = generate_default_cfgs({
+    'edgenext_xx_small.in1k': _cfg(
+        url="https://github.com/mmaaz60/EdgeNeXt/releases/download/v1.0/edgenext_xx_small.pth",
+        test_input_size=(3, 288, 288), test_crop_pct=1.0),
+    'edgenext_x_small.in1k': _cfg(
+        url="https://github.com/mmaaz60/EdgeNeXt/releases/download/v1.0/edgenext_x_small.pth",
+        test_input_size=(3, 288, 288), test_crop_pct=1.0),
+    'edgenext_small.usi_in1k': _cfg(  # USI weights
+        url="https://github.com/mmaaz60/EdgeNeXt/releases/download/v1.1/edgenext_small_usi.pth",
+        crop_pct=0.95, test_input_size=(3, 320, 320), test_crop_pct=1.0,
+    ),
+    'edgenext_base.usi_in1k': _cfg(  # USI weights
+        url="https://github.com/mmaaz60/EdgeNeXt/releases/download/v1.2/edgenext_base_usi.pth",
+        crop_pct=0.95, test_input_size=(3, 320, 320), test_crop_pct=1.0,
+    ),
+    'edgenext_base.in21k_ft_in1k': _cfg(  # USI weights
+        url="https://github.com/mmaaz60/EdgeNeXt/releases/download/v1.21/edgenext_base_IN21K.pth",
+        crop_pct=0.95, test_input_size=(3, 320, 320), test_crop_pct=1.0,
+    ),
+    'edgenext_small_rw.sw_in1k': _cfg(
+        url='https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-attn-weights/edgenext_small_rw-sw-b00041bb.pth',
+        test_input_size=(3, 320, 320), test_crop_pct=1.0,
+    ),
+})
 
 
 @register_model

--- a/timm/models/efficientformer.py
+++ b/timm/models/efficientformer.py
@@ -211,7 +211,7 @@ class MetaBlock1d(nn.Module):
             mlp_ratio=4.,
             act_layer=nn.GELU,
             norm_layer=nn.LayerNorm,
-            drop=0.,
+            proj_drop=0.,
             drop_path=0.,
             layer_scale_init_value=1e-5
     ):
@@ -219,7 +219,12 @@ class MetaBlock1d(nn.Module):
         self.norm1 = norm_layer(dim)
         self.token_mixer = Attention(dim)
         self.norm2 = norm_layer(dim)
-        self.mlp = Mlp(in_features=dim, hidden_features=int(dim * mlp_ratio), act_layer=act_layer, drop=drop)
+        self.mlp = Mlp(
+            in_features=dim,
+            hidden_features=int(dim * mlp_ratio),
+            act_layer=act_layer,
+            drop=proj_drop,
+        )
 
         self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
         self.ls1 = LayerScale(dim, layer_scale_init_value)
@@ -251,7 +256,7 @@ class MetaBlock2d(nn.Module):
             mlp_ratio=4.,
             act_layer=nn.GELU,
             norm_layer=nn.BatchNorm2d,
-            drop=0.,
+            proj_drop=0.,
             drop_path=0.,
             layer_scale_init_value=1e-5
     ):
@@ -261,7 +266,12 @@ class MetaBlock2d(nn.Module):
         self.drop_path1 = DropPath(drop_path) if drop_path > 0. else nn.Identity()
 
         self.mlp = ConvMlpWithNorm(
-            dim, hidden_features=int(dim * mlp_ratio), act_layer=act_layer, norm_layer=norm_layer, drop=drop)
+            dim,
+            hidden_features=int(dim * mlp_ratio),
+            act_layer=act_layer,
+            norm_layer=norm_layer,
+            drop=proj_drop,
+        )
         self.ls2 = LayerScale2d(dim, layer_scale_init_value)
         self.drop_path2 = DropPath(drop_path) if drop_path > 0. else nn.Identity()
 
@@ -285,7 +295,7 @@ class EfficientFormerStage(nn.Module):
             act_layer=nn.GELU,
             norm_layer=nn.BatchNorm2d,
             norm_layer_cl=nn.LayerNorm,
-            drop=.0,
+            proj_drop=.0,
             drop_path=0.,
             layer_scale_init_value=1e-5,
 ):
@@ -312,7 +322,7 @@ class EfficientFormerStage(nn.Module):
                         mlp_ratio=mlp_ratio,
                         act_layer=act_layer,
                         norm_layer=norm_layer_cl,
-                        drop=drop,
+                        proj_drop=proj_drop,
                         drop_path=drop_path[block_idx],
                         layer_scale_init_value=layer_scale_init_value,
                     ))
@@ -324,7 +334,7 @@ class EfficientFormerStage(nn.Module):
                         mlp_ratio=mlp_ratio,
                         act_layer=act_layer,
                         norm_layer=norm_layer,
-                        drop=drop,
+                        proj_drop=proj_drop,
                         drop_path=drop_path[block_idx],
                         layer_scale_init_value=layer_scale_init_value,
                     ))
@@ -360,6 +370,7 @@ class EfficientFormer(nn.Module):
             norm_layer=nn.BatchNorm2d,
             norm_layer_cl=nn.LayerNorm,
             drop_rate=0.,
+            proj_drop_rate=0.,
             drop_path_rate=0.,
             **kwargs
     ):
@@ -386,7 +397,7 @@ class EfficientFormer(nn.Module):
                 act_layer=act_layer,
                 norm_layer_cl=norm_layer_cl,
                 norm_layer=norm_layer,
-                drop=drop_rate,
+                proj_drop=proj_drop_rate,
                 drop_path=dpr[i],
                 layer_scale_init_value=layer_scale_init_value,
             )
@@ -398,6 +409,7 @@ class EfficientFormer(nn.Module):
         # Classifier head
         self.num_features = embed_dims[-1]
         self.norm = norm_layer_cl(self.num_features)
+        self.head_drop = nn.Dropout(drop_rate)
         self.head = nn.Linear(self.num_features, num_classes) if num_classes > 0 else nn.Identity()
         # assuming model is always distilled (valid for current checkpoints, will split def if that changes)
         self.head_dist = nn.Linear(embed_dims[-1], num_classes) if num_classes > 0 else nn.Identity()
@@ -453,6 +465,7 @@ class EfficientFormer(nn.Module):
     def forward_head(self, x, pre_logits: bool = False):
         if self.global_pool == 'avg':
             x = x.mean(dim=1)
+        x = self.head_drop(x)
         if pre_logits:
             return x
         x, x_dist = self.head(x), self.head_dist(x)

--- a/timm/models/efficientformer_v2.py
+++ b/timm/models/efficientformer_v2.py
@@ -342,7 +342,8 @@ class ConvMlpWithNorm(nn.Module):
         out_features = out_features or in_features
         hidden_features = hidden_features or in_features
         self.fc1 = ConvNormAct(
-            in_features, hidden_features, 1, bias=True, norm_layer=norm_layer, act_layer=act_layer)
+            in_features, hidden_features, 1,
+            bias=True, norm_layer=norm_layer, act_layer=act_layer)
         if mid_conv:
             self.mid = ConvNormAct(
                 hidden_features, hidden_features, 3,
@@ -380,7 +381,7 @@ class EfficientFormerV2Block(nn.Module):
             mlp_ratio=4.,
             act_layer=nn.GELU,
             norm_layer=nn.BatchNorm2d,
-            drop=0.,
+            proj_drop=0.,
             drop_path=0.,
             layer_scale_init_value=1e-5,
             resolution=7,
@@ -409,7 +410,7 @@ class EfficientFormerV2Block(nn.Module):
             hidden_features=int(dim * mlp_ratio),
             act_layer=act_layer,
             norm_layer=norm_layer,
-            drop=drop,
+            drop=proj_drop,
             mid_conv=True,
         )
         self.ls2 = LayerScale2d(
@@ -451,7 +452,7 @@ class EfficientFormerV2Stage(nn.Module):
             block_use_attn=False,
             num_vit=1,
             mlp_ratio=4.,
-            drop=.0,
+            proj_drop=.0,
             drop_path=0.,
             layer_scale_init_value=1e-5,
             act_layer=nn.GELU,
@@ -487,7 +488,7 @@ class EfficientFormerV2Stage(nn.Module):
                 stride=block_stride,
                 mlp_ratio=mlp_ratio[block_idx],
                 use_attn=block_use_attn and block_idx > remain_idx,
-                drop=drop,
+                proj_drop=proj_drop,
                 drop_path=drop_path[block_idx],
                 layer_scale_init_value=layer_scale_init_value,
                 act_layer=act_layer,
@@ -520,6 +521,7 @@ class EfficientFormerV2(nn.Module):
             act_layer='gelu',
             num_classes=1000,
             drop_rate=0.,
+            proj_drop_rate=0.,
             drop_path_rate=0.,
             layer_scale_init_value=1e-5,
             num_vit=0,
@@ -556,7 +558,7 @@ class EfficientFormerV2(nn.Module):
                 block_use_attn=i >= 2,
                 num_vit=num_vit,
                 mlp_ratio=mlp_ratios[i],
-                drop=drop_rate,
+                proj_drop=proj_drop_rate,
                 drop_path=dpr[i],
                 layer_scale_init_value=layer_scale_init_value,
                 act_layer=act_layer,
@@ -572,6 +574,7 @@ class EfficientFormerV2(nn.Module):
         # Classifier head
         self.num_features = embed_dims[-1]
         self.norm = norm_layer(embed_dims[-1])
+        self.head_drop = nn.Dropout(drop_rate)
         self.head = nn.Linear(embed_dims[-1], num_classes) if num_classes > 0 else nn.Identity()
         self.dist = distillation
         if self.dist:
@@ -630,6 +633,7 @@ class EfficientFormerV2(nn.Module):
     def forward_head(self, x, pre_logits: bool = False):
         if self.global_pool == 'avg':
             x = x.mean(dim=(2, 3))
+        x = self.head_drop(x)
         if pre_logits:
             return x
         x, x_dist = self.head(x), self.head_dist(x)

--- a/timm/models/eva.py
+++ b/timm/models/eva.py
@@ -773,29 +773,51 @@ default_cfgs = generate_default_cfgs({
     ),
 
     # EVA01 and EVA02 CLIP image towers
-    'eva_giant_patch14_224.clip': _cfg(
-        #hf_hub_id='QuanSun/EVA-CLIP', hf_hub_filename='EVA01_CLIP_g_14_plus_psz14_s11B.pt',
+    'eva_giant_patch14_clip_224.laion400m': _cfg(
+        # hf_hub_id='QuanSun/EVA-CLIP', hf_hub_filename='EVA01_CLIP_g_14_plus_psz14_s11B.pt',
+        hf_hub_id='timm/eva_giant_patch14_clip_224.laion400m_s11b_b41k',  # float16 weights
+        hf_hub_filename='open_clip_pytorch_model.bin',
         num_classes=1024,
     ),
-    'eva02_base_patch16_clip_224.clip': _cfg(
-        #hf_hub_id='QuanSun/EVA-CLIP', hf_hub_filename='EVA02_CLIP_L_psz14_s4B.pt',
+    'eva_giant_patch14_clip_224.merged2b': _cfg(
+        # hf_hub_id='QuanSun/EVA-CLIP', hf_hub_filename='EVA01_CLIP_g_14_plus_psz14_s11B.pt',
+        hf_hub_id='timm/eva_giant_patch14_plus_clip_224.merged2b_s11b_b114k',  # float16 weights
+        hf_hub_filename='open_clip_pytorch_model.bin',
+        num_classes=1024,
+    ),
+    'eva02_base_patch16_clip_224.merged2b': _cfg(
+        # hf_hub_id='QuanSun/EVA-CLIP', hf_hub_filename='EVA02_CLIP_L_psz14_s4B.pt',
+        hf_hub_id='timm/eva02_base_patch16_clip_224.merged2b_s8b_b131k',  # float16 weights
+        hf_hub_filename='open_clip_pytorch_model.bin',
         num_classes=512,
     ),
-    'eva02_large_patch14_clip_224.clip': _cfg(
-        #hf_hub_id='QuanSun/EVA-CLIP', hf_hub_filename='EVA02_CLIP_L_psz14_s4B.pt',
+    'eva02_large_patch14_clip_224.merged2b': _cfg(
+        # hf_hub_id='QuanSun/EVA-CLIP', hf_hub_filename='EVA02_CLIP_L_psz14_s4B.pt',
+        hf_hub_id='timm/eva02_large_patch14_clip_224.merged2b_s4b_b131k',  # float16 weights
+        hf_hub_filename='open_clip_pytorch_model.bin',
         num_classes=768,
     ),
-    'eva02_large_patch14_clip_336.clip': _cfg(
+    'eva02_large_patch14_clip_336.merged2b': _cfg(
         # hf_hub_id='QuanSun/EVA-CLIP', hf_hub_filename='EVA02_CLIP_L_psz14_s4B.pt',
+        hf_hub_id='timm/eva02_large_patch14_clip_336.merged2b_s6b_b61k',  # float16 weights
+        hf_hub_filename='open_clip_pytorch_model.bin',
         input_size=(3, 336, 336), crop_pct=1.0,
         num_classes=768,
     ),
-    'eva02_enormous_patch14_clip_224.clip': _cfg(
-        #hf_hub_id='QuanSun/EVA-CLIP', hf_hub_filename='EVA02_CLIP_E_psz14_plus_s9B.pt',
+    'eva02_enormous_patch14_clip_224.laion2b': _cfg(
+        # hf_hub_id='QuanSun/EVA-CLIP', hf_hub_filename='EVA02_CLIP_E_psz14_plus_s9B.pt',
+        hf_hub_id='timm/eva02_enormous_patch14_clip_224.laion2b_s4b_b115k',  # float16 weights
+        hf_hub_filename='open_clip_pytorch_model.bin',
+        num_classes=1024,
+    ),
+    'eva02_enormous_patch14_clip_224.laion2b_plus': _cfg(
+        # hf_hub_id='QuanSun/EVA-CLIP', hf_hub_filename='EVA02_CLIP_E_psz14_plus_s9B.pt',
+        hf_hub_id='timm/eva02_enormous_patch14_plus_clip_224.laion2b_s9b_b144k',  # bfloat16 weights
+        hf_hub_filename='open_clip_pytorch_model.bin',
         num_classes=1024,
     ),
     'eva02_enormous_patch14_clip_224.pretrain': _cfg(
-        #hf_hub_id='QuanSun/EVA-CLIP', hf_hub_filename='EVA02_E_psz14.pt',
+        # hf_hub_id='QuanSun/EVA-CLIP', hf_hub_filename='EVA02_E_psz14.pt',
         num_classes=0,
     ),
 
@@ -971,8 +993,18 @@ def eva02_large_patch14_448(pretrained=False, **kwargs):
 
 
 @register_model
+def eva_giant_patch14_clip_224(pretrained=False, **kwargs):
+    """ EVA-g CLIP model (only difference from non-CLIP is the pooling)  """
+    model_args = dict(
+        patch_size=14, embed_dim=1408, depth=40, num_heads=16, mlp_ratio=6144 / 1408,
+        global_pool=kwargs.pop('global_pool', 'token'))
+    model = _create_eva('eva_giant_patch14_clip_224', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
+
+
+@register_model
 def eva02_base_patch16_clip_224(pretrained=False, **kwargs):
-    # A EVA-CLIP specific variant that adds additional attn scale layernorm to eva02_base
+    """ A EVA-CLIP specific variant that adds additional attn scale layernorm to eva02_base """
     model_args = dict(
         img_size=224,
         patch_size=16,
@@ -986,7 +1018,7 @@ def eva02_base_patch16_clip_224(pretrained=False, **kwargs):
         scale_attn_inner=True,
         use_rot_pos_emb=True,
         ref_feat_shape=(16, 16),  # 224/14
-        global_pool='token',
+        global_pool=kwargs.pop('global_pool', 'token'),
     )
     model = _create_eva('eva02_base_patch16_clip_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
@@ -994,7 +1026,7 @@ def eva02_base_patch16_clip_224(pretrained=False, **kwargs):
 
 @register_model
 def eva02_large_patch14_clip_224(pretrained=False, **kwargs):
-    # A EVA-CLIP specific variant that adds additional attn scale layernorm to eva02_large
+    """ A EVA-CLIP specific variant that adds additional attn scale layernorm to eva02_large """
     model_args = dict(
         img_size=224,
         patch_size=14,
@@ -1008,7 +1040,7 @@ def eva02_large_patch14_clip_224(pretrained=False, **kwargs):
         scale_attn_inner=True,
         use_rot_pos_emb=True,
         ref_feat_shape=(16, 16),  # 224/14
-        global_pool='token',
+        global_pool=kwargs.pop('global_pool', 'token'),
     )
     model = _create_eva('eva02_large_patch14_clip_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
@@ -1016,7 +1048,7 @@ def eva02_large_patch14_clip_224(pretrained=False, **kwargs):
 
 @register_model
 def eva02_large_patch14_clip_336(pretrained=False, **kwargs):
-    # A EVA-CLIP specific variant that adds additional attn scale layernorm to eva02_large
+    """ A EVA-CLIP specific variant that adds additional attn scale layernorm to eva02_large """
     model_args = dict(
         img_size=336,
         patch_size=14,
@@ -1030,7 +1062,7 @@ def eva02_large_patch14_clip_336(pretrained=False, **kwargs):
         scale_attn_inner=True,
         use_rot_pos_emb=True,
         ref_feat_shape=(16, 16),  # 224/14
-        global_pool='token',
+        global_pool=kwargs.pop('global_pool', 'token'),
     )
     model = _create_eva('eva02_large_patch14_clip_336', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
@@ -1038,7 +1070,7 @@ def eva02_large_patch14_clip_336(pretrained=False, **kwargs):
 
 @register_model
 def eva02_enormous_patch14_clip_224(pretrained=False, **kwargs):
-    # A EVA-CLIP specific variant that uses residual post-norm in blocks
+    """ A EVA-CLIP specific variant that uses residual post-norm in blocks """
     model_args = dict(
         img_size=224,
         patch_size=14,
@@ -1047,7 +1079,7 @@ def eva02_enormous_patch14_clip_224(pretrained=False, **kwargs):
         num_heads=16,
         mlp_ratio=15360 / 1792,
         use_post_norm=True,
-        global_pool='token',
+        global_pool=kwargs.pop('global_pool', 'token'),
     )
     model = _create_eva('eva02_enormous_patch14_clip_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model

--- a/timm/models/focalnet.py
+++ b/timm/models/focalnet.py
@@ -75,12 +75,6 @@ class FocalModulation(nn.Module):
         self.norm = norm_layer(dim) if self.use_post_norm else nn.Identity()
 
     def forward(self, x):
-        """
-        Args:
-            x: input features with shape of (B, H, W, C)
-        """
-        C = x.shape[1]
-
         # pre linear projection
         x = self.f(x)
         q, ctx, gates = torch.split(x, self.input_split, 1)

--- a/timm/models/mobilevit.py
+++ b/timm/models/mobilevit.py
@@ -271,7 +271,7 @@ class MobileVitBlock(nn.Module):
                 num_heads=num_heads,
                 qkv_bias=True,
                 attn_drop=attn_drop,
-                drop=drop,
+                proj_drop=drop,
                 drop_path=drop_path_rate,
                 act_layer=layers.act,
                 norm_layer=transformer_norm_layer,

--- a/timm/models/swin_transformer.py
+++ b/timm/models/swin_transformer.py
@@ -181,7 +181,7 @@ class SwinTransformerBlock(nn.Module):
             shift_size: int = 0,
             mlp_ratio: float = 4.,
             qkv_bias: bool = True,
-            drop: float = 0.,
+            proj_drop: float = 0.,
             attn_drop: float = 0.,
             drop_path: float = 0.,
             act_layer: Callable = nn.GELU,
@@ -197,7 +197,7 @@ class SwinTransformerBlock(nn.Module):
             shift_size: Shift size for SW-MSA.
             mlp_ratio: Ratio of mlp hidden dim to embedding dim.
             qkv_bias: If True, add a learnable bias to query, key, value.
-            drop: Dropout rate.
+            proj_drop: Dropout rate.
             attn_drop: Attention dropout rate.
             drop_path: Stochastic depth rate.
             act_layer: Activation layer.
@@ -223,7 +223,7 @@ class SwinTransformerBlock(nn.Module):
             window_size=to_2tuple(self.window_size),
             qkv_bias=qkv_bias,
             attn_drop=attn_drop,
-            proj_drop=drop,
+            proj_drop=proj_drop,
         )
 
         self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
@@ -232,7 +232,7 @@ class SwinTransformerBlock(nn.Module):
             in_features=dim,
             hidden_features=int(dim * mlp_ratio),
             act_layer=act_layer,
-            drop=drop,
+            drop=proj_drop,
         )
 
         if self.shift_size > 0:
@@ -346,7 +346,7 @@ class SwinTransformerStage(nn.Module):
             window_size: _int_or_tuple_2_t = 7,
             mlp_ratio: float = 4.,
             qkv_bias: bool = True,
-            drop: float = 0.,
+            proj_drop: float = 0.,
             attn_drop: float = 0.,
             drop_path: Union[List[float], float] = 0.,
             norm_layer: Callable = nn.LayerNorm,
@@ -362,7 +362,7 @@ class SwinTransformerStage(nn.Module):
             window_size: Local window size.
             mlp_ratio: Ratio of mlp hidden dim to embedding dim.
             qkv_bias: If True, add a learnable bias to query, key, value.
-            drop: Dropout rate.
+            proj_drop: Projection dropout rate.
             attn_drop: Attention dropout rate.
             drop_path: Stochastic depth rate.
             norm_layer: Normalization layer.
@@ -396,7 +396,7 @@ class SwinTransformerStage(nn.Module):
                 shift_size=0 if (i % 2 == 0) else window_size // 2,
                 mlp_ratio=mlp_ratio,
                 qkv_bias=qkv_bias,
-                drop=drop,
+                proj_drop=proj_drop,
                 attn_drop=attn_drop,
                 drop_path=drop_path[i] if isinstance(drop_path, list) else drop_path,
                 norm_layer=norm_layer,
@@ -435,6 +435,7 @@ class SwinTransformer(nn.Module):
             mlp_ratio: float = 4.,
             qkv_bias: bool = True,
             drop_rate: float = 0.,
+            proj_drop_rate: float = 0.,
             attn_drop_rate: float = 0.,
             drop_path_rate: float = 0.1,
             norm_layer: Union[str, Callable] = nn.LayerNorm,
@@ -508,7 +509,7 @@ class SwinTransformer(nn.Module):
                 window_size=window_size[i],
                 mlp_ratio=mlp_ratio[i],
                 qkv_bias=qkv_bias,
-                drop=drop_rate,
+                proj_drop=proj_drop_rate,
                 attn_drop=attn_drop_rate,
                 drop_path=dpr[i],
                 norm_layer=norm_layer,

--- a/timm/models/swin_transformer_v2.py
+++ b/timm/models/swin_transformer_v2.py
@@ -203,7 +203,7 @@ class SwinTransformerV2Block(nn.Module):
             shift_size=0,
             mlp_ratio=4.,
             qkv_bias=True,
-            drop=0.,
+            proj_drop=0.,
             attn_drop=0.,
             drop_path=0.,
             act_layer=nn.GELU,
@@ -219,7 +219,7 @@ class SwinTransformerV2Block(nn.Module):
             shift_size: Shift size for SW-MSA.
             mlp_ratio: Ratio of mlp hidden dim to embedding dim.
             qkv_bias: If True, add a learnable bias to query, key, value.
-            drop: Dropout rate.
+            proj_drop: Dropout rate.
             attn_drop: Attention dropout rate.
             drop_path: Stochastic depth rate.
             act_layer: Activation layer.
@@ -242,7 +242,7 @@ class SwinTransformerV2Block(nn.Module):
             num_heads=num_heads,
             qkv_bias=qkv_bias,
             attn_drop=attn_drop,
-            proj_drop=drop,
+            proj_drop=proj_drop,
             pretrained_window_size=to_2tuple(pretrained_window_size),
         )
         self.norm1 = norm_layer(dim)
@@ -252,7 +252,7 @@ class SwinTransformerV2Block(nn.Module):
             in_features=dim,
             hidden_features=int(dim * mlp_ratio),
             act_layer=act_layer,
-            drop=drop,
+            drop=proj_drop,
         )
         self.norm2 = norm_layer(dim)
         self.drop_path2 = DropPath(drop_path) if drop_path > 0. else nn.Identity()
@@ -367,7 +367,7 @@ class SwinTransformerV2Stage(nn.Module):
             downsample=False,
             mlp_ratio=4.,
             qkv_bias=True,
-            drop=0.,
+            proj_drop=0.,
             attn_drop=0.,
             drop_path=0.,
             norm_layer=nn.LayerNorm,
@@ -384,7 +384,7 @@ class SwinTransformerV2Stage(nn.Module):
             downsample: Use downsample layer at start of the block.
             mlp_ratio: Ratio of mlp hidden dim to embedding dim.
             qkv_bias: If True, add a learnable bias to query, key, value.
-            drop: Dropout rate
+            proj_drop: Projection dropout rate
             attn_drop: Attention dropout rate.
             drop_path: Stochastic depth rate.
             norm_layer: Normalization layer.
@@ -416,7 +416,7 @@ class SwinTransformerV2Stage(nn.Module):
                 shift_size=0 if (i % 2 == 0) else window_size // 2,
                 mlp_ratio=mlp_ratio,
                 qkv_bias=qkv_bias,
-                drop=drop,
+                proj_drop=proj_drop,
                 attn_drop=attn_drop,
                 drop_path=drop_path[i] if isinstance(drop_path, list) else drop_path,
                 norm_layer=norm_layer,
@@ -463,6 +463,7 @@ class SwinTransformerV2(nn.Module):
             mlp_ratio: float = 4.,
             qkv_bias: bool = True,
             drop_rate: float = 0.,
+            proj_drop_rate: float = 0.,
             attn_drop_rate: float = 0.,
             drop_path_rate: float = 0.1,
             norm_layer: Callable = nn.LayerNorm,
@@ -481,7 +482,8 @@ class SwinTransformerV2(nn.Module):
             window_size: Window size.
             mlp_ratio: Ratio of mlp hidden dim to embedding dim.
             qkv_bias: If True, add a learnable bias to query, key, value.
-            drop_rate: Dropout rate.
+            drop_rate: Head dropout rate.
+            proj_drop_rate: Projection dropout rate.
             attn_drop_rate: Attention dropout rate.
             drop_path_rate: Stochastic depth rate.
             norm_layer: Normalization layer.
@@ -531,7 +533,8 @@ class SwinTransformerV2(nn.Module):
                 window_size=window_size,
                 mlp_ratio=mlp_ratio,
                 qkv_bias=qkv_bias,
-                drop=drop_rate, attn_drop=attn_drop_rate,
+                proj_drop=proj_drop_rate,
+                attn_drop=attn_drop_rate,
                 drop_path=dpr[i],
                 norm_layer=norm_layer,
                 pretrained_window_size=pretrained_window_sizes[i],

--- a/timm/models/swin_transformer_v2_cr.py
+++ b/timm/models/swin_transformer_v2_cr.py
@@ -221,7 +221,7 @@ class SwinTransformerV2CrBlock(nn.Module):
         window_size (Tuple[int, int]): Window size to be utilized
         shift_size (int): Shifting size to be used
         mlp_ratio (int): Ratio of the hidden dimension in the FFN to the input channels
-        drop (float): Dropout in input mapping
+        proj_drop (float): Dropout in input mapping
         drop_attn (float): Dropout rate of attention map
         drop_path (float): Dropout in main path
         extra_norm (bool): Insert extra norm on 'main' branch if True
@@ -238,7 +238,7 @@ class SwinTransformerV2CrBlock(nn.Module):
         shift_size: Tuple[int, int] = (0, 0),
         mlp_ratio: float = 4.0,
         init_values: Optional[float] = 0,
-        drop: float = 0.0,
+        proj_drop: float = 0.0,
         drop_attn: float = 0.0,
         drop_path: float = 0.0,
         extra_norm: bool = False,
@@ -259,7 +259,7 @@ class SwinTransformerV2CrBlock(nn.Module):
             num_heads=num_heads,
             window_size=self.window_size,
             drop_attn=drop_attn,
-            drop_proj=drop,
+            drop_proj=proj_drop,
             sequential_attn=sequential_attn,
         )
         self.norm1 = norm_layer(dim)
@@ -269,7 +269,7 @@ class SwinTransformerV2CrBlock(nn.Module):
         self.mlp = Mlp(
             in_features=dim,
             hidden_features=int(dim * mlp_ratio),
-            drop=drop,
+            drop=proj_drop,
             out_features=dim,
         )
         self.norm2 = norm_layer(dim)
@@ -445,7 +445,7 @@ class SwinTransformerV2CrStage(nn.Module):
         num_heads (int): Number of attention heads to be utilized
         window_size (int): Window size to be utilized
         mlp_ratio (int): Ratio of the hidden dimension in the FFN to the input channels
-        drop (float): Dropout in input mapping
+        proj_drop (float): Dropout in input mapping
         drop_attn (float): Dropout rate of attention map
         drop_path (float): Dropout in main path
         norm_layer (Type[nn.Module]): Type of normalization layer to be utilized. Default: nn.LayerNorm
@@ -464,7 +464,7 @@ class SwinTransformerV2CrStage(nn.Module):
         window_size: Tuple[int, int],
         mlp_ratio: float = 4.0,
         init_values: Optional[float] = 0.0,
-        drop: float = 0.0,
+        proj_drop: float = 0.0,
         drop_attn: float = 0.0,
         drop_path: Union[List[float], float] = 0.0,
         norm_layer: Type[nn.Module] = nn.LayerNorm,
@@ -498,7 +498,7 @@ class SwinTransformerV2CrStage(nn.Module):
                 shift_size=tuple([0 if ((index % 2) == 0) else w // 2 for w in window_size]),
                 mlp_ratio=mlp_ratio,
                 init_values=init_values,
-                drop=drop,
+                proj_drop=proj_drop,
                 drop_attn=drop_attn,
                 drop_path=drop_path[index] if isinstance(drop_path, list) else drop_path,
                 extra_norm=_extra_norm(index),
@@ -546,23 +546,24 @@ class SwinTransformerV2Cr(nn.Module):
           https://arxiv.org/pdf/2111.09883
 
     Args:
-        img_size (Tuple[int, int]): Input resolution.
-        window_size (Optional[int]): Window size. If None, img_size // window_div. Default: None
-        img_window_ratio (int): Window size to image size ratio. Default: 32
-        patch_size (int | tuple(int)): Patch size. Default: 4
-        in_chans (int): Number of input channels.
-        depths (int): Depth of the stage (number of layers).
-        num_heads (int): Number of attention heads to be utilized.
-        embed_dim (int): Patch embedding dimension. Default: 96
-        num_classes (int): Number of output classes. Default: 1000
-        mlp_ratio (int):  Ratio of the hidden dimension in the FFN to the input channels. Default: 4
-        drop_rate (float): Dropout rate. Default: 0.0
-        attn_drop_rate (float): Dropout rate of attention map. Default: 0.0
-        drop_path_rate (float): Stochastic depth rate. Default: 0.0
-        norm_layer (Type[nn.Module]): Type of normalization layer to be utilized. Default: nn.LayerNorm
-        extra_norm_period (int): Insert extra norm layer on main branch every N (period) blocks in stage
-        extra_norm_stage (bool): End each stage with an extra norm layer in main branch
-        sequential_attn (bool): If true sequential self-attention is performed. Default: False
+        img_size: Input resolution.
+        window_size: Window size. If None, img_size // window_div
+        img_window_ratio: Window size to image size ratio.
+        patch_size: Patch size.
+        in_chans: Number of input channels.
+        depths: Depth of the stage (number of layers).
+        num_heads: Number of attention heads to be utilized.
+        embed_dim: Patch embedding dimension.
+        num_classes: Number of output classes.
+        mlp_ratio:  Ratio of the hidden dimension in the FFN to the input channels.
+        drop_rate: Dropout rate.
+        proj_drop_rate: Projection dropout rate.
+        attn_drop_rate: Dropout rate of attention map.
+        drop_path_rate: Stochastic depth rate.
+        norm_layer: Type of normalization layer to be utilized.
+        extra_norm_period: Insert extra norm layer on main branch every N (period) blocks in stage
+        extra_norm_stage: End each stage with an extra norm layer in main branch
+        sequential_attn: If true sequential self-attention is performed.
     """
 
     def __init__(
@@ -579,6 +580,7 @@ class SwinTransformerV2Cr(nn.Module):
         mlp_ratio: float = 4.0,
         init_values: Optional[float] = 0.,
         drop_rate: float = 0.0,
+        proj_drop_rate: float = 0.0,
         attn_drop_rate: float = 0.0,
         drop_path_rate: float = 0.0,
         norm_layer: Type[nn.Module] = nn.LayerNorm,
@@ -627,7 +629,7 @@ class SwinTransformerV2Cr(nn.Module):
                 window_size=window_size,
                 mlp_ratio=mlp_ratio,
                 init_values=init_values,
-                drop=drop_rate,
+                proj_drop=proj_drop_rate,
                 drop_attn=attn_drop_rate,
                 drop_path=dpr[stage_idx],
                 extra_norm_period=extra_norm_period,

--- a/timm/models/visformer.py
+++ b/timm/models/visformer.py
@@ -40,8 +40,15 @@ default_cfgs = dict(
 
 class SpatialMlp(nn.Module):
     def __init__(
-            self, in_features, hidden_features=None, out_features=None,
-            act_layer=nn.GELU, drop=0., group=8, spatial_conv=False):
+            self,
+            in_features,
+            hidden_features=None,
+            out_features=None,
+            act_layer=nn.GELU,
+            drop=0.,
+            group=8,
+            spatial_conv=False,
+    ):
         super().__init__()
         out_features = out_features or in_features
         hidden_features = hidden_features or in_features
@@ -83,6 +90,8 @@ class SpatialMlp(nn.Module):
 
 
 class Attention(nn.Module):
+    fast_attn: torch.jit.Final[bool]
+
     def __init__(self, dim, num_heads=8, head_dim_ratio=1., attn_drop=0., proj_drop=0.):
         super().__init__()
         self.dim = dim
@@ -90,6 +99,8 @@ class Attention(nn.Module):
         head_dim = round(dim // num_heads * head_dim_ratio)
         self.head_dim = head_dim
         self.scale = head_dim ** -0.5
+        self.fast_attn = hasattr(torch.nn.functional, 'scaled_dot_product_attention')  # FIXME
+
         self.qkv = nn.Conv2d(dim, head_dim * num_heads * 3, 1, stride=1, padding=0, bias=False)
         self.attn_drop = nn.Dropout(attn_drop)
         self.proj = nn.Conv2d(self.head_dim * self.num_heads, dim, 1, stride=1, padding=0, bias=False)
@@ -100,10 +111,16 @@ class Attention(nn.Module):
         x = self.qkv(x).reshape(B, 3, self.num_heads, self.head_dim, -1).permute(1, 0, 2, 4, 3)
         q, k, v = x.unbind(0)
 
-        attn = (q @ k.transpose(-2, -1)) * self.scale
-        attn = attn.softmax(dim=-1)
-        attn = self.attn_drop(attn)
-        x = attn @ v
+        if self.fast_attn:
+            x = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v,
+                dropout_p=self.attn_drop.p,
+            )
+        else:
+            attn = (q @ k.transpose(-2, -1)) * self.scale
+            attn = attn.softmax(dim=-1)
+            attn = self.attn_drop(attn)
+            x = attn @ v
 
         x = x.permute(0, 1, 3, 2).reshape(B, -1, H, W)
         x = self.proj(x)
@@ -113,9 +130,20 @@ class Attention(nn.Module):
 
 class Block(nn.Module):
     def __init__(
-            self, dim, num_heads, head_dim_ratio=1., mlp_ratio=4.,
-            drop=0., attn_drop=0., drop_path=0., act_layer=nn.GELU, norm_layer=LayerNorm2d,
-            group=8, attn_disabled=False, spatial_conv=False):
+            self,
+            dim,
+            num_heads,
+            head_dim_ratio=1.,
+            mlp_ratio=4.,
+            proj_drop=0.,
+            attn_drop=0.,
+            drop_path=0.,
+            act_layer=nn.GELU,
+            norm_layer=LayerNorm2d,
+            group=8,
+            attn_disabled=False,
+            spatial_conv=False,
+    ):
         super().__init__()
         self.spatial_conv = spatial_conv
         self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
@@ -125,12 +153,22 @@ class Block(nn.Module):
         else:
             self.norm1 = norm_layer(dim)
             self.attn = Attention(
-                dim, num_heads=num_heads, head_dim_ratio=head_dim_ratio, attn_drop=attn_drop, proj_drop=drop)
+                dim,
+                num_heads=num_heads,
+                head_dim_ratio=head_dim_ratio,
+                attn_drop=attn_drop,
+                proj_drop=proj_drop,
+            )
 
         self.norm2 = norm_layer(dim)
         self.mlp = SpatialMlp(
-            in_features=dim, hidden_features=int(dim * mlp_ratio), act_layer=act_layer, drop=drop,
-            group=group, spatial_conv=spatial_conv)  # new setting
+            in_features=dim,
+            hidden_features=int(dim * mlp_ratio),
+            act_layer=act_layer,
+            drop=proj_drop,
+            group=group,
+            spatial_conv=spatial_conv,
+        )
 
     def forward(self, x):
         if self.attn is not None:
@@ -141,10 +179,31 @@ class Block(nn.Module):
 
 class Visformer(nn.Module):
     def __init__(
-            self, img_size=224, patch_size=16, in_chans=3, num_classes=1000, init_channels=32, embed_dim=384,
-            depth=12, num_heads=6, mlp_ratio=4., drop_rate=0., attn_drop_rate=0., drop_path_rate=0.,
-            norm_layer=LayerNorm2d, attn_stage='111', pos_embed=True, spatial_conv='111',
-            vit_stem=False, group=8, global_pool='avg', conv_init=False, embed_norm=None):
+            self,
+            img_size=224,
+            patch_size=16,
+            in_chans=3,
+            num_classes=1000,
+            init_channels=32,
+            embed_dim=384,
+            depth=12,
+            num_heads=6,
+            mlp_ratio=4.,
+            drop_rate=0.,
+            pos_drop_rate=0.,
+            proj_drop_rate=0.,
+            attn_drop_rate=0.,
+            drop_path_rate=0.,
+            norm_layer=LayerNorm2d,
+            attn_stage='111',
+            use_pos_embed=True,
+            spatial_conv='111',
+            vit_stem=False,
+            group=8,
+            global_pool='avg',
+            conv_init=False,
+            embed_norm=None,
+    ):
         super().__init__()
         img_size = to_2tuple(img_size)
         self.num_classes = num_classes
@@ -159,7 +218,7 @@ class Visformer(nn.Module):
         else:
             self.stage_num1 = self.stage_num3 = depth // 3
             self.stage_num2 = depth - self.stage_num1 - self.stage_num3
-        self.pos_embed = pos_embed
+        self.use_pos_embed = use_pos_embed
         self.grad_checkpointing = False
 
         dpr = [x.item() for x in torch.linspace(0, drop_path_rate, depth)]
@@ -167,15 +226,25 @@ class Visformer(nn.Module):
         if self.vit_stem:
             self.stem = None
             self.patch_embed1 = PatchEmbed(
-                img_size=img_size, patch_size=patch_size, in_chans=in_chans,
-                embed_dim=embed_dim, norm_layer=embed_norm, flatten=False)
+                img_size=img_size,
+                patch_size=patch_size,
+                in_chans=in_chans,
+                embed_dim=embed_dim,
+                norm_layer=embed_norm,
+                flatten=False,
+            )
             img_size = [x // patch_size for x in img_size]
         else:
             if self.init_channels is None:
                 self.stem = None
                 self.patch_embed1 = PatchEmbed(
-                    img_size=img_size, patch_size=patch_size // 2, in_chans=in_chans,
-                    embed_dim=embed_dim // 2, norm_layer=embed_norm, flatten=False)
+                    img_size=img_size,
+                    patch_size=patch_size // 2,
+                    in_chans=in_chans,
+                    embed_dim=embed_dim // 2,
+                    norm_layer=embed_norm,
+                    flatten=False,
+                )
                 img_size = [x // (patch_size // 2) for x in img_size]
             else:
                 self.stem = nn.Sequential(
@@ -185,21 +254,37 @@ class Visformer(nn.Module):
                 )
                 img_size = [x // 2 for x in img_size]
                 self.patch_embed1 = PatchEmbed(
-                    img_size=img_size, patch_size=patch_size // 4, in_chans=self.init_channels,
-                    embed_dim=embed_dim // 2, norm_layer=embed_norm, flatten=False)
+                    img_size=img_size,
+                    patch_size=patch_size // 4,
+                    in_chans=self.init_channels,
+                    embed_dim=embed_dim // 2,
+                    norm_layer=embed_norm,
+                    flatten=False,
+                )
                 img_size = [x // (patch_size // 4) for x in img_size]
 
-        if self.pos_embed:
+        if self.use_pos_embed:
             if self.vit_stem:
                 self.pos_embed1 = nn.Parameter(torch.zeros(1, embed_dim, *img_size))
             else:
                 self.pos_embed1 = nn.Parameter(torch.zeros(1, embed_dim//2, *img_size))
-            self.pos_drop = nn.Dropout(p=drop_rate)
+            self.pos_drop = nn.Dropout(p=pos_drop_rate)
+        else:
+            self.pos_embed1 = None
+
         self.stage1 = nn.Sequential(*[
             Block(
-                dim=embed_dim//2, num_heads=num_heads, head_dim_ratio=0.5, mlp_ratio=mlp_ratio,
-                drop=drop_rate, attn_drop=attn_drop_rate, drop_path=dpr[i], norm_layer=norm_layer,
-                group=group, attn_disabled=(attn_stage[0] == '0'), spatial_conv=(spatial_conv[0] == '1')
+                dim=embed_dim//2,
+                num_heads=num_heads,
+                head_dim_ratio=0.5,
+                mlp_ratio=mlp_ratio,
+                proj_drop=proj_drop_rate,
+                attn_drop=attn_drop_rate,
+                drop_path=dpr[i],
+                norm_layer=norm_layer,
+                group=group,
+                attn_disabled=(attn_stage[0] == '0'),
+                spatial_conv=(spatial_conv[0] == '1'),
             )
             for i in range(self.stage_num1)
         ])
@@ -207,16 +292,33 @@ class Visformer(nn.Module):
         # stage2
         if not self.vit_stem:
             self.patch_embed2 = PatchEmbed(
-                img_size=img_size, patch_size=patch_size // 8, in_chans=embed_dim // 2,
-                embed_dim=embed_dim, norm_layer=embed_norm, flatten=False)
+                img_size=img_size,
+                patch_size=patch_size // 8,
+                in_chans=embed_dim // 2,
+                embed_dim=embed_dim,
+                norm_layer=embed_norm,
+                flatten=False,
+            )
             img_size = [x // (patch_size // 8) for x in img_size]
-            if self.pos_embed:
+            if self.use_pos_embed:
                 self.pos_embed2 = nn.Parameter(torch.zeros(1, embed_dim, *img_size))
+            else:
+                self.pos_embed2 = None
+        else:
+            self.patch_embed2 = None
         self.stage2 = nn.Sequential(*[
             Block(
-                dim=embed_dim, num_heads=num_heads, head_dim_ratio=1.0, mlp_ratio=mlp_ratio,
-                drop=drop_rate, attn_drop=attn_drop_rate, drop_path=dpr[i], norm_layer=norm_layer,
-                group=group, attn_disabled=(attn_stage[1] == '0'), spatial_conv=(spatial_conv[1] == '1')
+                dim=embed_dim,
+                num_heads=num_heads,
+                head_dim_ratio=1.0,
+                mlp_ratio=mlp_ratio,
+                proj_drop=proj_drop_rate,
+                attn_drop=attn_drop_rate,
+                drop_path=dpr[i],
+                norm_layer=norm_layer,
+                group=group,
+                attn_disabled=(attn_stage[1] == '0'),
+                spatial_conv=(spatial_conv[1] == '1'),
             )
             for i in range(self.stage_num1, self.stage_num1+self.stage_num2)
         ])
@@ -224,27 +326,48 @@ class Visformer(nn.Module):
         # stage 3
         if not self.vit_stem:
             self.patch_embed3 = PatchEmbed(
-                img_size=img_size, patch_size=patch_size // 8, in_chans=embed_dim,
-                embed_dim=embed_dim * 2, norm_layer=embed_norm, flatten=False)
+                img_size=img_size,
+                patch_size=patch_size // 8,
+                in_chans=embed_dim,
+                embed_dim=embed_dim * 2,
+                norm_layer=embed_norm,
+                flatten=False,
+            )
             img_size = [x // (patch_size // 8) for x in img_size]
-            if self.pos_embed:
+            if self.use_pos_embed:
                 self.pos_embed3 = nn.Parameter(torch.zeros(1, embed_dim*2, *img_size))
+            else:
+                self.pos_embed3 = None
+        else:
+            self.patch_embed3 = None
         self.stage3 = nn.Sequential(*[
             Block(
-                dim=embed_dim*2, num_heads=num_heads, head_dim_ratio=1.0, mlp_ratio=mlp_ratio,
-                drop=drop_rate, attn_drop=attn_drop_rate, drop_path=dpr[i], norm_layer=norm_layer,
-                group=group, attn_disabled=(attn_stage[2] == '0'), spatial_conv=(spatial_conv[2] == '1')
+                dim=embed_dim * 2,
+                num_heads=num_heads,
+                head_dim_ratio=1.0,
+                mlp_ratio=mlp_ratio,
+                proj_drop=proj_drop_rate,
+                attn_drop=attn_drop_rate,
+                drop_path=dpr[i],
+                norm_layer=norm_layer,
+                group=group,
+                attn_disabled=(attn_stage[2] == '0'),
+                spatial_conv=(spatial_conv[2] == '1'),
             )
             for i in range(self.stage_num1+self.stage_num2, depth)
         ])
 
-        # head
         self.num_features = embed_dim if self.vit_stem else embed_dim * 2
         self.norm = norm_layer(self.num_features)
-        self.global_pool, self.head = create_classifier(self.num_features, self.num_classes, pool_type=global_pool)
+
+        # head
+        global_pool, head = create_classifier(self.num_features, self.num_classes, pool_type=global_pool)
+        self.global_pool = global_pool
+        self.head_drop = nn.Dropout(drop_rate)
+        self.head = head
 
         # weights init
-        if self.pos_embed:
+        if self.use_pos_embed:
             trunc_normal_(self.pos_embed1, std=0.02)
             if not self.vit_stem:
                 trunc_normal_(self.pos_embed2, std=0.02)
@@ -293,7 +416,7 @@ class Visformer(nn.Module):
 
         # stage 1
         x = self.patch_embed1(x)
-        if self.pos_embed:
+        if self.pos_embed1 is not None:
             x = self.pos_drop(x + self.pos_embed1)
         if self.grad_checkpointing and not torch.jit.is_scripting():
             x = checkpoint_seq(self.stage1, x)
@@ -301,9 +424,9 @@ class Visformer(nn.Module):
             x = self.stage1(x)
 
         # stage 2
-        if not self.vit_stem:
+        if self.patch_embed2 is not None:
             x = self.patch_embed2(x)
-            if self.pos_embed:
+            if self.pos_embed2 is not None:
                 x = self.pos_drop(x + self.pos_embed2)
         if self.grad_checkpointing and not torch.jit.is_scripting():
             x = checkpoint_seq(self.stage2, x)
@@ -311,9 +434,9 @@ class Visformer(nn.Module):
             x = self.stage2(x)
 
         # stage3
-        if not self.vit_stem:
+        if self.patch_embed3 is not None:
             x = self.patch_embed3(x)
-            if self.pos_embed:
+            if self.pos_embed3 is not None:
                 x = self.pos_drop(x + self.pos_embed3)
         if self.grad_checkpointing and not torch.jit.is_scripting():
             x = checkpoint_seq(self.stage3, x)
@@ -325,6 +448,7 @@ class Visformer(nn.Module):
 
     def forward_head(self, x, pre_logits: bool = False):
         x = self.global_pool(x)
+        x = self.head_drop(x)
         return x if pre_logits else self.head(x)
 
     def forward(self, x):
@@ -345,8 +469,8 @@ def visformer_tiny(pretrained=False, **kwargs):
     model_cfg = dict(
         init_channels=16, embed_dim=192, depth=(7, 4, 4), num_heads=3, mlp_ratio=4., group=8,
         attn_stage='011', spatial_conv='100', norm_layer=nn.BatchNorm2d, conv_init=True,
-        embed_norm=nn.BatchNorm2d, **kwargs)
-    model = _create_visformer('visformer_tiny', pretrained=pretrained, **model_cfg)
+        embed_norm=nn.BatchNorm2d)
+    model = _create_visformer('visformer_tiny', pretrained=pretrained, **dict(model_cfg, **kwargs))
     return model
 
 
@@ -355,8 +479,8 @@ def visformer_small(pretrained=False, **kwargs):
     model_cfg = dict(
         init_channels=32, embed_dim=384, depth=(7, 4, 4), num_heads=6, mlp_ratio=4., group=8,
         attn_stage='011', spatial_conv='100', norm_layer=nn.BatchNorm2d, conv_init=True,
-        embed_norm=nn.BatchNorm2d, **kwargs)
-    model = _create_visformer('visformer_small', pretrained=pretrained, **model_cfg)
+        embed_norm=nn.BatchNorm2d)
+    model = _create_visformer('visformer_small', pretrained=pretrained, **dict(model_cfg, **kwargs))
     return model
 
 

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -27,7 +27,7 @@ import logging
 import math
 from collections import OrderedDict
 from functools import partial
-from typing import Optional, List
+from typing import Callable, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -38,7 +38,7 @@ from torch.jit import Final
 from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD, IMAGENET_INCEPTION_MEAN, IMAGENET_INCEPTION_STD, \
     OPENAI_CLIP_MEAN, OPENAI_CLIP_STD
 from timm.layers import PatchEmbed, Mlp, DropPath, trunc_normal_, lecun_normal_, resample_patch_embed, \
-    resample_abs_pos_embed, RmsNorm
+    resample_abs_pos_embed, RmsNorm, PatchDropout
 from ._builder import build_model_with_cfg
 from ._manipulate import named_apply, checkpoint_seq, adapt_input_conv
 from ._registry import generate_default_cfgs, register_model, register_model_deprecations
@@ -119,7 +119,7 @@ class Block(nn.Module):
             mlp_ratio=4.,
             qkv_bias=False,
             qk_norm=False,
-            drop=0.,
+            proj_drop=0.,
             attn_drop=0.,
             init_values=None,
             drop_path=0.,
@@ -134,7 +134,7 @@ class Block(nn.Module):
             qkv_bias=qkv_bias,
             qk_norm=qk_norm,
             attn_drop=attn_drop,
-            proj_drop=drop,
+            proj_drop=proj_drop,
             norm_layer=norm_layer,
         )
         self.ls1 = LayerScale(dim, init_values=init_values) if init_values else nn.Identity()
@@ -145,7 +145,7 @@ class Block(nn.Module):
             in_features=dim,
             hidden_features=int(dim * mlp_ratio),
             act_layer=act_layer,
-            drop=drop,
+            drop=proj_drop,
         )
         self.ls2 = LayerScale(dim, init_values=init_values) if init_values else nn.Identity()
         self.drop_path2 = DropPath(drop_path) if drop_path > 0. else nn.Identity()
@@ -165,7 +165,7 @@ class ResPostBlock(nn.Module):
             mlp_ratio=4.,
             qkv_bias=False,
             qk_norm=False,
-            drop=0.,
+            proj_drop=0.,
             attn_drop=0.,
             init_values=None,
             drop_path=0.,
@@ -181,7 +181,7 @@ class ResPostBlock(nn.Module):
             qkv_bias=qkv_bias,
             qk_norm=qk_norm,
             attn_drop=attn_drop,
-            proj_drop=drop,
+            proj_drop=proj_drop,
             norm_layer=norm_layer,
         )
         self.norm1 = norm_layer(dim)
@@ -191,7 +191,7 @@ class ResPostBlock(nn.Module):
             in_features=dim,
             hidden_features=int(dim * mlp_ratio),
             act_layer=act_layer,
-            drop=drop,
+            drop=proj_drop,
         )
         self.norm2 = norm_layer(dim)
         self.drop_path2 = DropPath(drop_path) if drop_path > 0. else nn.Identity()
@@ -224,7 +224,7 @@ class ParallelScalingBlock(nn.Module):
             mlp_ratio=4.,
             qkv_bias=False,
             qk_norm=False,
-            drop=0.,
+            proj_drop=0.,
             attn_drop=0.,
             init_values=None,
             drop_path=0.,
@@ -255,7 +255,7 @@ class ParallelScalingBlock(nn.Module):
         self.attn_drop = nn.Dropout(attn_drop)
         self.attn_out_proj = nn.Linear(dim, dim)
 
-        self.mlp_drop = nn.Dropout(drop)
+        self.mlp_drop = nn.Dropout(proj_drop)
         self.mlp_act = act_layer()
         self.mlp_out_proj = nn.Linear(mlp_hidden_dim, dim)
 
@@ -318,7 +318,7 @@ class ParallelThingsBlock(nn.Module):
             qkv_bias=False,
             qk_norm=False,
             init_values=None,
-            drop=0.,
+            proj_drop=0.,
             attn_drop=0.,
             drop_path=0.,
             act_layer=nn.GELU,
@@ -337,7 +337,7 @@ class ParallelThingsBlock(nn.Module):
                     qkv_bias=qkv_bias,
                     qk_norm=qk_norm,
                     attn_drop=attn_drop,
-                    proj_drop=drop,
+                    proj_drop=proj_drop,
                     norm_layer=norm_layer,
                 )),
                 ('ls', LayerScale(dim, init_values=init_values) if init_values else nn.Identity()),
@@ -349,7 +349,7 @@ class ParallelThingsBlock(nn.Module):
                     dim,
                     hidden_features=int(dim * mlp_ratio),
                     act_layer=act_layer,
-                    drop=drop,
+                    drop=proj_drop,
                 )),
                 ('ls', LayerScale(dim, init_values=init_values) if init_values else nn.Identity()),
                 ('drop_path', DropPath(drop_path) if drop_path > 0. else nn.Identity())
@@ -382,53 +382,58 @@ class VisionTransformer(nn.Module):
 
     def __init__(
             self,
-            img_size=224,
-            patch_size=16,
-            in_chans=3,
-            num_classes=1000,
-            global_pool='token',
-            embed_dim=768,
-            depth=12,
-            num_heads=12,
-            mlp_ratio=4.,
-            qkv_bias=True,
-            qk_norm=False,
-            init_values=None,
-            class_token=True,
-            no_embed_class=False,
-            pre_norm=False,
-            fc_norm=None,
-            drop_rate=0.,
-            attn_drop_rate=0.,
-            drop_path_rate=0.,
-            weight_init='',
-            embed_layer=PatchEmbed,
-            norm_layer=None,
-            act_layer=None,
-            block_fn=Block,
+            img_size: Union[int, Tuple[int, int]] = 224,
+            patch_size: Union[int, Tuple[int, int]] = 16,
+            in_chans: int = 3,
+            num_classes: int = 1000,
+            global_pool: str = 'token',
+            embed_dim: int = 768,
+            depth: int = 12,
+            num_heads: int = 12,
+            mlp_ratio: float = 4.,
+            qkv_bias: bool = True,
+            qk_norm: bool = False,
+            init_values: Optional[float] = None,
+            class_token: bool = True,
+            no_embed_class: bool = False,
+            pre_norm: bool = False,
+            fc_norm: Optional[bool] = None,
+            drop_rate: float = 0.,
+            pos_drop_rate: float = 0.,
+            patch_drop_rate: float = 0.,
+            proj_drop_rate: float = 0.,
+            attn_drop_rate: float = 0.,
+            drop_path_rate: float = 0.,
+            weight_init: str = '',
+            embed_layer: Callable = PatchEmbed,
+            norm_layer: Optional[Callable] = None,
+            act_layer: Optional[Callable] = None,
+            block_fn: Callable = Block,
     ):
         """
         Args:
-            img_size (int, tuple): input image size
-            patch_size (int, tuple): patch size
-            in_chans (int): number of input channels
-            num_classes (int): number of classes for classification head
-            global_pool (str): type of global pooling for final sequence (default: 'token')
-            embed_dim (int): embedding dimension
-            depth (int): depth of transformer
-            num_heads (int): number of attention heads
-            mlp_ratio (int): ratio of mlp hidden dim to embedding dim
-            qkv_bias (bool): enable bias for qkv if True
-            init_values: (float): layer-scale init values
-            class_token (bool): use class token
-            fc_norm (Optional[bool]): pre-fc norm after pool, set if global_pool == 'avg' if None (default: None)
-            drop_rate (float): dropout rate
-            attn_drop_rate (float): attention dropout rate
-            drop_path_rate (float): stochastic depth rate
-            weight_init (str): weight init scheme
-            embed_layer (nn.Module): patch embedding layer
-            norm_layer: (nn.Module): normalization layer
-            act_layer: (nn.Module): MLP activation layer
+            img_size: Input image size.
+            patch_size: Patch size.
+            in_chans: Number of image input channels.
+            num_classes: Mumber of classes for classification head.
+            global_pool: Type of global pooling for final sequence (default: 'token').
+            embed_dim: Transformer embedding dimension.
+            depth: Depth of transformer.
+            num_heads: Number of attention heads.
+            mlp_ratio: Ratio of mlp hidden dim to embedding dim.
+            qkv_bias: Enable bias for qkv projections if True.
+            init_values: Layer-scale init values (layer-scale enabled if not None).
+            class_token: Use class token.
+            fc_norm: Pre head norm after pool (instead of before), if None, enabled when global_pool == 'avg'.
+            drop_rate: Head dropout rate.
+            pos_drop_rate: Position embedding dropout rate.
+            attn_drop_rate: Attention dropout rate.
+            drop_path_rate: Stochastic depth rate.
+            weight_init: Weight initialization scheme.
+            embed_layer: Patch embedding layey.
+            norm_layer: Normalization layer.
+            act_layer: MLP activation layer.
+            block_fn: Transformer block layer.
         """
         super().__init__()
         assert global_pool in ('', 'avg', 'token')
@@ -456,7 +461,14 @@ class VisionTransformer(nn.Module):
         self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim)) if class_token else None
         embed_len = num_patches if no_embed_class else num_patches + self.num_prefix_tokens
         self.pos_embed = nn.Parameter(torch.randn(1, embed_len, embed_dim) * .02)
-        self.pos_drop = nn.Dropout(p=drop_rate)
+        self.pos_drop = nn.Dropout(p=pos_drop_rate)
+        if patch_drop_rate > 0:
+            self.patch_drop = PatchDropout(
+                patch_drop_rate,
+                num_prefix_tokens=self.num_prefix_tokens,
+            )
+        else:
+            self.patch_drop = nn.Identity()
         self.norm_pre = norm_layer(embed_dim) if pre_norm else nn.Identity()
 
         dpr = [x.item() for x in torch.linspace(0, drop_path_rate, depth)]  # stochastic depth decay rule
@@ -468,7 +480,7 @@ class VisionTransformer(nn.Module):
                 qkv_bias=qkv_bias,
                 qk_norm=qk_norm,
                 init_values=init_values,
-                drop=drop_rate,
+                proj_drop=proj_drop_rate,
                 attn_drop=attn_drop_rate,
                 drop_path=dpr[i],
                 norm_layer=norm_layer,
@@ -479,6 +491,7 @@ class VisionTransformer(nn.Module):
 
         # Classifier Head
         self.fc_norm = norm_layer(embed_dim) if use_fc_norm else nn.Identity()
+        self.head_drop = nn.Dropout(drop_rate)
         self.head = nn.Linear(self.embed_dim, num_classes) if num_classes > 0 else nn.Identity()
 
         if weight_init != 'skip':
@@ -544,6 +557,7 @@ class VisionTransformer(nn.Module):
     def forward_features(self, x):
         x = self.patch_embed(x)
         x = self._pos_embed(x)
+        x = self.patch_drop(x)
         x = self.norm_pre(x)
         if self.grad_checkpointing and not torch.jit.is_scripting():
             x = checkpoint_seq(self.blocks, x)
@@ -556,6 +570,7 @@ class VisionTransformer(nn.Module):
         if self.global_pool:
             x = x[:, self.num_prefix_tokens:].mean(dim=1) if self.global_pool == 'avg' else x[:, 0]
         x = self.fc_norm(x)
+        x = self.head_drop(x)
         return x if pre_logits else self.head(x)
 
     def forward(self, x):

--- a/timm/models/vision_transformer_relpos.py
+++ b/timm/models/vision_transformer_relpos.py
@@ -43,7 +43,7 @@ class RelPosAttention(nn.Module):
         self.num_heads = num_heads
         self.head_dim = dim // num_heads
         self.scale = self.head_dim ** -0.5
-        self.fused_attn = hasattr(torch.nn.functional, 'scaled_dot_product_attention')  # FIXME
+        self.fused_attn = use_fused_attn()
 
         self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
         self.q_norm = norm_layer(self.head_dim) if qk_norm else nn.Identity()

--- a/timm/models/volo.py
+++ b/timm/models/volo.py
@@ -85,7 +85,17 @@ default_cfgs = {
 
 class OutlookAttention(nn.Module):
 
-    def __init__(self, dim, num_heads, kernel_size=3, padding=1, stride=1, qkv_bias=False, attn_drop=0., proj_drop=0.):
+    def __init__(
+            self,
+            dim,
+            num_heads,
+            kernel_size=3,
+            padding=1,
+            stride=1,
+            qkv_bias=False,
+            attn_drop=0.,
+            proj_drop=0.,
+    ):
         super().__init__()
         head_dim = dim // num_heads
         self.num_heads = num_heads
@@ -133,21 +143,40 @@ class OutlookAttention(nn.Module):
 
 class Outlooker(nn.Module):
     def __init__(
-            self, dim, kernel_size, padding, stride=1, num_heads=1, mlp_ratio=3., attn_drop=0.,
-            drop_path=0., act_layer=nn.GELU, norm_layer=nn.LayerNorm, qkv_bias=False
+            self,
+            dim,
+            kernel_size,
+            padding,
+            stride=1,
+            num_heads=1,
+            mlp_ratio=3.,
+            attn_drop=0.,
+            drop_path=0.,
+            act_layer=nn.GELU,
+            norm_layer=nn.LayerNorm,
+            qkv_bias=False,
     ):
         super().__init__()
         self.norm1 = norm_layer(dim)
         self.attn = OutlookAttention(
-            dim, num_heads, kernel_size=kernel_size,
-            padding=padding, stride=stride,
-            qkv_bias=qkv_bias, attn_drop=attn_drop)
+            dim,
+            num_heads,
+            kernel_size=kernel_size,
+            padding=padding,
+            stride=stride,
+            qkv_bias=qkv_bias,
+            attn_drop=attn_drop,
+        )
 
         self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
 
         self.norm2 = norm_layer(dim)
         mlp_hidden_dim = int(dim * mlp_ratio)
-        self.mlp = Mlp(in_features=dim, hidden_features=mlp_hidden_dim, act_layer=act_layer)
+        self.mlp = Mlp(
+            in_features=dim,
+            hidden_features=mlp_hidden_dim,
+            act_layer=act_layer,
+        )
 
     def forward(self, x):
         x = x + self.drop_path(self.attn(self.norm1(x)))
@@ -158,7 +187,13 @@ class Outlooker(nn.Module):
 class Attention(nn.Module):
 
     def __init__(
-            self, dim, num_heads=8, qkv_bias=False, attn_drop=0., proj_drop=0.):
+            self,
+            dim,
+            num_heads=8,
+            qkv_bias=False,
+            attn_drop=0.,
+            proj_drop=0.,
+    ):
         super().__init__()
         self.num_heads = num_heads
         head_dim = dim // num_heads
@@ -189,8 +224,16 @@ class Attention(nn.Module):
 class Transformer(nn.Module):
 
     def __init__(
-            self, dim, num_heads, mlp_ratio=4., qkv_bias=False,
-            attn_drop=0., drop_path=0., act_layer=nn.GELU, norm_layer=nn.LayerNorm):
+            self,
+            dim,
+            num_heads,
+            mlp_ratio=4.,
+            qkv_bias=False,
+            attn_drop=0.,
+            drop_path=0.,
+            act_layer=nn.GELU,
+            norm_layer=nn.LayerNorm,
+    ):
         super().__init__()
         self.norm1 = norm_layer(dim)
         self.attn = Attention(dim, num_heads=num_heads, qkv_bias=qkv_bias, attn_drop=attn_drop)
@@ -211,7 +254,14 @@ class Transformer(nn.Module):
 class ClassAttention(nn.Module):
 
     def __init__(
-            self, dim, num_heads=8, head_dim=None, qkv_bias=False, attn_drop=0., proj_drop=0.):
+            self,
+            dim,
+            num_heads=8,
+            head_dim=None,
+            qkv_bias=False,
+            attn_drop=0.,
+            proj_drop=0.,
+    ):
         super().__init__()
         self.num_heads = num_heads
         if head_dim is not None:
@@ -246,17 +296,38 @@ class ClassAttention(nn.Module):
 class ClassBlock(nn.Module):
 
     def __init__(
-            self, dim, num_heads, head_dim=None, mlp_ratio=4., qkv_bias=False,
-            drop=0., attn_drop=0., drop_path=0., act_layer=nn.GELU, norm_layer=nn.LayerNorm):
+            self,
+            dim,
+            num_heads,
+            head_dim=None,
+            mlp_ratio=4.,
+            qkv_bias=False,
+            drop=0.,
+            attn_drop=0.,
+            drop_path=0.,
+            act_layer=nn.GELU,
+            norm_layer=nn.LayerNorm,
+    ):
         super().__init__()
         self.norm1 = norm_layer(dim)
         self.attn = ClassAttention(
-            dim, num_heads=num_heads, head_dim=head_dim, qkv_bias=qkv_bias, attn_drop=attn_drop, proj_drop=drop)
+            dim,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            qkv_bias=qkv_bias,
+            attn_drop=attn_drop,
+            proj_drop=drop,
+        )
         # NOTE: drop path for stochastic depth
         self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
         self.norm2 = norm_layer(dim)
         mlp_hidden_dim = int(dim * mlp_ratio)
-        self.mlp = Mlp(in_features=dim, hidden_features=mlp_hidden_dim, act_layer=act_layer, drop=drop)
+        self.mlp = Mlp(
+            in_features=dim,
+            hidden_features=mlp_hidden_dim,
+            act_layer=act_layer,
+            drop=drop,
+        )
 
     def forward(self, x):
         cls_embed = x[:, :1]
@@ -354,18 +425,33 @@ def outlooker_blocks(
     blocks = []
     for block_idx in range(layers[index]):
         block_dpr = drop_path_rate * (block_idx + sum(layers[:index])) / (sum(layers) - 1)
-        blocks.append(
-            block_fn(
-                dim, kernel_size=kernel_size, padding=padding,
-                stride=stride, num_heads=num_heads, mlp_ratio=mlp_ratio,
-                qkv_bias=qkv_bias, attn_drop=attn_drop, drop_path=block_dpr))
+        blocks.append(block_fn(
+            dim,
+            kernel_size=kernel_size,
+            padding=padding,
+            stride=stride,
+            num_heads=num_heads,
+            mlp_ratio=mlp_ratio,
+            qkv_bias=qkv_bias,
+            attn_drop=attn_drop,
+            drop_path=block_dpr,
+        ))
     blocks = nn.Sequential(*blocks)
     return blocks
 
 
 def transformer_blocks(
-        block_fn, index, dim, layers, num_heads, mlp_ratio=3.,
-        qkv_bias=False, attn_drop=0, drop_path_rate=0., **kwargs):
+        block_fn,
+        index,
+        dim,
+        layers,
+        num_heads,
+        mlp_ratio=3.,
+        qkv_bias=False,
+        attn_drop=0,
+        drop_path_rate=0.,
+        **kwargs,
+):
     """
     generate transformer layers in stage2
     return: transformer layers
@@ -373,13 +459,14 @@ def transformer_blocks(
     blocks = []
     for block_idx in range(layers[index]):
         block_dpr = drop_path_rate * (block_idx + sum(layers[:index])) / (sum(layers) - 1)
-        blocks.append(
-            block_fn(
-                dim, num_heads,
-                mlp_ratio=mlp_ratio,
-                qkv_bias=qkv_bias,
-                attn_drop=attn_drop,
-                drop_path=block_dpr))
+        blocks.append(block_fn(
+            dim,
+            num_heads,
+            mlp_ratio=mlp_ratio,
+            qkv_bias=qkv_bias,
+            attn_drop=attn_drop,
+            drop_path=block_dpr,
+        ))
     blocks = nn.Sequential(*blocks)
     return blocks
 
@@ -405,6 +492,7 @@ class VOLO(nn.Module):
             mlp_ratio=3.0,
             qkv_bias=False,
             drop_rate=0.,
+            pos_drop_rate=0.,
             attn_drop_rate=0.,
             drop_path_rate=0.,
             norm_layer=nn.LayerNorm,
@@ -429,14 +517,18 @@ class VOLO(nn.Module):
         self.grad_checkpointing = False
 
         self.patch_embed = PatchEmbed(
-            stem_conv=True, stem_stride=2, patch_size=patch_size,
-            in_chans=in_chans, hidden_dim=stem_hidden_dim,
-            embed_dim=embed_dims[0])
+            stem_conv=True,
+            stem_stride=2,
+            patch_size=patch_size,
+            in_chans=in_chans,
+            hidden_dim=stem_hidden_dim,
+            embed_dim=embed_dims[0],
+        )
 
         # inital positional encoding, we add positional encoding after outlooker blocks
         patch_grid = (img_size[0] // patch_size // pooling_scale, img_size[1] // patch_size // pooling_scale)
         self.pos_embed = nn.Parameter(torch.zeros(1, patch_grid[0], patch_grid[1], embed_dims[-1]))
-        self.pos_drop = nn.Dropout(p=drop_rate)
+        self.pos_drop = nn.Dropout(p=pos_drop_rate)
 
         # set the main block in network
         network = []
@@ -444,14 +536,31 @@ class VOLO(nn.Module):
             if outlook_attention[i]:
                 # stage 1
                 stage = outlooker_blocks(
-                    Outlooker, i, embed_dims[i], layers, num_heads[i], mlp_ratio=mlp_ratio[i],
-                    qkv_bias=qkv_bias, attn_drop=attn_drop_rate, norm_layer=norm_layer)
+                    Outlooker,
+                    i,
+                    embed_dims[i],
+                    layers,
+                    num_heads[i],
+                    mlp_ratio=mlp_ratio[i],
+                    qkv_bias=qkv_bias,
+                    attn_drop=attn_drop_rate,
+                    norm_layer=norm_layer,
+                )
                 network.append(stage)
             else:
                 # stage 2
                 stage = transformer_blocks(
-                    Transformer, i, embed_dims[i], layers, num_heads[i], mlp_ratio=mlp_ratio[i], qkv_bias=qkv_bias,
-                    drop_path_rate=drop_path_rate, attn_drop=attn_drop_rate, norm_layer=norm_layer)
+                    Transformer,
+                    i,
+                    embed_dims[i],
+                    layers,
+                    num_heads[i],
+                    mlp_ratio=mlp_ratio[i],
+                    qkv_bias=qkv_bias,
+                    drop_path_rate=drop_path_rate,
+                    attn_drop=attn_drop_rate,
+                    norm_layer=norm_layer,
+                )
                 network.append(stage)
 
             if downsamples[i]:
@@ -463,19 +572,18 @@ class VOLO(nn.Module):
         # set post block, for example, class attention layers
         self.post_network = None
         if post_layers is not None:
-            self.post_network = nn.ModuleList(
-                [
-                    get_block(
-                        post_layers[i],
-                        dim=embed_dims[-1],
-                        num_heads=num_heads[-1],
-                        mlp_ratio=mlp_ratio[-1],
-                        qkv_bias=qkv_bias,
-                        attn_drop=attn_drop_rate,
-                        drop_path=0.,
-                        norm_layer=norm_layer)
-                    for i in range(len(post_layers))
-                ])
+            self.post_network = nn.ModuleList([
+                get_block(
+                    post_layers[i],
+                    dim=embed_dims[-1],
+                    num_heads=num_heads[-1],
+                    mlp_ratio=mlp_ratio[-1],
+                    qkv_bias=qkv_bias,
+                    attn_drop=attn_drop_rate,
+                    drop_path=0.,
+                    norm_layer=norm_layer)
+                for i in range(len(post_layers))
+            ])
             self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dims[-1]))
             trunc_normal_(self.cls_token, std=.02)
 
@@ -487,6 +595,7 @@ class VOLO(nn.Module):
         self.norm = norm_layer(self.num_features)
 
         # Classifier head
+        self.head_drop = nn.Dropout(drop_rate)
         self.head = nn.Linear(self.num_features, num_classes) if num_classes > 0 else nn.Identity()
 
         trunc_normal_(self.pos_embed, std=.02)
@@ -630,6 +739,7 @@ class VOLO(nn.Module):
             out = x[:, 0]
         else:
             out = x
+        x = self.head_drop(x)
         if pre_logits:
             return out
         out = self.head(out)

--- a/timm/models/xcit.py
+++ b/timm/models/xcit.py
@@ -219,17 +219,28 @@ class ClassAttentionBlock(nn.Module):
     """Class Attention Layer as in CaiT https://arxiv.org/abs/2103.17239"""
 
     def __init__(
-            self, dim, num_heads, mlp_ratio=4., qkv_bias=False, drop=0., attn_drop=0., drop_path=0.,
-            act_layer=nn.GELU, norm_layer=nn.LayerNorm, eta=1., tokens_norm=False):
+            self,
+            dim,
+            num_heads,
+            mlp_ratio=4.,
+            qkv_bias=False,
+            proj_drop=0.,
+            attn_drop=0.,
+            drop_path=0.,
+            act_layer=nn.GELU,
+            norm_layer=nn.LayerNorm,
+            eta=1.,
+            tokens_norm=False,
+    ):
         super().__init__()
         self.norm1 = norm_layer(dim)
 
         self.attn = ClassAttn(
-            dim, num_heads=num_heads, qkv_bias=qkv_bias, attn_drop=attn_drop, proj_drop=drop)
+            dim, num_heads=num_heads, qkv_bias=qkv_bias, attn_drop=attn_drop, proj_drop=proj_drop)
 
         self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
         self.norm2 = norm_layer(dim)
-        self.mlp = Mlp(in_features=dim, hidden_features=int(dim * mlp_ratio), act_layer=act_layer, drop=drop)
+        self.mlp = Mlp(in_features=dim, hidden_features=int(dim * mlp_ratio), act_layer=act_layer, drop=proj_drop)
 
         if eta is not None:  # LayerScale Initialization (no layerscale when None)
             self.gamma1 = nn.Parameter(eta * torch.ones(dim))
@@ -297,18 +308,28 @@ class XCA(nn.Module):
 
 class XCABlock(nn.Module):
     def __init__(
-            self, dim, num_heads, mlp_ratio=4., qkv_bias=False, drop=0., attn_drop=0.,
-            drop_path=0., act_layer=nn.GELU, norm_layer=nn.LayerNorm, eta=1.):
+            self,
+            dim,
+            num_heads,
+            mlp_ratio=4.,
+            qkv_bias=False,
+            proj_drop=0.,
+            attn_drop=0.,
+            drop_path=0.,
+            act_layer=nn.GELU,
+            norm_layer=nn.LayerNorm,
+            eta=1.,
+    ):
         super().__init__()
         self.norm1 = norm_layer(dim)
-        self.attn = XCA(dim, num_heads=num_heads, qkv_bias=qkv_bias, attn_drop=attn_drop, proj_drop=drop)
+        self.attn = XCA(dim, num_heads=num_heads, qkv_bias=qkv_bias, attn_drop=attn_drop, proj_drop=proj_drop)
         self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
 
         self.norm3 = norm_layer(dim)
         self.local_mp = LPI(in_features=dim, act_layer=act_layer)
 
         self.norm2 = norm_layer(dim)
-        self.mlp = Mlp(in_features=dim, hidden_features=int(dim * mlp_ratio), act_layer=act_layer, drop=drop)
+        self.mlp = Mlp(in_features=dim, hidden_features=int(dim * mlp_ratio), act_layer=act_layer, drop=proj_drop)
 
         self.gamma1 = nn.Parameter(eta * torch.ones(dim))
         self.gamma3 = nn.Parameter(eta * torch.ones(dim))
@@ -331,9 +352,29 @@ class XCiT(nn.Module):
     """
 
     def __init__(
-            self, img_size=224, patch_size=16, in_chans=3, num_classes=1000, global_pool='token', embed_dim=768,
-            depth=12, num_heads=12, mlp_ratio=4., qkv_bias=True, drop_rate=0., attn_drop_rate=0., drop_path_rate=0.,
-            act_layer=None, norm_layer=None, cls_attn_layers=2, use_pos_embed=True, eta=1., tokens_norm=False):
+            self,
+            img_size=224,
+            patch_size=16,
+            in_chans=3,
+            num_classes=1000,
+            global_pool='token',
+            embed_dim=768,
+            depth=12,
+            num_heads=12,
+            mlp_ratio=4.,
+            qkv_bias=True,
+            drop_rate=0.,
+            pos_drop_rate=0.,
+            proj_drop_rate=0.,
+            attn_drop_rate=0.,
+            drop_path_rate=0.,
+            act_layer=None,
+            norm_layer=None,
+            cls_attn_layers=2,
+            use_pos_embed=True,
+            eta=1.,
+            tokens_norm=False,
+    ):
         """
         Args:
             img_size (int, tuple): input image size
@@ -346,6 +387,8 @@ class XCiT(nn.Module):
             mlp_ratio (int): ratio of mlp hidden dim to embedding dim
             qkv_bias (bool): enable bias for qkv if True
             drop_rate (float): dropout rate after positional embedding, and in XCA/CA projection + MLP
+            pos_drop_rate: position embedding dropout rate
+            proj_drop_rate (float): projection dropout rate
             attn_drop_rate (float): attention dropout rate
             drop_path_rate (float): stochastic depth rate (constant across all layers)
             norm_layer: (nn.Module): normalization layer
@@ -372,28 +415,53 @@ class XCiT(nn.Module):
         self.grad_checkpointing = False
 
         self.patch_embed = ConvPatchEmbed(
-            img_size=img_size, patch_size=patch_size, in_chans=in_chans, embed_dim=embed_dim, act_layer=act_layer)
+            img_size=img_size,
+            patch_size=patch_size,
+            in_chans=in_chans,
+            embed_dim=embed_dim,
+            act_layer=act_layer,
+        )
 
         self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
-        self.use_pos_embed = use_pos_embed
         if use_pos_embed:
             self.pos_embed = PositionalEncodingFourier(dim=embed_dim)
-        self.pos_drop = nn.Dropout(p=drop_rate)
+        else:
+            self.pos_embed = None
+        self.pos_drop = nn.Dropout(p=pos_drop_rate)
 
         self.blocks = nn.ModuleList([
             XCABlock(
-                dim=embed_dim, num_heads=num_heads, mlp_ratio=mlp_ratio, qkv_bias=qkv_bias, drop=drop_rate,
-                attn_drop=attn_drop_rate, drop_path=drop_path_rate, act_layer=act_layer, norm_layer=norm_layer, eta=eta)
+                dim=embed_dim,
+                num_heads=num_heads,
+                mlp_ratio=mlp_ratio,
+                qkv_bias=qkv_bias,
+                proj_drop=proj_drop_rate,
+                attn_drop=attn_drop_rate,
+                drop_path=drop_path_rate,
+                act_layer=act_layer,
+                norm_layer=norm_layer,
+                eta=eta,
+            )
             for _ in range(depth)])
 
         self.cls_attn_blocks = nn.ModuleList([
             ClassAttentionBlock(
-                dim=embed_dim, num_heads=num_heads, mlp_ratio=mlp_ratio, qkv_bias=qkv_bias, drop=drop_rate,
-                attn_drop=attn_drop_rate, act_layer=act_layer, norm_layer=norm_layer, eta=eta, tokens_norm=tokens_norm)
+                dim=embed_dim,
+                num_heads=num_heads,
+                mlp_ratio=mlp_ratio,
+                qkv_bias=qkv_bias,
+                proj_drop=drop_rate,
+                attn_drop=attn_drop_rate,
+                act_layer=act_layer,
+                norm_layer=norm_layer,
+                eta=eta,
+                tokens_norm=tokens_norm,
+            )
             for _ in range(cls_attn_layers)])
 
         # Classifier head
         self.norm = norm_layer(embed_dim)
+        self.head_drop = nn.Dropout(drop_rate)
         self.head = nn.Linear(self.num_features, num_classes) if num_classes > 0 else nn.Identity()
 
         # Init weights
@@ -438,7 +506,7 @@ class XCiT(nn.Module):
         # x is (B, N, C). (Hp, Hw) is (height in units of patches, width in units of patches)
         x, (Hp, Wp) = self.patch_embed(x)
 
-        if self.use_pos_embed:
+        if self.pos_embed is not None:
             # `pos_embed` (B, C, Hp, Wp), reshape -> (B, C, N), permute -> (B, N, C)
             pos_encoding = self.pos_embed(B, Hp, Wp).reshape(B, -1, x.shape[1]).permute(0, 2, 1)
             x = x + pos_encoding
@@ -464,6 +532,7 @@ class XCiT(nn.Module):
     def forward_head(self, x, pre_logits: bool = False):
         if self.global_pool:
             x = x[:, 1:].mean(dim=1) if self.global_pool == 'avg' else x[:, 0]
+        x = self.head_drop(x)
         return x if pre_logits else self.head(x)
 
     def forward(self, x):
@@ -509,336 +578,336 @@ def _create_xcit(variant, pretrained=False, default_cfg=None, **kwargs):
 
 @register_model
 def xcit_nano_12_p16_224(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=128, depth=12, num_heads=4, eta=1.0, tokens_norm=False, **kwargs)
-    model = _create_xcit('xcit_nano_12_p16_224', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=128, depth=12, num_heads=4, eta=1.0, tokens_norm=False)
+    model = _create_xcit('xcit_nano_12_p16_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_nano_12_p16_224_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=128, depth=12, num_heads=4, eta=1.0, tokens_norm=False, **kwargs)
-    model = _create_xcit('xcit_nano_12_p16_224_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=128, depth=12, num_heads=4, eta=1.0, tokens_norm=False)
+    model = _create_xcit('xcit_nano_12_p16_224_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_nano_12_p16_384_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=128, depth=12, num_heads=4, eta=1.0, tokens_norm=False, img_size=384, **kwargs)
-    model = _create_xcit('xcit_nano_12_p16_384_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=128, depth=12, num_heads=4, eta=1.0, tokens_norm=False, img_size=384)
+    model = _create_xcit('xcit_nano_12_p16_384_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_tiny_12_p16_224(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=192, depth=12, num_heads=4, eta=1.0, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_tiny_12_p16_224', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=192, depth=12, num_heads=4, eta=1.0, tokens_norm=True)
+    model = _create_xcit('xcit_tiny_12_p16_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_tiny_12_p16_224_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=192, depth=12, num_heads=4, eta=1.0, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_tiny_12_p16_224_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=192, depth=12, num_heads=4, eta=1.0, tokens_norm=True)
+    model = _create_xcit('xcit_tiny_12_p16_224_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_tiny_12_p16_384_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=192, depth=12, num_heads=4, eta=1.0, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_tiny_12_p16_384_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=192, depth=12, num_heads=4, eta=1.0, tokens_norm=True)
+    model = _create_xcit('xcit_tiny_12_p16_384_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_small_12_p16_224(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=384, depth=12, num_heads=8, eta=1.0, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_small_12_p16_224', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=384, depth=12, num_heads=8, eta=1.0, tokens_norm=True)
+    model = _create_xcit('xcit_small_12_p16_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_small_12_p16_224_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=384, depth=12, num_heads=8, eta=1.0, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_small_12_p16_224_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=384, depth=12, num_heads=8, eta=1.0, tokens_norm=True)
+    model = _create_xcit('xcit_small_12_p16_224_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_small_12_p16_384_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=384, depth=12, num_heads=8, eta=1.0, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_small_12_p16_384_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=384, depth=12, num_heads=8, eta=1.0, tokens_norm=True)
+    model = _create_xcit('xcit_small_12_p16_384_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_tiny_24_p16_224(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=192, depth=24, num_heads=4, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_tiny_24_p16_224', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=192, depth=24, num_heads=4, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_tiny_24_p16_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_tiny_24_p16_224_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=192, depth=24, num_heads=4, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_tiny_24_p16_224_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=192, depth=24, num_heads=4, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_tiny_24_p16_224_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_tiny_24_p16_384_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=192, depth=24, num_heads=4, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_tiny_24_p16_384_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=192, depth=24, num_heads=4, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_tiny_24_p16_384_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_small_24_p16_224(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=384, depth=24, num_heads=8, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_small_24_p16_224', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=384, depth=24, num_heads=8, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_small_24_p16_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_small_24_p16_224_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=384, depth=24, num_heads=8, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_small_24_p16_224_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=384, depth=24, num_heads=8, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_small_24_p16_224_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_small_24_p16_384_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=384, depth=24, num_heads=8, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_small_24_p16_384_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=384, depth=24, num_heads=8, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_small_24_p16_384_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_medium_24_p16_224(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=512, depth=24, num_heads=8, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_medium_24_p16_224', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=512, depth=24, num_heads=8, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_medium_24_p16_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_medium_24_p16_224_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=512, depth=24, num_heads=8, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_medium_24_p16_224_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=512, depth=24, num_heads=8, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_medium_24_p16_224_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_medium_24_p16_384_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=512, depth=24, num_heads=8, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_medium_24_p16_384_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=512, depth=24, num_heads=8, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_medium_24_p16_384_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_large_24_p16_224(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=768, depth=24, num_heads=16, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_large_24_p16_224', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=768, depth=24, num_heads=16, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_large_24_p16_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_large_24_p16_224_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=768, depth=24, num_heads=16, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_large_24_p16_224_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=768, depth=24, num_heads=16, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_large_24_p16_224_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_large_24_p16_384_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=16, embed_dim=768, depth=24, num_heads=16, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_large_24_p16_384_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=16, embed_dim=768, depth=24, num_heads=16, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_large_24_p16_384_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 # Patch size 8x8 models
 @register_model
 def xcit_nano_12_p8_224(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=128, depth=12, num_heads=4, eta=1.0, tokens_norm=False, **kwargs)
-    model = _create_xcit('xcit_nano_12_p8_224', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=128, depth=12, num_heads=4, eta=1.0, tokens_norm=False)
+    model = _create_xcit('xcit_nano_12_p8_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_nano_12_p8_224_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=128, depth=12, num_heads=4, eta=1.0, tokens_norm=False, **kwargs)
-    model = _create_xcit('xcit_nano_12_p8_224_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=128, depth=12, num_heads=4, eta=1.0, tokens_norm=False)
+    model = _create_xcit('xcit_nano_12_p8_224_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_nano_12_p8_384_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=128, depth=12, num_heads=4, eta=1.0, tokens_norm=False, **kwargs)
-    model = _create_xcit('xcit_nano_12_p8_384_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=128, depth=12, num_heads=4, eta=1.0, tokens_norm=False)
+    model = _create_xcit('xcit_nano_12_p8_384_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_tiny_12_p8_224(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=192, depth=12, num_heads=4, eta=1.0, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_tiny_12_p8_224', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=192, depth=12, num_heads=4, eta=1.0, tokens_norm=True)
+    model = _create_xcit('xcit_tiny_12_p8_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_tiny_12_p8_224_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=192, depth=12, num_heads=4, eta=1.0, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_tiny_12_p8_224_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=192, depth=12, num_heads=4, eta=1.0, tokens_norm=True)
+    model = _create_xcit('xcit_tiny_12_p8_224_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_tiny_12_p8_384_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=192, depth=12, num_heads=4, eta=1.0, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_tiny_12_p8_384_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=192, depth=12, num_heads=4, eta=1.0, tokens_norm=True)
+    model = _create_xcit('xcit_tiny_12_p8_384_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_small_12_p8_224(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=384, depth=12, num_heads=8, eta=1.0, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_small_12_p8_224', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=384, depth=12, num_heads=8, eta=1.0, tokens_norm=True)
+    model = _create_xcit('xcit_small_12_p8_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_small_12_p8_224_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=384, depth=12, num_heads=8, eta=1.0, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_small_12_p8_224_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=384, depth=12, num_heads=8, eta=1.0, tokens_norm=True)
+    model = _create_xcit('xcit_small_12_p8_224_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_small_12_p8_384_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=384, depth=12, num_heads=8, eta=1.0, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_small_12_p8_384_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=384, depth=12, num_heads=8, eta=1.0, tokens_norm=True)
+    model = _create_xcit('xcit_small_12_p8_384_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_tiny_24_p8_224(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=192, depth=24, num_heads=4, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_tiny_24_p8_224', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=192, depth=24, num_heads=4, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_tiny_24_p8_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_tiny_24_p8_224_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=192, depth=24, num_heads=4, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_tiny_24_p8_224_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=192, depth=24, num_heads=4, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_tiny_24_p8_224_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_tiny_24_p8_384_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=192, depth=24, num_heads=4, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_tiny_24_p8_384_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=192, depth=24, num_heads=4, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_tiny_24_p8_384_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_small_24_p8_224(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=384, depth=24, num_heads=8, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_small_24_p8_224', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=384, depth=24, num_heads=8, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_small_24_p8_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_small_24_p8_224_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=384, depth=24, num_heads=8, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_small_24_p8_224_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=384, depth=24, num_heads=8, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_small_24_p8_224_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_small_24_p8_384_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=384, depth=24, num_heads=8, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_small_24_p8_384_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=384, depth=24, num_heads=8, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_small_24_p8_384_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_medium_24_p8_224(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=512, depth=24, num_heads=8, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_medium_24_p8_224', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=512, depth=24, num_heads=8, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_medium_24_p8_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_medium_24_p8_224_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=512, depth=24, num_heads=8, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_medium_24_p8_224_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=512, depth=24, num_heads=8, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_medium_24_p8_224_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_medium_24_p8_384_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=512, depth=24, num_heads=8, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_medium_24_p8_384_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=512, depth=24, num_heads=8, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_medium_24_p8_384_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_large_24_p8_224(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=768, depth=24, num_heads=16, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_large_24_p8_224', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=768, depth=24, num_heads=16, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_large_24_p8_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_large_24_p8_224_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=768, depth=24, num_heads=16, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_large_24_p8_224_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=768, depth=24, num_heads=16, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_large_24_p8_224_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
 
 @register_model
 def xcit_large_24_p8_384_dist(pretrained=False, **kwargs):
-    model_kwargs = dict(
-        patch_size=8, embed_dim=768, depth=24, num_heads=16, eta=1e-5, tokens_norm=True, **kwargs)
-    model = _create_xcit('xcit_large_24_p8_384_dist', pretrained=pretrained, **model_kwargs)
+    model_args = dict(
+        patch_size=8, embed_dim=768, depth=24, num_heads=16, eta=1e-5, tokens_norm=True)
+    model = _create_xcit('xcit_large_24_p8_384_dist', pretrained=pretrained, **dict(model_args, **kwargs))
     return model


### PR DESCRIPTION
* add PatchDropout layer (FLIP), integrate into eva.py and vision_transformer.py
* patch dropout works with ROPE for eva
* make dropout args more consistent across all transformers
  *  `drop_rate` - always (classifier) head dropout (this used to be used for proj_drop with no head drop in most transformers)
  * `patch_drop_rate` - patch dropout
  * `pos_drop_rate` - abs position dropout (used to be set via drop_rate)
  * `proj_drop_rate` - transformer projection dropout (MLP and after specific linear proj layers)
  * `attn_drop_rate` - attention dropout
  * `drop_path_rate` - stochastic depth dropout rate
