### PR TITLE
Add drop path schedule

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -14,8 +14,8 @@ jobs:
       commit_sha: ${{ github.sha }}
       package: pytorch-image-models
       package_name: timm
-      repo_owner: rwightman
       path_to_docs: pytorch-image-models/hfdocs/source
       version_tag_suffix: ""
     secrets:
       token: ${{ secrets.HUGGINGFACE_PUSH }}
+      hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,6 +15,5 @@ jobs:
       pr_number: ${{ github.event.number }}
       package: pytorch-image-models
       package_name: timm
-      repo_owner: rwightman
       path_to_docs: pytorch-image-models/hfdocs/source
       version_tag_suffix: ""

--- a/.github/workflows/delete_doc_comment.yml
+++ b/.github/workflows/delete_doc_comment.yml
@@ -1,13 +1,13 @@
-name: Delete dev documentation
+name: Delete doc comment
 
 on:
-  pull_request:
-    types: [ closed ]
-
+  workflow_run:
+    workflows: ["Delete doc comment trigger"]
+    types:
+      - completed
 
 jobs:
   delete:
     uses: huggingface/doc-builder/.github/workflows/delete_doc_comment.yml@main
-    with:
-      pr_number: ${{ github.event.number }}
-      package: timm
+    secrets:
+      comment_bot_token: ${{ secrets.COMMENT_BOT_TOKEN }}

--- a/.github/workflows/delete_doc_comment_trigger.yml
+++ b/.github/workflows/delete_doc_comment_trigger.yml
@@ -1,0 +1,12 @@
+name: Delete doc comment trigger
+
+on:
+  pull_request:
+    types: [ closed ]
+
+
+jobs:
+  delete:
+    uses: huggingface/doc-builder/.github/workflows/delete_doc_comment_trigger.yml@main
+    with:
+      pr_number: ${{ github.event.number }}

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -1,0 +1,16 @@
+name: Upload PR Documentation
+
+on:
+  workflow_run:
+    workflows: ["Build PR Documentation"]
+    types:
+      - completed
+
+jobs:
+  build:
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@main
+    with:
+      package_name: timm
+    secrets:
+      hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}
+      comment_bot_token: ${{ secrets.COMMENT_BOT_TOKEN }}

--- a/timm/layers/__init__.py
+++ b/timm/layers/__init__.py
@@ -14,7 +14,7 @@ from .create_attn import get_attn, create_attn
 from .create_conv2d import create_conv2d
 from .create_norm import get_norm_layer, create_norm_layer
 from .create_norm_act import get_norm_act_layer, create_norm_act_layer, get_norm_act_layer
-from .drop import DropBlock2d, DropPath, drop_block_2d, drop_path
+from .drop import DropBlock2d, DropPath, drop_block_2d, drop_path, efficient_drop_path
 from .eca import EcaModule, CecaModule, EfficientChannelAttn, CircularEfficientChannelAttn
 from .evo_norm import EvoNorm2dB0, EvoNorm2dB1, EvoNorm2dB2,\
     EvoNorm2dS0, EvoNorm2dS0a, EvoNorm2dS1, EvoNorm2dS1a, EvoNorm2dS2, EvoNorm2dS2a

