### PR TITLE
Omit Normalization Layer from MLP Class 

### DIFF
--- a/timm/layers/mlp.py
+++ b/timm/layers/mlp.py
@@ -19,7 +19,6 @@ class Mlp(nn.Module):
             hidden_features=None,
             out_features=None,
             act_layer=nn.GELU,
-            norm_layer=None,
             bias=True,
             drop=0.,
             use_conv=False,
@@ -34,7 +33,6 @@ class Mlp(nn.Module):
         self.fc1 = linear_layer(in_features, hidden_features, bias=bias[0])
         self.act = act_layer()
         self.drop1 = nn.Dropout(drop_probs[0])
-        self.norm = norm_layer(hidden_features) if norm_layer is not None else nn.Identity()
         self.fc2 = linear_layer(hidden_features, out_features, bias=bias[1])
         self.drop2 = nn.Dropout(drop_probs[1])
 

--- a/timm/models/beit.py
+++ b/timm/models/beit.py
@@ -220,7 +220,6 @@ class Block(nn.Module):
                 in_features=dim,
                 hidden_features=int(dim * mlp_ratio),
                 act_layer=act_layer,
-                norm_layer=norm_layer if scale_mlp else None,
                 drop=proj_drop,
             )
         self.drop_path2 = DropPath(drop_path) if drop_path > 0. else nn.Identity()

--- a/timm/models/eva.py
+++ b/timm/models/eva.py
@@ -225,7 +225,6 @@ class EvaBlock(nn.Module):
                 in_features=dim,
                 hidden_features=hidden_features,
                 act_layer=act_layer,
-                norm_layer=norm_layer if scale_mlp else None,
                 drop=proj_drop,
             )
         self.gamma_2 = nn.Parameter(init_values * torch.ones(dim)) if init_values is not None else None
@@ -319,7 +318,6 @@ class EvaBlockPostNorm(nn.Module):
                 in_features=dim,
                 hidden_features=hidden_features,
                 act_layer=act_layer,
-                norm_layer=norm_layer if scale_mlp else None,
                 drop=proj_drop,
             )
         self.norm2 = norm_layer(dim)


### PR DESCRIPTION
This pull request fixes issue #1851. The unused normalization layer is omitted from the Mlp class. Usage of the `norm_layer` argument is also omitted. Both BEiT(-v2) and EVA(-02) models are not affected by this change. EVA(-02) uses the `norm_layer` argument but since all configurations are using the SwiGLU instead if Mlp existing model weights are not affected. BEiT(-v2) sets in all configurations `scale_mlp=False`, meaning `norm_layer` was set to `None`, thus, also no affect here on existing models/weights.