### PR TITLE
add I-JEPA pretrained weight for ViT

### DIFF
--- a/timm/models/vision_transformer_sam.py
+++ b/timm/models/vision_transformer_sam.py
@@ -605,6 +605,3 @@ def samvit_huge_patch16(pretrained=False, **kwargs) -> VisionTransformerSAM:
     model = _create_vision_transformer(
         'samvit_huge_patch16', pretrained=pretrained, **dict(model_args, **kwargs))
     return model
-
-# TODO:
-# support any input size, now only 1024 x 1024 (pretrained)


### PR DESCRIPTION
Add weights from: https://github.com/facebookresearch/ijepa , a strong self-sup pretraining method from FAIR / Lecun's team. (Similar to MAE and other MIM methods in some aspects)

It seems that only the weight of the vit backbone is provided (without the classifier's weight).

Alos support dynamic input size, but only test in ViT-H. Due to the small DRAM of my work pc, I did no check whether ViT-G pretrained is correctly loaded. May need help verifying the correctness of weight loading.

![image](https://github.com/huggingface/pytorch-image-models/assets/19152032/0ff95091-608e-45cf-b2e4-33bd7bf9ab43)
![image](https://github.com/huggingface/pytorch-image-models/assets/19152032/f637e29f-b327-404d-80c9-19dc8238c702)
![image](https://github.com/huggingface/pytorch-image-models/assets/19152032/be0fe49c-51cf-4570-afa5-638880499f0a)