--- a/timm/layers/drop.py
+++ b/timm/layers/drop.py
@@ -206,6 +206,19 @@ def apply_residual(
 def efficient_drop_path(
     x: torch.Tensor, func: Callable[[torch.Tensor], torch.Tensor], drop_ratio: float = 0.0, training: bool = False
 ) -> torch.Tensor:
+    """Efficient Drop Path implementation.
+    Ref impl: https://github.com/facebookresearch/dinov2/blob/main/dinov2/layers/block.py
+
+    Args:
+        x (torch.Tensor): input tensor
+        func (Callable[[torch.Tensor], torch.Tensor]): function to calculate residual
+        drop_ratio (float, optional): Drop ratio. Defaults to 0.0.
+        training (bool, optional): training mode. Defaults to False.
+
+    Returns:
+        torch.Tensor: output tensor
+    """
+
     if not training or drop_ratio == 0.0:
         return func(x)
 

--- a/timm/models/_efficientnet_blocks.py
+++ b/timm/models/_efficientnet_blocks.py
@@ -75,7 +75,7 @@ class ConvBnAct(nn.Module):
         if location == 'expansion':  # output of conv after act, same as block coutput
             return dict(module='bn1', hook_type='forward', num_chs=self.conv.out_channels)
         else:  # location == 'bottleneck', block output
-            return dict(module='', hook_type='', num_chs=self.conv.out_channels)
+            return dict(module='', num_chs=self.conv.out_channels)
 
     def forward(self, x):
         shortcut = x
@@ -116,7 +116,7 @@ class DepthwiseSeparableConv(nn.Module):
         if location == 'expansion':  # after SE, input to PW
             return dict(module='conv_pw', hook_type='forward_pre', num_chs=self.conv_pw.in_channels)
         else:  # location == 'bottleneck', block output
-            return dict(module='', hook_type='', num_chs=self.conv_pw.out_channels)
+            return dict(module='', num_chs=self.conv_pw.out_channels)
 
     def forward(self, x):
         shortcut = x
@@ -173,7 +173,7 @@ class InvertedResidual(nn.Module):
         if location == 'expansion':  # after SE, input to PWL
             return dict(module='conv_pwl', hook_type='forward_pre', num_chs=self.conv_pwl.in_channels)
         else:  # location == 'bottleneck', block output
-            return dict(module='', hook_type='', num_chs=self.conv_pwl.out_channels)
+            return dict(module='', num_chs=self.conv_pwl.out_channels)
 
     def forward(self, x):
         shortcut = x
@@ -266,7 +266,7 @@ class EdgeResidual(nn.Module):
         if location == 'expansion':  # after SE, before PWL
             return dict(module='conv_pwl', hook_type='forward_pre', num_chs=self.conv_pwl.in_channels)
         else:  # location == 'bottleneck', block output
-            return dict(module='', hook_type='', num_chs=self.conv_pwl.out_channels)
+            return dict(module='', num_chs=self.conv_pwl.out_channels)
 
     def forward(self, x):
         shortcut = x

--- a/timm/models/_efficientnet_builder.py
+++ b/timm/models/_efficientnet_builder.py
@@ -370,9 +370,7 @@ class EfficientNetBuilder:
         stages = []
         if model_block_args[0][0]['stride'] > 1:
             # if the first block starts with a stride, we need to extract first level feat from stem
-            feature_info = dict(
-                module='act1', num_chs=in_chs, stage=0, reduction=current_stride,
-                hook_type='forward' if self.feature_location != 'bottleneck' else '')
+            feature_info = dict(module='bn1', num_chs=in_chs, stage=0, reduction=current_stride)
             self.features.append(feature_info)
 
         # outer list of block_args defines the stacks
@@ -418,11 +416,15 @@ class EfficientNetBuilder:
                 # stash feature module name and channel info for model feature extraction
                 if extract_features:
                     feature_info = dict(
-                        stage=stack_idx + 1, reduction=current_stride, **block.feature_info(self.feature_location))
+                        stage=stack_idx + 1,
+                        reduction=current_stride,
+                        **block.feature_info(self.feature_location),
+                    )
                     leaf_name = feature_info.get('module', '')
                     if leaf_name:
                         feature_info['module'] = '.'.join([f'blocks.{stack_idx}.{block_idx}', leaf_name])
                     else:
+                        assert last_block
                         feature_info['module'] = f'blocks.{stack_idx}'
                     self.features.append(feature_info)
 

--- a/timm/models/_efficientnet_builder.py
+++ b/timm/models/_efficientnet_builder.py
@@ -419,9 +419,11 @@ class EfficientNetBuilder:
                 if extract_features:
                     feature_info = dict(
                         stage=stack_idx + 1, reduction=current_stride, **block.feature_info(self.feature_location))
-                    module_name = f'blocks.{stack_idx}.{block_idx}'
                     leaf_name = feature_info.get('module', '')
-                    feature_info['module'] = '.'.join([module_name, leaf_name]) if leaf_name else module_name
+                    if leaf_name:
+                        feature_info['module'] = '.'.join([f'blocks.{stack_idx}.{block_idx}', leaf_name])
+                    else:
+                        feature_info['module'] = f'blocks.{stack_idx}'
                     self.features.append(feature_info)
 
                 total_block_idx += 1  # incr global block idx (across all stacks)

--- a/timm/models/_features.py
+++ b/timm/models/_features.py
@@ -27,12 +27,13 @@ class FeatureInfo:
 
     def __init__(self, feature_info: List[Dict], out_indices: Tuple[int]):
         prev_reduction = 1
-        for fi in feature_info:
+        for i, fi in enumerate(feature_info):
             # sanity check the mandatory fields, there may be additional fields depending on the model
             assert 'num_chs' in fi and fi['num_chs'] > 0
             assert 'reduction' in fi and fi['reduction'] >= prev_reduction
             prev_reduction = fi['reduction']
             assert 'module' in fi
+            fi.setdefault('index', i)
         self.out_indices = out_indices
         self.info = feature_info
 

--- a/timm/models/_features_fx.py
+++ b/timm/models/_features_fx.py
@@ -6,7 +6,7 @@ from typing import Callable, List, Dict, Union, Type
 import torch
 from torch import nn
 
-from ._features import _get_feature_info
+from ._features import _get_feature_info, _get_return_layers
 
 try:
     from torchvision.models.feature_extraction import create_feature_extractor as _create_feature_extractor
@@ -93,9 +93,7 @@ class FeatureGraphNet(nn.Module):
         self.feature_info = _get_feature_info(model, out_indices)
         if out_map is not None:
             assert len(out_map) == len(out_indices)
-        return_nodes = {
-            info['module']: out_map[i] if out_map is not None else info['module']
-            for i, info in enumerate(self.feature_info) if i in out_indices}
+        return_nodes = _get_return_layers(self.feature_info, out_map)
         self.graph_module = create_feature_extractor(model, return_nodes)
 
     def forward(self, x):

--- a/timm/models/efficientnet.py
+++ b/timm/models/efficientnet.py
@@ -269,15 +269,20 @@ class EfficientNetFeatures(nn.Module):
 
 def _create_effnet(variant, pretrained=False, **kwargs):
     features_only = False
