### PR TITLE
[Fix] Update dinov2 layerscale init values

### DIFF
--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -1982,7 +1982,7 @@ def vit_small_patch14_dinov2(pretrained=False, **kwargs) -> VisionTransformer:
     """ ViT-S/14 for DINOv2
     """
     model_args = dict(
-        patch_size=14, embed_dim=384, depth=12, num_heads=6, init_values=1.0, img_size=518,
+        patch_size=14, embed_dim=384, depth=12, num_heads=6, init_values=1e-5, img_size=518,
     )
     model = _create_vision_transformer(
         'vit_small_patch14_dinov2', pretrained=pretrained, **dict(model_args, **kwargs))
@@ -1994,7 +1994,7 @@ def vit_base_patch14_dinov2(pretrained=False, **kwargs) -> VisionTransformer:
     """ ViT-B/14 for DINOv2
     """
     model_args = dict(
-        patch_size=14, embed_dim=768, depth=12, num_heads=12, init_values=1.0, img_size=518,
+        patch_size=14, embed_dim=768, depth=12, num_heads=12, init_values=1e-5, img_size=518,
     )
     model = _create_vision_transformer(
         'vit_base_patch14_dinov2', pretrained=pretrained, **dict(model_args, **kwargs))
@@ -2006,7 +2006,7 @@ def vit_large_patch14_dinov2(pretrained=False, **kwargs) -> VisionTransformer:
     """ ViT-L/14 for DINOv2
     """
     model_args = dict(
-        patch_size=14, embed_dim=1024, depth=24, num_heads=16, init_values=1.0, img_size=518,
+        patch_size=14, embed_dim=1024, depth=24, num_heads=16, init_values=1e-5, img_size=518,
     )
     model = _create_vision_transformer(
         'vit_large_patch14_dinov2', pretrained=pretrained, **dict(model_args, **kwargs))
@@ -2024,7 +2024,7 @@ def vit_giant_patch14_dinov2(pretrained=False, **kwargs) -> VisionTransformer:
     # With SwiGLUPacked, we need to set hidden_features = 2 * 4096 = 8192
 
     model_args = dict(
-        patch_size=14, embed_dim=1536, depth=40, num_heads=24, init_values=1.0, 
+        patch_size=14, embed_dim=1536, depth=40, num_heads=24, init_values=1e-5, 
         mlp_ratio=2.66667 * 2, mlp_layer=SwiGLUPacked, img_size=518, act_layer=nn.SiLU
     )
     model = _create_vision_transformer(


### PR DESCRIPTION
This pull request addresses the issue of incorrect initial layer scale values in DINOv2. The current values on DINOv2's torchhub are inaccurate and can cause training instability when starting from scratch (although they do not affect inference results). Therefore, I have updated the values to match those used in their training configuration.

Incorrect:  
https://github.com/facebookresearch/dinov2/blob/c3c2683a13cde94d4d99f523cf4170384b00c34c/hubconf.py#L27

Correct:  
https://github.com/facebookresearch/dinov2/blob/c3c2683a13cde94d4d99f523cf4170384b00c34c/dinov2/configs/ssl_default_config.yaml#L75

<details>
  <summary>Validaiton code</summary>

  ```python
import timm
import torch

pairs = [
    ('dinov2_vits14', 'vit_small_patch14_dinov2'),
    ('dinov2_vitl14', 'vit_large_patch14_dinov2'),
    ('dinov2_vitg14', 'vit_giant_patch14_dinov2'),
]

# Fused attention will cause a slight difference in the output
timm.layers.config.set_fused_attn(enable=False)

# Use deterministic algorithms for reproducibility
torch.use_deterministic_algorithms(True)

x = torch.randn(1, 3, 518, 518)

for p0, p1 in pairs:
    m0 = torch.hub.load('facebookresearch/dinov2', p0)
    m0.eval()

    m1 = timm.create_model(p1, pretrained=True)
    m1.eval()

    with torch.no_grad():
        y0 = m0.forward_features(x)
        y1 = m1.forward_features(x)
    
    y0 = torch.cat([y0["x_norm_clstoken"][:, None], y0["x_norm_patchtokens"]], dim=1)

    absolute_error = torch.abs(y0 - y1).mean()
    print(f"{p0} error: {absolute_error:.8f}")

    assert absolute_error <= 1e-6, f"{p0} check failed"

  ```

```txt
dinov2_vits14 error: 0.00000000
dinov2_vitl14 error: 0.00000000
dinov2_vitg14 error: 0.00000000
```
</details>