### PR TITLE
Replace deprecated NumPy aliases of builtin types

### DIFF
--- a/timm/data/mixup.py
+++ b/timm/data/mixup.py
@@ -120,7 +120,7 @@ class Mixup:
 
     def _params_per_elem(self, batch_size):
         lam = np.ones(batch_size, dtype=np.float32)
-        use_cutmix = np.zeros(batch_size, dtype=np.bool)
+        use_cutmix = np.zeros(batch_size, dtype=bool)
         if self.mixup_enabled:
             if self.mixup_alpha > 0. and self.cutmix_alpha > 0.:
                 use_cutmix = np.random.rand(batch_size) < self.switch_prob
@@ -131,7 +131,7 @@ class Mixup:
             elif self.mixup_alpha > 0.:
                 lam_mix = np.random.beta(self.mixup_alpha, self.mixup_alpha, size=batch_size)
             elif self.cutmix_alpha > 0.:
-                use_cutmix = np.ones(batch_size, dtype=np.bool)
+                use_cutmix = np.ones(batch_size, dtype=bool)
                 lam_mix = np.random.beta(self.cutmix_alpha, self.cutmix_alpha, size=batch_size)
             else:
                 assert False, "One of mixup_alpha > 0., cutmix_alpha > 0., cutmix_minmax not None should be true."

--- a/timm/models/volo.py
+++ b/timm/models/volo.py
@@ -301,8 +301,8 @@ def rand_bbox(size, lam, scale=1):
     W = size[1] // scale
     H = size[2] // scale
     cut_rat = np.sqrt(1. - lam)
-    cut_w = np.int(W * cut_rat)
-    cut_h = np.int(H * cut_rat)
+    cut_w = (W * cut_rat).astype(int)
+    cut_h = (H * cut_rat).astype(int)
 
     # uniform
     cx = np.random.randint(W)


### PR DESCRIPTION
`np.bool` and `np.int` were originally [deprecated](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) in NumPy 1.20 and recently [removed](https://github.com/numpy/numpy/releases/tag/v1.24.0) in 1.24.

Using them in new versions (tested on 1.24.3 and 1.25.0) of NumPy raises an error:

```
AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```