### PR TITLE
Update hub.py

### DIFF
--- a/timm/models/hub.py
+++ b/timm/models/hub.py
@@ -1,4 +1,4 @@
-from _hub import *
+from ._hub import *
 
 import warnings
 warnings.warn(f"Importing from {__name__} is deprecated, please import via timm.models", DeprecationWarning)


### PR DESCRIPTION
fixed import of _hub modules using the local _hub.py file

otherwise you get the error: `ModuleNotFoundError: No module named '_hub'`