+    features_cls = False
     model_cls = EfficientNet
     kwargs_filter = None
     if kwargs.pop('features_only', False):
-        features_only = True
-        kwargs_filter = ('num_classes', 'num_features', 'head_conv', 'global_pool')
-        model_cls = EfficientNetFeatures
+        if 'feature_cfg' not in kwargs:
+            kwargs_filter = ('num_classes', 'num_features', 'head_conv', 'global_pool')
+            model_cls = EfficientNetFeatures
+            features_cls = True
+        else:
+            features_only = True
     model = build_model_with_cfg(
         model_cls, variant, pretrained,
-        pretrained_strict=not features_only,
+        features_only=features_only,
+        pretrained_strict=not features_cls,
         kwargs_filter=kwargs_filter,
         **kwargs)
     if features_only:

--- a/timm/models/hrnet.py
+++ b/timm/models/hrnet.py
@@ -829,7 +829,7 @@ class HighResolutionNetFeatures(HighResolutionNet):
             **kwargs,
         )
         self.feature_info = FeatureInfo(self.feature_info, out_indices)
-        self._out_idx = {i for i in out_indices}
+        self._out_idx = {f['index'] for f in self.feature_info.get_dicts()}
 
     def forward_features(self, x):
         assert False, 'Not supported'

--- a/timm/models/mobilenetv3.py
+++ b/timm/models/mobilenetv3.py
@@ -210,7 +210,7 @@ class MobileNetV3Features(nn.Module):
         )
         self.blocks = nn.Sequential(*builder(stem_size, block_args))
         self.feature_info = FeatureInfo(builder.features, out_indices)
-        self._stage_out_idx = {v['stage']: i for i, v in enumerate(self.feature_info) if i in out_indices}
+        self._stage_out_idx = {f['stage']: f['index'] for f in self.feature_info.get_dicts()}
 
         efficientnet_init_weights(self)
 
@@ -247,21 +247,27 @@ class MobileNetV3Features(nn.Module):
 
 
 def _create_mnv3(variant, pretrained=False, **kwargs):
-    features_only = False
+    features_mode = ''
     model_cls = MobileNetV3
     kwargs_filter = None
     if kwargs.pop('features_only', False):
-        features_only = True
-        kwargs_filter = ('num_classes', 'num_features', 'head_conv', 'head_bias', 'global_pool')
-        model_cls = MobileNetV3Features
+        if 'feature_cfg' in kwargs:
+            features_mode = 'cfg'
+        else:
+            kwargs_filter = ('num_classes', 'num_features', 'head_conv', 'head_bias', 'global_pool')
+            model_cls = MobileNetV3Features
+            features_mode = 'cls'
+
     model = build_model_with_cfg(
         model_cls,
         variant,
         pretrained,
-        pretrained_strict=not features_only,
+        features_only=features_mode == 'cfg',
+        pretrained_strict=features_mode != 'cls',
         kwargs_filter=kwargs_filter,
-        **kwargs)
-    if features_only:
+        **kwargs,
+    )
+    if features_mode == 'cls':
         model.default_cfg = pretrained_cfg_for_features(model.default_cfg)
     return model
 

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -158,11 +158,13 @@ class Block(nn.Module):
         if self.efficient_drop_path:
             x = x + efficient_drop_path(
                 x, lambda _x: self.ls1(self.attn(self.norm1(_x))), 
-                self.drop_path1.drop_prob if isinstance(self.drop_path1, DropPath) else 0.
+                drop_ratio=self.drop_path1.drop_prob if isinstance(self.drop_path1, DropPath) else 0.,
+                training=self.training
             )
             x = x + efficient_drop_path(
                 x, lambda _x: self.ls2(self.mlp(self.norm2(_x))),
-                self.drop_path2.drop_prob if isinstance(self.drop_path2, DropPath) else 0.
+                drop_ratio=self.drop_path2.drop_prob if isinstance(self.drop_path2, DropPath) else 0.,
+                training=self.training
             )
         else:
             x = x + self.drop_path1(self.ls1(self.attn(self.norm1(x))))

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -489,7 +489,6 @@ class VisionTransformer(nn.Module):
             act_layer: Optional[Callable] = None,
             block_fn: Callable = Block,
             mlp_layer: Callable = Mlp,
-            efficient_drop_path: bool = False,
     ):
         """
         Args:
@@ -515,7 +514,6 @@ class VisionTransformer(nn.Module):
             norm_layer: Normalization layer.
             act_layer: MLP activation layer.
             block_fn: Transformer block layer.
-            efficient_drop_path: Use efficient drop path implementation.
         """
         super().__init__()
         assert global_pool in ('', 'avg', 'token')
@@ -575,7 +573,6 @@ class VisionTransformer(nn.Module):
                 norm_layer=norm_layer,
                 act_layer=act_layer,
                 mlp_layer=mlp_layer,
-                efficient_drop_path=efficient_drop_path,
             )
             for i in range(depth)])
         self.norm = norm_layer(embed_dim) if not use_fc_norm else nn.Identity()

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -156,12 +156,12 @@ class Block(nn.Module):
 
     def forward(self, x):
         if self.efficient_drop_path:
