### PR TITLE
use float in resample_abs_pos_embed_nhwc

### DIFF
--- a/timm/layers/pos_embed.py
+++ b/timm/layers/pos_embed.py
@@ -64,10 +64,12 @@ def resample_abs_pos_embed_nhwc(
     if new_size[0] == posemb.shape[-3] and new_size[1] == posemb.shape[-2]:
         return posemb
 
+    previous_dtype = posemb.dtype
+    posemb = posemb.float()
     # do the interpolation
     posemb = posemb.reshape(1, posemb.shape[-3], posemb.shape[-2], posemb.shape[-1]).permute(0, 3, 1, 2)
     posemb = F.interpolate(posemb, size=new_size, mode=interpolation, antialias=antialias)
-    posemb = posemb.permute(0, 2, 3, 1)
+    posemb = posemb.permute(0, 2, 3, 1).to(previous_dtype)
 
     if not torch.jit.is_scripting() and verbose:
         _logger.info(f'Resized position embedding: {posemb.shape[-3:-1]} to {new_size}.')


### PR DESCRIPTION
I was trying to use SAM with a small image (smaller than 1024) and BFloat16, and I got this error message: "upsample_bilinear2d_out_frame" not implemented for 'BFloat16'
I checked DINOv2's codebase and they also have this conversion [here](https://github.com/facebookresearch/dinov2/blob/c3c2683a13cde94d4d99f523cf4170384b00c34c/dinov2/models/vision_transformer.py#L171)