### PR TITLE
Add dinov2 pretrained models

### DIFF
--- a/timm/layers/mlp.py
+++ b/timm/layers/mlp.py
@@ -130,8 +130,8 @@ class SwiGLU(nn.Module):
 
     def init_weights(self):
         # override init of fc1 w/ gate portion set to weight near zero, bias=1
-        nn.init.ones_(self.fc1a.bias)
-        nn.init.normal_(self.fc1a.weight, std=1e-6)
+        nn.init.ones_(self.fc1_g.bias)
+        nn.init.normal_(self.fc1_g.weight, std=1e-6)
 
     def forward(self, x):
         x_gate = self.fc1_g(x)

--- a/timm/models/_builder.py
+++ b/timm/models/_builder.py
@@ -219,10 +219,6 @@ def load_pretrained(
                 state_dict[classifier_name + '.weight'] = classifier_weight[label_offset:]
                 classifier_bias = state_dict[classifier_name + '.bias']
                 state_dict[classifier_name + '.bias'] = classifier_bias[label_offset:]
-    
-    if "mask_token" in state_dict:
-        # Remove mask token for dinov2
-        del state_dict["mask_token"]
 
     model.load_state_dict(state_dict, strict=strict)
 

--- a/timm/models/_builder.py
+++ b/timm/models/_builder.py
@@ -219,6 +219,10 @@ def load_pretrained(
                 state_dict[classifier_name + '.weight'] = classifier_weight[label_offset:]
                 classifier_bias = state_dict[classifier_name + '.bias']
                 state_dict[classifier_name + '.bias'] = classifier_bias[label_offset:]
+    
+    if "mask_token" in state_dict:
+        # Remove mask token for dinov2
+        del state_dict["mask_token"]
 
     model.load_state_dict(state_dict, strict=strict)
 

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -231,7 +231,8 @@ class ParallelScalingBlock(nn.Module):
             init_values=None,
             drop_path=0.,
             act_layer=nn.GELU,
-            norm_layer=nn.LayerNorm
+            norm_layer=nn.LayerNorm,
+            ffn_layer=None, # NOTE: not used
     ):
         super().__init__()
         assert dim % num_heads == 0, 'dim should be divisible by num_heads'
@@ -1901,8 +1902,8 @@ def vit_small_patch14_dinov2(pretrained=False, **kwargs):
     """ ViT-S/14 for DINOv2
     """
     model_args = dict(
-        patch_size=14, embed_dim=384, depth=12, num_heads=6, init_values=1.0,
-        ffn_layer=partial(Mlp, norm_layer=None), img_size=518, norm_layer=partial(nn.LayerNorm, eps=1e-6), 
+        patch_size=14, embed_dim=384, depth=12, num_heads=6, 
+        init_values=1.0, img_size=518, 
     )
     
     model = _create_vision_transformer(
@@ -1915,8 +1916,8 @@ def vit_base_patch14_dinov2(pretrained=False, **kwargs):
     """ ViT-B/14 for DINOv2
     """
     model_args = dict(
-        patch_size=14, embed_dim=768, depth=12, num_heads=12, init_values=1.0,
-        ffn_layer=partial(Mlp, norm_layer=None), img_size=518, norm_layer=partial(nn.LayerNorm, eps=1e-6), 
+        patch_size=14, embed_dim=768, depth=12, num_heads=12, 
+        init_values=1.0, img_size=518, 
     )
 
     model = _create_vision_transformer(
@@ -1929,8 +1930,8 @@ def vit_large_patch14_dinov2(pretrained=False, **kwargs):
     """ ViT-L/14 for DINOv2
     """
     model_args = dict(
-        patch_size=14, embed_dim=1024, depth=24, num_heads=16, init_values=1.0,
-        ffn_layer=partial(Mlp, norm_layer=None), img_size=518, norm_layer=partial(nn.LayerNorm, eps=1e-6), 
+        patch_size=14, embed_dim=1024, depth=24, num_heads=16, 
+        init_values=1.0, img_size=518, 
     )
 
     model = _create_vision_transformer(
@@ -1948,9 +1949,8 @@ def vit_giant_patch14_dinov2(pretrained=False, **kwargs):
     # With SwiGLUPacked, we need to set hidden_features = 2 * 4096 = 8192
 
     model_args = dict(
-        patch_size=14, embed_dim=1536, depth=40, num_heads=24, init_values=1.0, mlp_ratio=2.66667 * 2,
-        ffn_layer=SwiGLUPacked, img_size=518, norm_layer=partial(nn.LayerNorm, eps=1e-6), 
-        act_layer=nn.SiLU
+        patch_size=14, embed_dim=1536, depth=40, num_heads=24, init_values=1.0, 
+        mlp_ratio=2.66667 * 2, ffn_layer=SwiGLUPacked, img_size=518, act_layer=nn.SiLU
     )
 
     model = _create_vision_transformer(

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -1052,16 +1052,16 @@ default_cfgs = generate_default_cfgs({
     # DINOv2 pretrained - https://arxiv.org/abs/2304.07193 (no classifier head, for fine-tune only)
     'vit_small_patch14_dinov2': _cfg(
         url='https://dl.fbaipublicfiles.com/dinov2/dinov2_vits14/dinov2_vits14_pretrain.pth',
-        mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD, num_classes=0),
+        mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD, num_classes=0, input_size=(3, 518, 518)),
     'vit_base_patch14_dinov2': _cfg(
         url='https://dl.fbaipublicfiles.com/dinov2/dinov2_vitb14/dinov2_vitb14_pretrain.pth',
-        mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD, num_classes=0),
+        mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD, num_classes=0, input_size=(3, 518, 518)),
     'vit_large_patch14_dinov2': _cfg(
         url='https://dl.fbaipublicfiles.com/dinov2/dinov2_vitl14/dinov2_vitl14_pretrain.pth',
-        mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD, num_classes=0),
+        mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD, num_classes=0, input_size=(3, 518, 518)),
     'vit_giant_patch14_dinov2': _cfg(
         url='https://dl.fbaipublicfiles.com/dinov2/dinov2_vitg14/dinov2_vitg14_pretrain.pth',
-        mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD, num_classes=0),
+        mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD, num_classes=0, input_size=(3, 518, 518)),
 
     # ViT ImageNet-21K-P pretraining by MILL
     'vit_base_patch16_224_miil.in21k': _cfg(


### PR DESCRIPTION
This pr aims to add dinov2's small, base, large, and giant pre-trained models to timm. #1779  
All models are aligned with dinov2's official release (torch hub) and guarantee that absolute error is less than 1e-6 given a normal distribution input.  

<details>
  <summary>Validaiton code</summary>

  ```python
import timm
import torch

pairs = [
    ('dinov2_vits14', 'vit_small_patch14_dinov2'),
    ('dinov2_vitb14', 'vit_base_patch14_dinov2'),
    ('dinov2_vitl14', 'vit_large_patch14_dinov2'),
    ('dinov2_vitg14', 'vit_giant_patch14_dinov2'),
]

# Fused attention will cause a slight difference in the output
timm.layers.config.set_fused_attn(enable=False)

# Use deterministic algorithms for reproducibility
torch.use_deterministic_algorithms(True)

x = torch.randn(1, 3, 518, 518)

for p0, p1 in pairs:
    m0 = torch.hub.load('facebookresearch/dinov2', p0)
    m0.eval()

    m1 = timm.create_model(p1, pretrained=True)
    m1.eval()

    with torch.no_grad():
        y0 = m0.forward_features(x)
        y1 = m1.forward_features(x)
    
    y0 = torch.cat([y0["x_norm_clstoken"][:, None], y0["x_norm_patchtokens"]], dim=1)

    absolute_error = torch.abs(y0 - y1).mean()
    print(f"{p0} error: {absolute_error:.8f}")

    assert absolute_error <= 1e-6, f"{p0} check failed"

  ```

```txt
dinov2_vits14 error: 0.00000000
dinov2_vitb14 error: 0.00000000
dinov2_vitl14 error: 0.00000000
dinov2_vitg14 error: 0.00000000
```
</details>