-            x = x + efficient_drop_path(
+            x = efficient_drop_path(
                 x, lambda _x: self.ls1(self.attn(self.norm1(_x))), 
                 drop_ratio=self.drop_path1.drop_prob if isinstance(self.drop_path1, DropPath) else 0.,
                 training=self.training
             )
-            x = x + efficient_drop_path(
+            x = efficient_drop_path(
                 x, lambda _x: self.ls2(self.mlp(self.norm2(_x))),
                 drop_ratio=self.drop_path2.drop_prob if isinstance(self.drop_path2, DropPath) else 0.,
                 training=self.training

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -1992,7 +1992,7 @@ def vit_small_patch14_dinov2(pretrained=False, **kwargs) -> VisionTransformer:
     """
     model_args = dict(
         patch_size=14, embed_dim=384, depth=12, num_heads=6, init_values=1e-5, 
-        img_size=518, drop_path_schedule='uniform'
+        img_size=518, drop_path_schedule='uniform', drop_path_rate=0.4
     )
     model = _create_vision_transformer(
         'vit_small_patch14_dinov2', pretrained=pretrained, **dict(model_args, **kwargs))
@@ -2005,7 +2005,7 @@ def vit_base_patch14_dinov2(pretrained=False, **kwargs) -> VisionTransformer:
     """
     model_args = dict(
         patch_size=14, embed_dim=768, depth=12, num_heads=12, init_values=1e-5, 
-        img_size=518, drop_path_schedule='uniform'
+        img_size=518, drop_path_schedule='uniform', drop_path_rate=0.4
     )
     model = _create_vision_transformer(
         'vit_base_patch14_dinov2', pretrained=pretrained, **dict(model_args, **kwargs))
@@ -2018,7 +2018,7 @@ def vit_large_patch14_dinov2(pretrained=False, **kwargs) -> VisionTransformer:
     """
     model_args = dict(
         patch_size=14, embed_dim=1024, depth=24, num_heads=16, init_values=1e-5, 
-        img_size=518, drop_path_schedule='uniform'
+        img_size=518, drop_path_schedule='uniform', drop_path_rate=0.4
     )
     model = _create_vision_transformer(
         'vit_large_patch14_dinov2', pretrained=pretrained, **dict(model_args, **kwargs))
@@ -2038,7 +2038,7 @@ def vit_giant_patch14_dinov2(pretrained=False, **kwargs) -> VisionTransformer:
     model_args = dict(
         patch_size=14, embed_dim=1536, depth=40, num_heads=24, init_values=1e-5, 
         mlp_ratio=2.66667 * 2, mlp_layer=SwiGLUPacked, img_size=518, act_layer=nn.SiLU,
-        drop_path_schedule='uniform'
+        drop_path_schedule='uniform', drop_path_rate=0.4
     )
     model = _create_vision_transformer(
         'vit_giant_patch14_dinov2', pretrained=pretrained, **dict(model_args, **kwargs))

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -126,10 +126,11 @@ class Block(nn.Module):
             act_layer=nn.GELU,
             norm_layer=nn.LayerNorm,
             mlp_layer=Mlp,
+            attn_class=Attention,
     ):
         super().__init__()
         self.norm1 = norm_layer(dim)
-        self.attn = Attention(
+        self.attn = attn_class(
             dim,
             num_heads=num_heads,
             qkv_bias=qkv_bias,

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -961,6 +961,17 @@ def _convert_dinov2(state_dict, model):
     return out_dict
 
 
+def _convert_ijepa(state_dict, model):
+    out_dict = {}
+    for k, v in state_dict['encoder'].items():
+        if k.startswith('module.'):
+            k = k[7:]
+        if k.startswith('norm.'):
+            k = 'fc_norm.' + k[5:]
+        out_dict[k] = v
+    return out_dict
+
+
 def checkpoint_filter_fn(
         state_dict,
         model,
@@ -978,7 +989,10 @@ def checkpoint_filter_fn(
         return _convert_openai_clip(state_dict, model)
 
     if "mask_token" in state_dict:
-        return _convert_dinov2(state_dict, model)
+        state_dict = _convert_dinov2(state_dict, model)
+
+    if "encoder" in state_dict:
+        state_dict = _convert_ijepa(state_dict, model)
 
     for k, v in state_dict.items():
         if 'patch_embed.proj.weight' in k:
@@ -1517,6 +1531,27 @@ default_cfgs = generate_default_cfgs({
     'vit_huge_patch14_224.mae': _cfg(
         url='https://dl.fbaipublicfiles.com/mae/pretrain/mae_pretrain_vit_huge.pth',
         hf_hub_id='timm/',
+        license='cc-by-nc-4.0',
+        mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD, num_classes=0),
+    
+    'vit_huge_patch14_224_ijepa.in1k': _cfg(
+        url='https://dl.fbaipublicfiles.com/ijepa/IN1K-vit.h.14-300e.pth.tar',
+        # hf_hub_id='timm/',
+        license='cc-by-nc-4.0',
+        mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD, num_classes=0),
+    'vit_huge_patch14_224_ijepa.in22k': _cfg(
+        url='https://dl.fbaipublicfiles.com/ijepa/IN22K-vit.h.14-900e.pth.tar',
+        # hf_hub_id='timm/',
+        license='cc-by-nc-4.0',
+        mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD, num_classes=0),
+    'vit_huge_patch16_448_ijepa.in1k': _cfg(
+        url='https://dl.fbaipublicfiles.com/ijepa/IN1K-vit.h.16-448px-300e.pth.tar',
+        # hf_hub_id='timm/',
+        license='cc-by-nc-4.0',
+        mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD, num_classes=0),
+    'vit_gigantic_patch16_224_ijepa.in22k': _cfg(
+        url='https://dl.fbaipublicfiles.com/ijepa/IN22K-vit.g.16-600e.pth.tar',
+        # hf_hub_id='timm/',
         license='cc-by-nc-4.0',
         mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD, num_classes=0),
 })
@@ -2117,6 +2152,30 @@ def vit_giant_patch14_dinov2(pretrained=False, **kwargs) -> VisionTransformer:
         'vit_giant_patch14_dinov2', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
 
+@register_model
+def vit_huge_patch14_224_ijepa(pretrained=False, **kwargs) -> VisionTransformer:
+    """ ViT-Huge model (ViT-H/14) from `I-JEPA` - https://arxiv.org/abs/2301.08243
+    """
+    model_args = dict(patch_size=14, embed_dim=1280, depth=32, num_heads=16, class_token=False, global_pool='avg')
+    model = _create_vision_transformer('vit_huge_patch14_224_ijepa', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
+
+@register_model
+def vit_huge_patch16_448_ijepa(pretrained=False, **kwargs) -> VisionTransformer:
+    """ ViT-Huge model (ViT-H/16) from `I-JEPA` - https://arxiv.org/abs/2301.08243
+    """
+    model_args = dict(patch_size=16, embed_dim=1280, depth=32, num_heads=16, class_token=False, global_pool='avg', img_size=448)
+    model = _create_vision_transformer('vit_huge_patch16_448_ijepa', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
+
+@register_model
+def vit_gigantic_patch16_224_ijepa(pretrained=False, **kwargs) -> VisionTransformer:
+    """ ViT-Gigantic (big-G) model (ViT-G/16) from `I-JEPA - https://arxiv.org/abs/2301.08243
+    """
+    model_args = dict(patch_size=16, embed_dim=1664, mlp_ratio=64/13, depth=48, num_heads=16)
+    model = _create_vision_transformer(
+        'vit_gigantic_patch16_224_ijepa', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
 
 register_model_deprecations(__name__, {
     'vit_tiny_patch16_224_in21k': 'vit_tiny_patch16_224.augreg_in21k',

--- a/timm/models/vision_transformer_sam.py
+++ b/timm/models/vision_transformer_sam.py
@@ -605,6 +605,3 @@ def samvit_huge_patch16(pretrained=False, **kwargs) -> VisionTransformerSAM:
     model = _create_vision_transformer(
         'samvit_huge_patch16', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
-
-# TODO:
-# support any input size, now only 1024 x 1024 (pretrained)

--- a/timm/optim/lookahead.py
+++ b/timm/optim/lookahead.py
@@ -4,6 +4,9 @@ Paper: `Lookahead Optimizer: k steps forward, 1 step back` - https://arxiv.org/a
 
 Hacked together by / Copyright 2020 Ross Wightman
 """
+from collections import OrderedDict
+from typing import Callable, Dict
+
 import torch
 from torch.optim.optimizer import Optimizer
 from collections import defaultdict
@@ -12,6 +15,8 @@ from collections import defaultdict
 class Lookahead(Optimizer):
     def __init__(self, base_optimizer, alpha=0.5, k=6):
         # NOTE super().__init__() not called on purpose
+        self._optimizer_step_pre_hooks: Dict[int, Callable] = OrderedDict()
+        self._optimizer_step_post_hooks: Dict[int, Callable] = OrderedDict()
         if not 0.0 <= alpha <= 1.0:
             raise ValueError(f'Invalid slow update rate: {alpha}')
         if not 1 <= k:

--- a/timm/optim/nadam.py
+++ b/timm/optim/nadam.py
@@ -32,7 +32,12 @@ class Nadam(Optimizer):
         if not 0.0 <= lr:
             raise ValueError("Invalid learning rate: {}".format(lr))
         defaults = dict(
-            lr=lr, betas=betas, eps=eps, weight_decay=weight_decay, schedule_decay=schedule_decay)
+            lr=lr,
+            betas=betas,
+            eps=eps,
+            weight_decay=weight_decay,
+            schedule_decay=schedule_decay,
+        )
         super(Nadam, self).__init__(params, defaults)
 
     @torch.no_grad()

--- a/timm/optim/nadamw.py
+++ b/timm/optim/nadamw.py
@@ -315,6 +315,11 @@ def _multi_tensor_nadamw(
 
         bias_correction2_sqrt = torch._foreach_sqrt(bias_correction2)
 
+        # Only difference between NAdamW and AdamW in this implementation.
+        # The official PyTorch implementation of NAdam uses a different algorithm.
+        exp_avgs = torch._foreach_mul(exp_avgs, beta1)
+        torch._foreach_add_(exp_avgs, grads, alpha=1 - beta1)
+
         exp_avg_sq_sqrt = torch._foreach_sqrt(exp_avg_sqs)
         torch._foreach_div_(
             exp_avg_sq_sqrt, torch._foreach_mul(bias_correction2_sqrt, step_size)

--- a/timm/optim/nadamw.py
+++ b/timm/optim/nadamw.py
@@ -1,0 +1,344 @@
+""" NAdamW Optimizer
+
+Based on simplified algorithm in https://github.com/mlcommons/algorithmic-efficiency/tree/main/baselines/nadamw
+
+Added multi-tensor (foreach) path.
+"""
+import math
+from typing import List, Optional
+
+import torch
+from torch import Tensor
+
+
+# Modified from github.com/pytorch/pytorch/blob/v1.12.1/torch/optim/adamw.py.
+class NAdamW(torch.optim.Optimizer):
+    r"""Implements NAdamW algorithm.
+
+      See Table 1 in https://arxiv.org/abs/1910.05446 for the implementation of
+      the NAdam algorithm (there is also a comment in the code which highlights
+      the only difference of NAdamW and AdamW).
+      For further details regarding the algorithm we refer to
+      `Decoupled Weight Decay Regularization`_.
+
+      Args:
+        params (iterable): iterable of parameters to optimize or dicts defining
+            parameter groups
+        lr (float, optional): learning rate (default: 1e-3)
+        betas (Tuple[float, float], optional): coefficients used for computing
+            running averages of gradient and its square (default: (0.9, 0.999))
+        eps (float, optional): term added to the denominator to improve
+            numerical stability (default: 1e-8)
+        weight_decay (float, optional): weight decay coefficient (default: 1e-2)
+      .. _Decoupled Weight Decay Regularization:
+          https://arxiv.org/abs/1711.05101
+      .. _On the Convergence of Adam and Beyond:
+          https://openreview.net/forum?id=ryQu7f-RZ
+    """
+
+    def __init__(
+            self,
+            params,
+            lr=1e-3,
+            betas=(0.9, 0.999),
+            eps=1e-8,
+            weight_decay=1e-2,
+            maximize: bool = False,
+            foreach: Optional[bool] = None,
+            capturable: bool = False,
+    ):
+        if not 0.0 <= lr:
+            raise ValueError(f'Invalid learning rate: {lr}')
+        if not 0.0 <= eps:
+            raise ValueError(f'Invalid epsilon value: {eps}')
+        if not 0.0 <= betas[0] < 1.0:
+            raise ValueError(f'Invalid beta parameter at index 0: {betas[0]}')
+        if not 0.0 <= betas[1] < 1.0:
+            raise ValueError(f'Invalid beta parameter at index 1: {betas[1]}')
+        if not 0.0 <= weight_decay:
+            raise ValueError(f'Invalid weight_decay value: {weight_decay}')
+        defaults = dict(
+            lr=lr,
+            betas=betas,
+            eps=eps,
+            weight_decay=weight_decay,
+            foreach=foreach,
+            maximize=maximize,
+            capturable=capturable,
+        )
+        super().__init__(params, defaults)
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        state_values = list(self.state.values())
+        step_is_tensor = (len(state_values) != 0) and torch.is_tensor(
+            state_values[0]['step'])
+        if not step_is_tensor:
+            for s in state_values:
+                s['step'] = torch.tensor(float(s['step']))
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        """Performs a single optimization step.
+
+            Args:
+              closure (callable, optional): A closure that reevaluates the model
+                  and returns the loss.
+        """
+        self._cuda_graph_capture_health_check()
+
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            params_with_grad = []
+            grads = []
+            exp_avgs = []
+            exp_avg_sqs = []
+            state_steps = []
+            beta1, beta2 = group['betas']
+
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+                params_with_grad.append(p)
+                if p.grad.is_sparse:
+                    raise RuntimeError('NAdamW does not support sparse gradients')
+                grads.append(p.grad)
+
+                state = self.state[p]
+
+                # State initialization
+                if len(state) == 0:
+                    state['step'] = torch.tensor(0.)
+                    # Exponential moving average of gradient values
+                    state['exp_avg'] = torch.zeros_like(p, memory_format=torch.preserve_format)
+                    # Exponential moving average of squared gradient values
+                    state['exp_avg_sq'] = torch.zeros_like(p, memory_format=torch.preserve_format)
+
+                exp_avgs.append(state['exp_avg'])
+                exp_avg_sqs.append(state['exp_avg_sq'])
+                state_steps.append(state['step'])
+
+            nadamw(
+                params_with_grad,
+                grads,
+                exp_avgs,
+                exp_avg_sqs,
+                state_steps,
+                beta1=beta1,
+                beta2=beta2,
+                lr=group['lr'],
+                weight_decay=group['weight_decay'],
+                eps=group['eps'],
+                maximize=group['maximize'],
+                capturable=group['capturable'],
+            )
+
+        return loss
+
+
+def nadamw(
+        params: List[Tensor],
+        grads: List[Tensor],
+        exp_avgs: List[Tensor],
+        exp_avg_sqs: List[Tensor],
+        state_steps: List[Tensor],
+        foreach: Optional[bool] = None,
+        capturable: bool = False,
+        *,
+        beta1: float,
+        beta2: float,
+        lr: float,
+        weight_decay: float,
+        eps: float,
+        maximize: bool,
+) -> None:
+    r"""Functional API that performs NAdamW algorithm computation.
+      See NAdamW class for details.
+    """
+
+    if not all(isinstance(t, torch.Tensor) for t in state_steps):
+        raise RuntimeError(
+            'API has changed, `state_steps` argument must contain a list of' +
+            ' singleton tensors')
+
+    if foreach is None:
+        foreach = True
+    if foreach and not torch.jit.is_scripting():
+        func = _multi_tensor_nadamw
+    else:
+        func = _single_tensor_nadamw
+
+    func(
+        params,
+        grads,
+        exp_avgs,
+        exp_avg_sqs,
+        state_steps,
+        beta1=beta1,
+        beta2=beta2,
+        lr=lr,
+        weight_decay=weight_decay,
+        eps=eps,
+        maximize=maximize,
+        capturable=capturable,
+    )
+
+
+def _single_tensor_nadamw(
+        params: List[Tensor],
+        grads: List[Tensor],
+        exp_avgs: List[Tensor],
+        exp_avg_sqs: List[Tensor],
+        state_steps: List[Tensor],
+        *,
+        beta1: float,
+        beta2: float,
+        lr: float,
+        weight_decay: float,
+        eps: float,
+        maximize: bool,
+        capturable: bool
+):
+
+    for i, param in enumerate(params):
+        grad = grads[i] if not maximize else -grads[i]
+        exp_avg = exp_avgs[i]
+        exp_avg_sq = exp_avg_sqs[i]
+        step_t = state_steps[i]
+
+        # Update step.
+        step_t += 1
+
+        # Perform stepweight decay.
+        param.mul_(1. - lr * weight_decay)
+
+        # Decay the first and second moment running average coefficient.
+        exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
+
+        if capturable:
+            step = step_t
+
+            # 1 - beta1 ** step can't be captured in a CUDA graph, even if step is a CUDA tensor
+            # (incurs "RuntimeError: CUDA error: operation not permitted when stream is capturing")
+            bias_correction1 = 1 - torch.pow(beta1, step)
+            bias_correction2 = 1 - torch.pow(beta2, step)
+
+            step_size = lr / bias_correction1
+            step_size_neg = step_size.neg()
+
+            bias_correction2_sqrt = bias_correction2.sqrt()
+
+            # Only difference between NAdamW and AdamW in this implementation.
+            # The official PyTorch implementation of NAdam uses a different algorithm.
+            exp_avg = exp_avg.mul(beta1).add_(grad, alpha=1 - beta1)
+
+            denom = (exp_avg_sq.sqrt() / (bias_correction2_sqrt * step_size_neg)).add_(eps / step_size_neg)
+            param.addcdiv_(exp_avg, denom)
+        else:
+            step = step_t.item()
+            bias_correction1 = 1 - beta1 ** step
+            bias_correction2 = 1 - beta2 ** step
+            step_size = lr / bias_correction1
+            bias_correction2_sqrt = math.sqrt(bias_correction2)
+
+            # Only difference between NAdamW and AdamW in this implementation.
+            # The official PyTorch implementation of NAdam uses a different algorithm.
+            exp_avg = exp_avg.mul(beta1).add_(grad, alpha=1 - beta1)
+
+            denom = (exp_avg_sq.sqrt() / bias_correction2_sqrt).add_(eps)
+            param.addcdiv_(exp_avg, denom, value=-step_size)
+
+
+def _multi_tensor_nadamw(
+        params: List[Tensor],
+        grads: List[Tensor],
+        exp_avgs: List[Tensor],
+        exp_avg_sqs: List[Tensor],
+        state_steps: List[Tensor],
+        *,
+        beta1: float,
+        beta2: float,
+        lr: float,
+        weight_decay: float,
+        eps: float,
+        maximize: bool,
+        capturable: bool,
+):
+    if len(params) == 0:
+        return
+
+    if capturable:
+        assert all(
+            p.is_cuda and step.is_cuda for p, step in zip(params, state_steps)
+        ), "If capturable=True, params and state_steps must be CUDA tensors."
+
+    if maximize:
+        grads = torch._foreach_neg(tuple(grads))  # type: ignore[assignment]
+
+    grads = [torch.view_as_real(x) if torch.is_complex(x) else x for x in grads]
+    exp_avgs = [torch.view_as_real(x) if torch.is_complex(x) else x for x in exp_avgs]
+    exp_avg_sqs = [torch.view_as_real(x) if torch.is_complex(x) else x for x in exp_avg_sqs]
+    params = [torch.view_as_real(x) if torch.is_complex(x) else x for x in params]
+
+    # update steps
+    torch._foreach_add_(state_steps, 1)
+
+    # Perform stepweight decay
+    torch._foreach_mul_(params, 1 - lr * weight_decay)
+
+    # Decay the first and second moment running average coefficient
+    torch._foreach_mul_(exp_avgs, beta1)
+    torch._foreach_add_(exp_avgs, grads, alpha=1 - beta1)
+
+    torch._foreach_mul_(exp_avg_sqs, beta2)
+    torch._foreach_addcmul_(exp_avg_sqs, grads, grads, 1 - beta2)
+
+    if capturable:
+        # TODO: use foreach_pow if/when foreach_pow is added
+        bias_correction1 = [torch.pow(beta1, step) for step in state_steps]
+        bias_correction2 = [torch.pow(beta2, step) for step in state_steps]
+        # foreach_sub doesn't allow a scalar as the first arg
+        torch._foreach_sub_(bias_correction1, 1)
+        torch._foreach_sub_(bias_correction2, 1)
+        torch._foreach_neg_(bias_correction1)
+        torch._foreach_neg_(bias_correction2)
+
+        # foreach_div doesn't allow a scalar as the first arg
+        step_size = torch._foreach_div(bias_correction1, lr)
+        torch._foreach_reciprocal_(step_size)
+        torch._foreach_neg_(step_size)
+
+        bias_correction2_sqrt = torch._foreach_sqrt(bias_correction2)
+
+        exp_avg_sq_sqrt = torch._foreach_sqrt(exp_avg_sqs)
+        torch._foreach_div_(
+            exp_avg_sq_sqrt, torch._foreach_mul(bias_correction2_sqrt, step_size)
+        )
+        eps_over_step_size = torch._foreach_div(step_size, eps)
+        torch._foreach_reciprocal_(eps_over_step_size)
+        denom = torch._foreach_add(exp_avg_sq_sqrt, eps_over_step_size)
+
+        torch._foreach_addcdiv_(params, exp_avgs, denom)
+    else:
+        bias_correction1 = [1 - beta1 ** step.item() for step in state_steps]
+        bias_correction2 = [1 - beta2 ** step.item() for step in state_steps]
+
+        step_size = [(lr / bc) * -1 for bc in bias_correction1]
+
+        bias_correction2_sqrt = [math.sqrt(bc) for bc in bias_correction2]
+
+        # Only difference between NAdamW and AdamW in this implementation.
+        # The official PyTorch implementation of NAdam uses a different algorithm.
+        exp_avgs = torch._foreach_mul(exp_avgs, beta1)
+        torch._foreach_add_(exp_avgs, grads, alpha=1 - beta1)
+
+        exp_avg_sq_sqrt = torch._foreach_sqrt(exp_avg_sqs)
+        torch._foreach_div_(exp_avg_sq_sqrt, bias_correction2_sqrt)
+        denom = torch._foreach_add(exp_avg_sq_sqrt, eps)
+
+        torch._foreach_addcdiv_(params, exp_avgs, denom, step_size)

--- a/timm/optim/optim_factory.py
+++ b/timm/optim/optim_factory.py
@@ -22,6 +22,7 @@ from .lion import Lion
 from .lookahead import Lookahead
 from .madgrad import MADGRAD
 from .nadam import Nadam
+from .nadamw import NAdamW
 from .nvnovograd import NvNovoGrad
 from .radam import RAdam
 from .rmsprop_tf import RMSpropTF
@@ -301,6 +302,8 @@ def create_optimizer_v2(
             optimizer = optim.Nadam(parameters, **opt_args)
         except AttributeError:
             optimizer = Nadam(parameters, **opt_args)
+    elif opt_lower == 'nadamw':
+        optimizer = NAdamW(parameters, **opt_args)
     elif opt_lower == 'radam':
         optimizer = RAdam(parameters, **opt_args)
     elif opt_lower == 'adamax':

--- a/validate.py
+++ b/validate.py
@@ -66,7 +66,7 @@ parser.add_argument('--dataset-download', action='store_true', default=False,
 parser.add_argument('--model', '-m', metavar='NAME', default='dpn92',
                     help='model architecture (default: dpn92)')
 parser.add_argument('-j', '--workers', default=4, type=int, metavar='N',
-                    help='number of data loading workers (default: 2)')
+                    help='number of data loading workers (default: 4)')
 parser.add_argument('-b', '--batch-size', default=256, type=int,
                     metavar='N', help='mini-batch size (default: 256)')
 parser.add_argument('--img-size', default=None, type=int,


### PR DESCRIPTION
Update the drop path schedule adheres to the original implementation found in DINOv2.
Add an efficient drop path to accelerate training. #1836

Given 40% drop rate, we can see a 38% performance improvement:
ViT-L/14 eval took 8.701655239999809
ViT-L/14 with efficient drop path eval took 8.702854548999994
ViT-L/14 train took 8.81138907400009
ViT-L/14 with efficient drop path train took 5.4026294970001345

Ref: [DinoV2](https://github.com/facebookresearch/dinov2/blob/c3c2683a13cde94d4d99f523cf4170384b00c34c/dinov2/layers/block.py#L110). 
Benchmark: [COLAB](https://colab.research.google.com/drive/1ydeHogHNlGgVYCFBbgd4a5PYi9LZWHLH?usp=sharing#scrollTo=5-lPAZsLXnQ-)