### PR TITLE
add two different EfficientViT models

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,7 +41,7 @@ NON_STD_FILTERS = [
     'vit_*', 'tnt_*', 'pit_*', 'coat_*', 'cait_*', '*mixer_*', 'gmlp_*', 'resmlp_*', 'twins_*',
     'convit_*', 'levit*', 'visformer*', 'deit*', 'jx_nest_*', 'nest_*', 'xcit_*', 'crossvit_*', 'beit*',
     'poolformer_*', 'volo_*', 'sequencer2d_*', 'pvt_v2*', 'mvitv2*', 'gcvit*', 'efficientformer*',
-    'eva_*', 'flexivit*', 'eva02*', 'samvit_*'
+    'eva_*', 'flexivit*', 'eva02*', 'samvit_*', 'efficientvit_m*'
 ]
 NUM_NON_STD = len(NON_STD_FILTERS)
 

--- a/timm/models/__init__.py
+++ b/timm/models/__init__.py
@@ -17,6 +17,7 @@ from .edgenext import *
 from .efficientformer import *
 from .efficientformer_v2 import *
 from .efficientnet import *
+from .efficientvit_mit import *
 from .eva import *
 from .focalnet import *
 from .gcvit import *

--- a/timm/models/__init__.py
+++ b/timm/models/__init__.py
@@ -18,6 +18,7 @@ from .efficientformer import *
 from .efficientformer_v2 import *
 from .efficientnet import *
 from .efficientvit_mit import *
+from .efficientvit_msra import *
 from .eva import *
 from .focalnet import *
 from .gcvit import *

--- a/timm/models/efficientvit_mit.py
+++ b/timm/models/efficientvit_mit.py
@@ -53,7 +53,7 @@ class ConvNormAct(nn.Module):
         dilation=1,
         groups=1,
         bias=False,
-        dropout=0,
+        dropout=0.,
         norm_layer=nn.BatchNorm2d,
         act_layer=nn.ReLU,
     ):
@@ -248,7 +248,7 @@ class LiteMSA(nn.Module):
         # lightweight global attention
         q = self.kernel_func(q)
         k = self.kernel_func(k)
-        v = F.pad(v, (0, 1), mode="constant", value=1)
+        v = F.pad(v, (0, 1), mode="constant", value=1.)
 
         kv = k.transpose(-1, -2) @ v
         out = q @ kv
@@ -443,7 +443,7 @@ class ClassifierHead(nn.Module):
         in_channels,
         widths,
         n_classes=1000,
-        dropout=0,
+        dropout=0.,
         norm_layer=nn.BatchNorm2d,
         act_layer=nn.Hardswish,
         global_pool='avg',
@@ -547,7 +547,7 @@ class EfficientVit(nn.Module):
     def get_classifier(self):
         return self.head.classifier[-1]
 
-    def reset_classifier(self, num_classes, global_pool=None, dropout=0):
+    def reset_classifier(self, num_classes, global_pool=None):
         self.num_classes = num_classes
         if global_pool is not None:
             self.global_pool = global_pool
@@ -561,7 +561,7 @@ class EfficientVit(nn.Module):
             )
         else:
             if self.global_pool == 'avg':
-                self.head = SelectAdaptivePool2d(pool_type=global_pool, flatten=True)
+                self.head = SelectAdaptivePool2d(pool_type=self.global_pool, flatten=True)
             else:
                 self.head = nn.Identity()
 
@@ -592,6 +592,7 @@ def _cfg(url='', **kwargs):
         'classifier': 'head.classifier.4',
         'crop_pct': 0.95,
         'input_size': (3, 224, 224),
+        'pool_size': (7, 7),
         **kwargs,
     }
 
@@ -605,33 +606,33 @@ default_cfgs = generate_default_cfgs({
     ),
     'efficientvit_b1.r256_in1k': _cfg(
         hf_hub_id='timm/',
-        input_size=(3, 256, 256), crop_pct=1.0,
+        input_size=(3, 256, 256), pool_size=(8, 8), crop_pct=1.0,
     ),
     'efficientvit_b1.r288_in1k': _cfg(
         hf_hub_id='timm/',
-        input_size=(3, 288, 288), crop_pct=1.0,
+        input_size=(3, 288, 288), pool_size=(9, 9), crop_pct=1.0,
     ),
     'efficientvit_b2.r224_in1k': _cfg(
         hf_hub_id='timm/',
     ),
     'efficientvit_b2.r256_in1k': _cfg(
         hf_hub_id='timm/',
-        input_size=(3, 256, 256), crop_pct=1.0,
+        input_size=(3, 256, 256), pool_size=(8, 8), crop_pct=1.0,
     ),
     'efficientvit_b2.r288_in1k': _cfg(
         hf_hub_id='timm/',
-        input_size=(3, 288, 288), crop_pct=1.0,
+        input_size=(3, 288, 288), pool_size=(9, 9), crop_pct=1.0,
     ),
     'efficientvit_b3.r224_in1k': _cfg(
         hf_hub_id='timm/',
     ),
     'efficientvit_b3.r256_in1k': _cfg(
         hf_hub_id='timm/',
-        input_size=(3, 256, 256), crop_pct=1.0,
+        input_size=(3, 256, 256), pool_size=(8, 8), crop_pct=1.0,
     ),
     'efficientvit_b3.r288_in1k': _cfg(
         hf_hub_id='timm/',
-        input_size=(3, 288, 288), crop_pct=1.0,
+        input_size=(3, 288, 288), pool_size=(9, 9), crop_pct=1.0,
     ),
 })
 

--- a/timm/models/efficientvit_mit.py
+++ b/timm/models/efficientvit_mit.py
@@ -527,7 +527,7 @@ class EfficientVit(nn.Module):
             )
         else:
             if self.global_pool == 'avg':
-                self.head = SelectAdaptivePool2d(pool_type=global_pool, flatten=True, input_fmt='NCHW')
+                self.head = SelectAdaptivePool2d(pool_type=global_pool, flatten=True)
             else:
                 self.head = nn.Identity()
 
@@ -561,7 +561,7 @@ class EfficientVit(nn.Module):
             )
         else:
             if self.global_pool == 'avg':
-                self.head = SelectAdaptivePool2d(pool_type=global_pool, flatten=True, input_fmt='NCHW')
+                self.head = SelectAdaptivePool2d(pool_type=global_pool, flatten=True)
             else:
                 self.head = nn.Identity()
 

--- a/timm/models/efficientvit_mit.py
+++ b/timm/models/efficientvit_mit.py
@@ -1,0 +1,654 @@
+""" EfficientViT
+
+Paper: `Efficientvit: Enhanced linear attention for high-resolution low-computation visual recognition`
+    - https://arxiv.org/abs/2205.14756
+
+Adapted from official impl at https://github.com/mit-han-lab/efficientvit
+"""
+
+__all__ = ['EfficientViT']
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
+from ._registry import register_model, generate_default_cfgs
+from ._builder import build_model_with_cfg
+from ._manipulate import checkpoint_seq
+from functools import partial
+from timm.layers import SelectAdaptivePool2d
+from collections import OrderedDict
+
+
+def val2list(x: list or tuple or any, repeat_time=1):
+    if isinstance(x, (list, tuple)):
+        return list(x)
+    return [x for _ in range(repeat_time)]
+
+def val2tuple(x: list or tuple or any, min_len: int = 1, idx_repeat: int = -1):
+    # repeat elements if necessary
+    x = val2list(x)
+    if len(x) > 0:
+        x[idx_repeat:idx_repeat] = [x[idx_repeat] for _ in range(min_len - len(x))]
+
+    return tuple(x)
+
+def get_same_padding(kernel_size: int or tuple[int, ...]) -> int or tuple[int, ...]:
+    if isinstance(kernel_size, tuple):
+        return tuple([get_same_padding(ks) for ks in kernel_size])
+    else:
+        assert kernel_size % 2 > 0, "kernel size should be odd number"
+        return kernel_size // 2
+
+class ConvLayer(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size=3,
+        stride=1,
+        dilation=1,
+        groups=1,
+        use_bias=False,
+        dropout=0,
+        norm=nn.BatchNorm2d,
+        act_func=nn.ReLU,
+    ):
+        super(ConvLayer, self).__init__()
+
+        padding = get_same_padding(kernel_size)
+        padding *= dilation
+
+        self.dropout = nn.Dropout(dropout, inplace=False) if dropout > 0 else None
+        self.conv = nn.Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size=(kernel_size, kernel_size),
+            stride=(stride, stride),
+            padding=padding,
+            dilation=(dilation, dilation),
+            groups=groups,
+            bias=use_bias,
+        )
+        self.norm = norm(num_features=out_channels) if norm else None
+        self.act = act_func(inplace=True) if act_func else None
+
+    def forward(self, x):
+        if self.dropout is not None:
+            x = self.dropout(x)
+        x = self.conv(x)
+        if self.norm:
+            x = self.norm(x)
+        if self.act:
+            x = self.act(x)
+        return x
+
+
+class DSConv(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size=3,
+        stride=1,
+        use_bias=False,
+        norm=(nn.BatchNorm2d, nn.BatchNorm2d),
+        act_func=(nn.ReLU6, None),
+    ):
+        super(DSConv, self).__init__()
+
+        use_bias = val2tuple(use_bias, 2)
+        norm = val2tuple(norm, 2)
+        act_func = val2tuple(act_func, 2)
+
+        self.depth_conv = ConvLayer(
+            in_channels,
+            in_channels,
+            kernel_size,
+            stride,
+            groups=in_channels,
+            norm=norm[0],
+            act_func=act_func[0],
+            use_bias=use_bias[0],
+        )
+        self.point_conv = ConvLayer(
+            in_channels,
+            out_channels,
+            1,
+            norm=norm[1],
+            act_func=act_func[1],
+            use_bias=use_bias[1],
+        )
+
+    def forward(self, x):
+        x = self.depth_conv(x)
+        x = self.point_conv(x)
+        return x
+
+
+class MBConv(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size=3,
+        stride=1,
+        mid_channels=None,
+        expand_ratio=6,
+        use_bias=False,
+        norm=(nn.BatchNorm2d, nn.BatchNorm2d, nn.BatchNorm2d),
+        act_func=(nn.ReLU6, nn.ReLU6, None),
+    ):
+        super(MBConv, self).__init__()
+
+        use_bias = val2tuple(use_bias, 3)
+        norm = val2tuple(norm, 3)
+        act_func = val2tuple(act_func, 3)
+        mid_channels = mid_channels or round(in_channels * expand_ratio)
+
+        self.inverted_conv = ConvLayer(
+            in_channels,
+            mid_channels,
+            1,
+            stride=1,
+            norm=norm[0],
+            act_func=act_func[0],
+            use_bias=use_bias[0],
+        )
+        self.depth_conv = ConvLayer(
+            mid_channels,
+            mid_channels,
+            kernel_size,
+            stride=stride,
+            groups=mid_channels,
+            norm=norm[1],
+            act_func=act_func[1],
+            use_bias=use_bias[1],
+        )
+        self.point_conv = ConvLayer(
+            mid_channels,
+            out_channels,
+            1,
+            norm=norm[2],
+            act_func=act_func[2],
+            use_bias=use_bias[2],
+        )
+
+    def forward(self, x):
+        x = self.inverted_conv(x)
+        x = self.depth_conv(x)
+        x = self.point_conv(x)
+        return x
+
+
+class LiteMSA(nn.Module):
+    """Lightweight multi-scale attention"""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        heads: int or None = None,
+        heads_ratio: float = 1.0,
+        dim=8,
+        use_bias=False,
+        norm=(None, nn.BatchNorm2d),
+        act_func=(None, None),
+        kernel_func=nn.ReLU,
+        scales=(5,),
+    ):
+        super(LiteMSA, self).__init__()
+        heads = heads or int(in_channels // dim * heads_ratio)
+
+        total_dim = heads * dim
+
+        use_bias = val2tuple(use_bias, 2)
+        norm = val2tuple(norm, 2)
+        act_func = val2tuple(act_func, 2)
+
+        self.dim = dim
+        self.qkv = ConvLayer(
+            in_channels,
+            3 * total_dim,
+            1,
+            use_bias=use_bias[0],
+            norm=norm[0],
+            act_func=act_func[0],
+        )
+        self.aggreg = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Conv2d(
+                        3 * total_dim,
+                        3 * total_dim,
+                        scale,
+                        padding=get_same_padding(scale),
+                        groups=3 * total_dim,
+                        bias=use_bias[0],
+                    ),
+                    nn.Conv2d(3 * total_dim, 3 * total_dim, 1, groups=3 * heads, bias=use_bias[0]),
+                )
+                for scale in scales
+            ]
+        )
+        self.kernel_func = kernel_func(inplace=False)
+
+        self.proj = ConvLayer(
+            total_dim * (1 + len(scales)),
+            out_channels,
+            1,
+            use_bias=use_bias[1],
+            norm=norm[1],
+            act_func=act_func[1],
+        )
+
+    def forward(self, x):
+        B, _, H, W = list(x.size())
+
+        # generate multi-scale q, k, v
+        qkv = self.qkv(x)
+        multi_scale_qkv = [qkv]
+        for op in self.aggreg:
+            multi_scale_qkv.append(op(qkv))
+        multi_scale_qkv = torch.cat(multi_scale_qkv, dim=1)
+
+        multi_scale_qkv = torch.reshape(
+            multi_scale_qkv,
+            (
+                B,
+                -1,
+                3 * self.dim,
+                H * W,
+            ),
+        )
+        multi_scale_qkv = torch.transpose(multi_scale_qkv, -1, -2)
+        q, k, v = (
+            multi_scale_qkv[..., 0 : self.dim],
+            multi_scale_qkv[..., self.dim : 2 * self.dim],
+            multi_scale_qkv[..., 2 * self.dim :],
+        )
+
+        # lightweight global attention
+        q = self.kernel_func(q)
+        k = self.kernel_func(k)
+
+        trans_k = k.transpose(-1, -2)
+
+        v = F.pad(v, (0, 1), mode="constant", value=1)
+        kv = torch.matmul(trans_k, v)
+        out = torch.matmul(q, kv)
+        out = out[..., :-1] / (out[..., -1:] + 1e-15)
+
+        # final projecttion
+        out = torch.transpose(out, -1, -2)
+        out = torch.reshape(out, (B, -1, H, W))
+        out = self.proj(out)
+
+        return out
+
+class EfficientViTBlock(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        heads_ratio=1.0,
+        dim=32,
+        expand_ratio=4,
+        norm=nn.BatchNorm2d,
+        act_func=nn.Hardswish,
+    ):
+        super(EfficientViTBlock, self).__init__()
+        self.context_module = ResidualBlock(
+            LiteMSA(
+                in_channels=in_channels,
+                out_channels=in_channels,
+                heads_ratio=heads_ratio,
+                dim=dim,
+                norm=(None, norm),
+            ),
+            nn.Identity(),
+        )
+        local_module = MBConv(
+            in_channels=in_channels,
+            out_channels=in_channels,
+            expand_ratio=expand_ratio,
+            use_bias=(True, True, False),
+            norm=(None, None, norm),
+            act_func=(act_func, act_func, None),
+        )
+        self.local_module = ResidualBlock(local_module, nn.Identity())
+
+    def forward(self, x):
+        x = self.context_module(x)
+        x = self.local_module(x)
+        return x
+
+
+class ResidualBlock(nn.Module):
+    def __init__(
+        self,
+        main: nn.Module or None,
+        shortcut: nn.Module or None,
+        post_act=None,
+        pre_norm: nn.Module or None = None,
+    ):
+        super(ResidualBlock, self).__init__()
+
+        self.pre_norm = pre_norm
+        self.main = main
+        self.shortcut = shortcut
+        self.post_act = post_act(inplace=True) if post_act else nn.Identity()
+
+    def forward_main(self, x):
+        if self.pre_norm is None:
+            return self.main(x)
+        else:
+            return self.main(self.pre_norm(x))
+
+    def forward(self, x):
+        if self.main is None:
+            res = x
+        elif self.shortcut is None:
+            res = self.forward_main(x)
+        else:
+            res = self.forward_main(x) + self.shortcut(x)
+            if self.post_act:
+                res = self.post_act(res)
+        return res
+
+class ClsHead(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        width_list,
+        n_classes=1000,
+        dropout=0,
+        norm=nn.BatchNorm2d,
+        act_func=nn.Hardswish,
+        global_pool='avg',
+    ):
+        super(ClsHead, self).__init__()
+        self.ops = nn.Sequential(
+            ConvLayer(in_channels, width_list[0], 1, norm=norm, act_func=act_func),
+            SelectAdaptivePool2d(pool_type=global_pool, flatten=True, input_fmt='NCHW'),
+            nn.Linear(width_list[0], width_list[1], bias=False),
+            nn.LayerNorm(width_list[1]),
+            act_func(inplace=True),
+            nn.Dropout(dropout, inplace=False) if dropout else nn.Identity(),
+            nn.Linear(width_list[1], n_classes, bias=True),
+        )
+
+    def forward(self, x):
+        x = self.ops(x)
+        return x
+
+
+class EfficientViT(nn.Module):
+    def __init__(
+        self,
+        in_chans=3,
+        width_list=[],
+        depth_list=[],
+        dim=32,
+        expand_ratio=4,
+        norm=nn.BatchNorm2d,
+        act_func=nn.Hardswish,
+        global_pool='avg',
+        head_width_list=[],
+        head_dropout=0.0,
+        num_classes=1000,
+    ):
+        super(EfficientViT, self).__init__()
+        self.grad_checkpointing = False
+        self.global_pool = global_pool
+        # input stem
+        input_stem = [
+            ('in_conv', ConvLayer(
+                in_channels=3,
+                out_channels=width_list[0],
+                kernel_size=3,
+                stride=2,
+                norm=norm,
+                act_func=act_func,
+            ))
+        ]
+        stem_block = 0
+        for _ in range(depth_list[0]):
+            block = self.build_local_block(
+                in_channels=width_list[0],
+                out_channels=width_list[0],
+                stride=1,
+                expand_ratio=1,
+                norm=norm,
+                act_func=act_func,
+            )
+            input_stem.append((f'res{stem_block}', ResidualBlock(block, nn.Identity())))
+            stem_block += 1
+        in_channels = width_list[0]
+        self.stem = nn.Sequential(OrderedDict(input_stem))
+
+        self.feature_info = []
+        stages = []
+        stage_idx = 0
+        for w, d in zip(width_list[1:3], depth_list[1:3]):
+            stage = []
+            for i in range(d):
+                stride = 2 if i == 0 else 1
+                block = self.build_local_block(
+                    in_channels=in_channels,
+                    out_channels=w,
+                    stride=stride,
+                    expand_ratio=expand_ratio,
+                    norm=norm,
+                    act_func=act_func,
+                )
+                block = ResidualBlock(block, nn.Identity() if stride == 1 else None)
+                stage.append(block)
+                in_channels = w
+            stages.append(nn.Sequential(*stage))
+            self.feature_info += [dict(num_chs=in_channels, reduction=stride, module=f'stages.{stage_idx}')]
+            stage_idx += 1
+        
+        for w, d in zip(width_list[3:], depth_list[3:]):
+            stage = []
+            block = self.build_local_block(
+                in_channels=in_channels,
+                out_channels=w,
+                stride=2,
+                expand_ratio=expand_ratio,
+                norm=norm,
+                act_func=act_func,
+                fewer_norm=True,
+            )
+            stage.append(ResidualBlock(block, None))
+            in_channels = w
+
+            for _ in range(d):
+                stage.append(
+                    EfficientViTBlock(
+                        in_channels=in_channels,
+                        dim=dim,
+                        expand_ratio=expand_ratio,
+                        norm=norm,
+                        act_func=act_func,
+                    )
+                )
+            stages.append(nn.Sequential(*stage))
+            self.feature_info += [dict(num_chs=in_channels, reduction=stride, module=f'stages.{stage_idx}')]
+            stage_idx += 1
+        
+        self.stages = nn.Sequential(*stages)
+        self.num_features = in_channels
+        self.head_width_list = head_width_list
+        self.head_dropout = head_dropout
+        if num_classes > 0:
+            self.head = ClsHead(self.num_features, self.head_width_list, n_classes=num_classes, dropout=self.head_dropout, global_pool=self.global_pool)
+        else:
+            if global_pool is not None:
+                self.head = SelectAdaptivePool2d(pool_type=global_pool, flatten=True, input_fmt='NCHW')
+            else:
+                self.head = nn.Identity()
+
+    @staticmethod
+    def build_local_block(
+        in_channels: int,
+        out_channels: int,
+        stride: int,
+        expand_ratio: float,
+        norm: str,
+        act_func: str,
+        fewer_norm: bool = False,
+    ):
+        if expand_ratio == 1:
+            block = DSConv(
+                in_channels=in_channels,
+                out_channels=out_channels,
+                stride=stride,
+                use_bias=(True, False) if fewer_norm else False,
+                norm=(None, norm) if fewer_norm else norm,
+                act_func=(act_func, None),
+            )
+        else:
+            block = MBConv(
+                in_channels=in_channels,
+                out_channels=out_channels,
+                stride=stride,
+                expand_ratio=expand_ratio,
+                use_bias=(True, True, False) if fewer_norm else False,
+                norm=(None, None, norm) if fewer_norm else norm,
+                act_func=(act_func, act_func, None),
+            )
+        return block
+
+    @torch.jit.ignore
+    def group_matcher(self, coarse=False):
+        matcher = dict(
+            stem=r'^stem',  # stem and embed
+            blocks=[(r'^stages\.(\d+)', None)]
+        )
+        return matcher
+
+    @torch.jit.ignore
+    def set_grad_checkpointing(self, enable=True):
+        self.grad_checkpointing = enable
+
+    @torch.jit.ignore
+    def get_classifier(self):
+        return self.head
+
+    def reset_classifier(self, num_classes, global_pool=None, dropout=0):
+        self.num_classes = num_classes
+        if global_pool is not None:
+            self.global_pool = global_pool
+        if num_classes > 0:
+            self.head = ClsHead(self.num_features, self.head_width_list, n_classes=num_classes, dropout=self.head_dropout, global_pool=global_pool)
+        else:
+            if global_pool is not None:
+                self.head = SelectAdaptivePool2d(pool_type=global_pool, flatten=True, input_fmt='NCHW')
+            else:
+                self.head = nn.Identity()
+
+    def forward_features(self, x):
+        x = self.stem(x)
+        if self.grad_checkpointing and not torch.jit.is_scripting():
+            x = checkpoint_seq(self.stages, x)
+        else:
+            x = self.stages(x)
+        return x
+
+    def forward_head(self, x, pre_logits: bool = False):
+        return x if pre_logits else self.head(x)
+
+    def forward(self, x):
+        x = self.forward_features(x)
+        x = self.forward_head(x)
+        return x
+
+
+def checkpoint_filter_fn(state_dict, model):
+    target_keys = list(model.state_dict().keys())
+    if 'state_dict' in state_dict.keys():
+        state_dict = state_dict['state_dict']
+    out_dict = {}
+    for i, (k, v) in enumerate(state_dict.items()):
+        out_dict[target_keys[i]] = v
+    return out_dict
+
+
+def _cfg(url='', **kwargs):
+    return {
+        'url': url,
+        'num_classes': 1000,
+        'mean': IMAGENET_DEFAULT_MEAN,
+        'std': IMAGENET_DEFAULT_STD,
+        'first_conv': 'stem.in_conv.conv',
+        'classifier': 'head',
+        **kwargs,
+    }
+
+
+default_cfgs = generate_default_cfgs(
+    {
+        'efficientvit_b0.r224_in1k': _cfg(
+            # url='https://drive.google.com/file/d/1ganFBZmmvCTpgUwiLb8ePD6NBNxRyZDk/view?usp=drive_link'
+        ),
+        'efficientvit_b1.r224_in1k': _cfg(
+            # url='https://drive.google.com/file/d/1hKN_hvLG4nmRzbfzKY7GlqwpR5uKpOOk/view?usp=share_link'
+        ),
+        'efficientvit_b1.r256_in1k': _cfg(
+            # url='https://drive.google.com/file/d/1hXcG_jB0ODMOESsSkzVye-58B4F3Cahs/view?usp=share_link'
+        ),
+        'efficientvit_b1.r288_in1k': _cfg(
+            # url='https://drive.google.com/file/d/1sE_Suz9gOOUO7o5r9eeAT4nKK8Hrbhsu/view?usp=share_link'
+        ),
+        'efficientvit_b2.r224_in1k': _cfg(
+            # url='https://drive.google.com/file/d/1DiM-iqVGTrq4te8mefHl3e1c12u4qR7d/view?usp=share_link'
+        ),
+        'efficientvit_b2.r256_in1k': _cfg(
+            # url='https://drive.google.com/file/d/192OOk4ISitwlyW979M-FSJ_fYMMW9HQz/view?usp=share_link'
+        ),
+        'efficientvit_b2.r288_in1k': _cfg(
+            # url='https://drive.google.com/file/d/1aodcepOyne667hvBAGpf9nDwmd5g0NpU/view?usp=share_link'
+        ),
+        'efficientvit_b3.r224_in1k': _cfg(
+            # url='https://drive.google.com/file/d/18RZDGLiY8KsyJ7LGic4mg1JHwd-a_ky6/view?usp=share_link'
+        ),
+        'efficientvit_b3.r256_in1k': _cfg(
+            # url='https://drive.google.com/file/d/1y1rnir4I0XiId-oTCcHhs7jqnrHGFi-g/view?usp=share_link'
+        ),
+        'efficientvit_b3.r288_in1k': _cfg(
+            # url='https://drive.google.com/file/d/1KfwbGtlyFgslNr4LIHERv6aCfkItEvRk/view?usp=share_link'
+        ),
+    }
+)
+
+
+def _create_efficientvit(variant, pretrained=False, **kwargs):
+    model = build_model_with_cfg(
+        EfficientViT,
+        variant,
+        pretrained,
+        pretrained_filter_fn=checkpoint_filter_fn,
+        **kwargs
+    )
+    return model
+
+
+@register_model
+def efficientvit_b0(pretrained=False, **kwargs):
+    model_args = dict(width_list=[8, 16, 32, 64, 128], depth_list=[1, 2, 2, 2, 2], dim=16, head_width_list=[1024, 1280])
+    return _create_efficientvit('efficientvit_b0', pretrained=pretrained, **dict(model_args, **kwargs))
+
+@register_model
+def efficientvit_b1(pretrained=False, **kwargs):
+    model_args = dict(width_list=[16, 32, 64, 128, 256], depth_list=[1, 2, 3, 3, 4], dim=16, head_width_list=[1536, 1600])
+    return _create_efficientvit('efficientvit_b0', pretrained=pretrained, **dict(model_args, **kwargs))
+
+@register_model
+def efficientvit_b2(pretrained=False, **kwargs):
+    model_args = dict(width_list=[24, 48, 96, 192, 384], depth_list=[1, 3, 4, 4, 6], dim=32, head_width_list=[2304, 2560])
+    return _create_efficientvit('efficientvit_b0', pretrained=pretrained, **dict(model_args, **kwargs))
+
+@register_model
+def efficientvit_b3(pretrained=False, **kwargs):
+    model_args = dict(width_list=[32, 64, 128, 256, 512], depth_list=[1, 4, 6, 6, 9], dim=32, head_width_list=[2304, 2560])
+    return _create_efficientvit('efficientvit_b0', pretrained=pretrained, **dict(model_args, **kwargs))

--- a/timm/models/efficientvit_mit.py
+++ b/timm/models/efficientvit_mit.py
@@ -661,14 +661,14 @@ def efficientvit_b0(pretrained=False, **kwargs):
 @register_model
 def efficientvit_b1(pretrained=False, **kwargs):
     model_args = dict(width_list=[16, 32, 64, 128, 256], depth_list=[1, 2, 3, 3, 4], dim=16, head_width_list=[1536, 1600])
-    return _create_efficientvit('efficientvit_b0', pretrained=pretrained, **dict(model_args, **kwargs))
+    return _create_efficientvit('efficientvit_b1', pretrained=pretrained, **dict(model_args, **kwargs))
 
 @register_model
 def efficientvit_b2(pretrained=False, **kwargs):
     model_args = dict(width_list=[24, 48, 96, 192, 384], depth_list=[1, 3, 4, 4, 6], dim=32, head_width_list=[2304, 2560])
-    return _create_efficientvit('efficientvit_b0', pretrained=pretrained, **dict(model_args, **kwargs))
+    return _create_efficientvit('efficientvit_b2', pretrained=pretrained, **dict(model_args, **kwargs))
 
 @register_model
 def efficientvit_b3(pretrained=False, **kwargs):
     model_args = dict(width_list=[32, 64, 128, 256, 512], depth_list=[1, 4, 6, 6, 9], dim=32, head_width_list=[2304, 2560])
-    return _create_efficientvit('efficientvit_b0', pretrained=pretrained, **dict(model_args, **kwargs))
+    return _create_efficientvit('efficientvit_b3', pretrained=pretrained, **dict(model_args, **kwargs))

--- a/timm/models/efficientvit_msra.py
+++ b/timm/models/efficientvit_msra.py
@@ -384,6 +384,7 @@ class EfficientViTMSRA(nn.Module):
         return x
 
     def forward_head(self, x, pre_logits: bool = False):
+        x = self.global_pool(x)
         return x if pre_logits else self.head(x)
 
     def forward(self, x):

--- a/timm/models/efficientvit_msra.py
+++ b/timm/models/efficientvit_msra.py
@@ -518,6 +518,7 @@ def _cfg(url='', **kwargs):
         'std': IMAGENET_DEFAULT_STD,
         'first_conv': 'patch_embed.conv1.conv',
         'classifier': 'head.linear',
+        'fixed_input_size': True,
         **kwargs,
     }
 

--- a/timm/models/efficientvit_msra.py
+++ b/timm/models/efficientvit_msra.py
@@ -373,8 +373,8 @@ class EfficientViTMSRA(nn.Module):
         self.stages = nn.Sequential(*stages)
 
         self.global_pool = SelectAdaptivePool2d(pool_type=global_pool, flatten=True, input_fmt='NCHW')
-        self.out_dims = embed_dim[-1]
-        self.head = BNLinear(self.out_dims, num_classes) if num_classes > 0 else torch.nn.Identity()
+        self.num_features = embed_dim[-1]
+        self.head = BNLinear(self.num_features, num_classes) if num_classes > 0 else torch.nn.Identity()
 
     @torch.jit.ignore
     def group_matcher(self, coarse=False):
@@ -396,7 +396,7 @@ class EfficientViTMSRA(nn.Module):
         self.num_classes = num_classes
         if global_pool is not None:
             self.global_pool = SelectAdaptivePool2d(pool_type=global_pool, flatten=True, input_fmt='NCHW')
-        self.head = BNLinear(self.out_dims, num_classes) if num_classes > 0 else torch.nn.Identity()
+        self.head = BNLinear(self.num_features, num_classes) if num_classes > 0 else torch.nn.Identity()
 
     def forward_features(self, x):
         x = self.patch_embed(x)

--- a/timm/models/efficientvit_msra.py
+++ b/timm/models/efficientvit_msra.py
@@ -1,0 +1,441 @@
+""" EfficientViT (by MSRA)
+
+Paper: `EfficientViT: Memory Efficient Vision Transformer with Cascaded Group Attention`
+    - https://arxiv.org/abs/2305.07027
+
+Adapted from official impl at https://github.com/microsoft/Cream/tree/main/EfficientViT
+"""
+
+__all__ = ['EfficientViTMSRA']
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
+from timm.models.vision_transformer import trunc_normal_
+from timm.models.layers import SqueezeExcite
+from ._registry import register_model, generate_default_cfgs
+from ._builder import build_model_with_cfg
+from ._manipulate import checkpoint_seq
+from functools import partial
+from collections import OrderedDict
+import itertools
+
+
+class ConvBN(torch.nn.Sequential):
+    def __init__(self, a, b, ks=1, stride=1, pad=0, dilation=1, groups=1, bn_weight_init=1):
+        super().__init__()
+        self.add_module('c', torch.nn.Conv2d(
+            a, b, ks, stride, pad, dilation, groups, bias=False))
+        self.add_module('bn', torch.nn.BatchNorm2d(b))
+        torch.nn.init.constant_(self.bn.weight, bn_weight_init)
+        torch.nn.init.constant_(self.bn.bias, 0)
+
+    @torch.no_grad()
+    def fuse(self):
+        c, bn = self._modules.values()
+        w = bn.weight / (bn.running_var + bn.eps)**0.5
+        w = c.weight * w[:, None, None, None]
+        b = bn.bias - bn.running_mean * bn.weight / \
+            (bn.running_var + bn.eps)**0.5
+        m = torch.nn.Conv2d(w.size(1) * self.c.groups, w.size(
+            0), w.shape[2:], stride=self.c.stride, padding=self.c.padding, dilation=self.c.dilation, groups=self.c.groups)
+        m.weight.data.copy_(w)
+        m.bias.data.copy_(b)
+        return m
+
+class BNLinear(torch.nn.Sequential):
+    def __init__(self, a, b, bias=True, std=0.02):
+        super().__init__()
+        self.add_module('bn', torch.nn.BatchNorm1d(a))
+        self.add_module('l', torch.nn.Linear(a, b, bias=bias))
+        trunc_normal_(self.l.weight, std=std)
+        if bias:
+            torch.nn.init.constant_(self.l.bias, 0)
+
+    @torch.no_grad()
+    def fuse(self):
+        bn, l = self._modules.values()
+        w = bn.weight / (bn.running_var + bn.eps)**0.5
+        b = bn.bias - self.bn.running_mean * \
+            self.bn.weight / (bn.running_var + bn.eps)**0.5
+        w = l.weight * w[None, :]
+        if l.bias is None:
+            b = b @ self.l.weight.T
+        else:
+            b = (l.weight @ b[:, None]).view(-1) + self.l.bias
+        m = torch.nn.Linear(w.size(1), w.size(0))
+        m.weight.data.copy_(w)
+        m.bias.data.copy_(b)
+        return m
+
+class PatchMerging(torch.nn.Module):
+    def __init__(self, dim, out_dim):
+        super().__init__()
+        hid_dim = int(dim * 4)
+        self.conv1 = ConvBN(dim, hid_dim, 1, 1, 0)
+        self.act = torch.nn.ReLU()
+        self.conv2 = ConvBN(hid_dim, hid_dim, 3, 2, 1, groups=hid_dim)
+        self.se = SqueezeExcite(hid_dim, .25)
+        self.conv3 = ConvBN(hid_dim, out_dim, 1, 1, 0)
+
+    def forward(self, x):
+        x = self.conv3(self.se(self.act(self.conv2(self.act(self.conv1(x))))))
+        return x
+
+class ResidualDrop(torch.nn.Module):
+    def __init__(self, m, drop=0.):
+        super().__init__()
+        self.m = m
+        self.drop = drop
+
+    def forward(self, x):
+        if self.training and self.drop > 0:
+            return x + self.m(x) * torch.rand(x.size(0), 1, 1, 1,
+                                              device=x.device).ge_(self.drop).div(1 - self.drop).detach()
+        else:
+            return x + self.m(x)
+
+class FFN(torch.nn.Module):
+    def __init__(self, ed, h):
+        super().__init__()
+        self.pw1 = ConvBN(ed, h)
+        self.act = torch.nn.ReLU()
+        self.pw2 = ConvBN(h, ed, bn_weight_init=0)
+
+    def forward(self, x):
+        x = self.pw2(self.act(self.pw1(x)))
+        return x
+
+class CascadedGroupAttention(torch.nn.Module):
+    r""" Cascaded Group Attention.
+
+    Args:
+        dim (int): Number of input channels.
+        key_dim (int): The dimension for query and key.
+        num_heads (int): Number of attention heads.
+        attn_ratio (int): Multiplier for the query dim for value dimension.
+        resolution (int): Input resolution, correspond to the window size.
+        kernels (List[int]): The kernel size of the dw conv on query.
+    """
+    def __init__(self, dim, key_dim, num_heads=8,
+                 attn_ratio=4,
+                 resolution=14,
+                 kernels=[5, 5, 5, 5],):
+        super().__init__()
+        self.num_heads = num_heads
+        self.scale = key_dim ** -0.5
+        self.key_dim = key_dim
+        self.d = int(attn_ratio * key_dim)
+        self.attn_ratio = attn_ratio
+
+        qkvs = []
+        dws = []
+        for i in range(num_heads):
+            qkvs.append(ConvBN(dim // (num_heads), self.key_dim * 2 + self.d))
+            dws.append(ConvBN(self.key_dim, self.key_dim, kernels[i], 1, kernels[i]//2, groups=self.key_dim))
+        self.qkvs = torch.nn.ModuleList(qkvs)
+        self.dws = torch.nn.ModuleList(dws)
+        self.proj = torch.nn.Sequential(
+            torch.nn.ReLU(),
+            ConvBN(self.d * num_heads, dim, bn_weight_init=0)
+        )
+
+        points = list(itertools.product(range(resolution), range(resolution)))
+        N = len(points)
+        attention_offsets = {}
+        idxs = []
+        for p1 in points:
+            for p2 in points:
+                offset = (abs(p1[0] - p2[0]), abs(p1[1] - p2[1]))
+                if offset not in attention_offsets:
+                    attention_offsets[offset] = len(attention_offsets)
+                idxs.append(attention_offsets[offset])
+        self.attention_biases = torch.nn.Parameter(
+            torch.zeros(num_heads, len(attention_offsets)))
+        self.register_buffer('attention_bias_idxs',
+                             torch.LongTensor(idxs).view(N, N))
+
+    @torch.no_grad()
+    def train(self, mode=True):
+        super().train(mode)
+        if mode and hasattr(self, 'ab'):
+            del self.ab
+        else:
+            self.ab = self.attention_biases[:, self.attention_bias_idxs]
+
+    def forward(self, x):  # x (B,C,H,W)
+        B, C, H, W = x.shape
+        trainingab = self.attention_biases[:, self.attention_bias_idxs]
+        feats_in = x.chunk(len(self.qkvs), dim=1)
+        feats_out = []
+        feat = feats_in[0]
+        for i, qkv in enumerate(self.qkvs):
+            if i > 0: # add the previous output to the input
+                feat = feat + feats_in[i]
+            feat = qkv(feat)
+            q, k, v = feat.view(B, -1, H, W).split([self.key_dim, self.key_dim, self.d], dim=1) # B, C/h, H, W
+            q = self.dws[i](q)
+            q, k, v = q.flatten(2), k.flatten(2), v.flatten(2) # B, C/h, N
+            attn = (
+                (q.transpose(-2, -1) @ k) * self.scale
+                +
+                (trainingab[i] if self.training else self.ab[i])
+            )
+            attn = attn.softmax(dim=-1) # BNN
+            feat = (v @ attn.transpose(-2, -1)).view(B, self.d, H, W) # BCHW
+            feats_out.append(feat)
+        x = self.proj(torch.cat(feats_out, 1))
+        return x
+
+class LocalWindowAttention(torch.nn.Module):
+    r""" Local Window Attention.
+
+    Args:
+        dim (int): Number of input channels.
+        key_dim (int): The dimension for query and key.
+        num_heads (int): Number of attention heads.
+        attn_ratio (int): Multiplier for the query dim for value dimension.
+        resolution (int): Input resolution.
+        window_resolution (int): Local window resolution.
+        kernels (List[int]): The kernel size of the dw conv on query.
+    """
+    def __init__(self, dim, key_dim, num_heads=8,
+                 attn_ratio=4,
+                 resolution=14,
+                 window_resolution=7,
+                 kernels=[5, 5, 5, 5],):
+        super().__init__()
+        self.dim = dim
+        self.num_heads = num_heads
+        self.resolution = resolution
+        assert window_resolution > 0, 'window_size must be greater than 0'
+        self.window_resolution = window_resolution
+        
+        window_resolution = min(window_resolution, resolution)
+        self.attn = CascadedGroupAttention(dim, key_dim, num_heads,
+                                attn_ratio=attn_ratio, 
+                                resolution=window_resolution,
+                                kernels=kernels,)
+
+    def forward(self, x):
+        H = W = self.resolution
+        B, C, H_, W_ = x.shape
+        # Only check this for classifcation models
+        assert H == H_ and W == W_, 'input feature has wrong size, expect {}, got {}'.format((H, W), (H_, W_))
+               
+        if H <= self.window_resolution and W <= self.window_resolution:
+            x = self.attn(x)
+        else:
+            x = x.permute(0, 2, 3, 1)
+            pad_b = (self.window_resolution - H %
+                     self.window_resolution) % self.window_resolution
+            pad_r = (self.window_resolution - W %
+                     self.window_resolution) % self.window_resolution
+            padding = pad_b > 0 or pad_r > 0
+
+            if padding:
+                x = torch.nn.functional.pad(x, (0, 0, 0, pad_r, 0, pad_b))
+
+            pH, pW = H + pad_b, W + pad_r
+            nH = pH // self.window_resolution
+            nW = pW // self.window_resolution
+            # window partition, BHWC -> B(nHh)(nWw)C -> BnHnWhwC -> (BnHnW)hwC -> (BnHnW)Chw
+            x = x.view(B, nH, self.window_resolution, nW, self.window_resolution, C).transpose(2, 3).reshape(
+                B * nH * nW, self.window_resolution, self.window_resolution, C
+            ).permute(0, 3, 1, 2)
+            x = self.attn(x)
+            # window reverse, (BnHnW)Chw -> (BnHnW)hwC -> BnHnWhwC -> B(nHh)(nWw)C -> BHWC
+            x = x.permute(0, 2, 3, 1).view(B, nH, nW, self.window_resolution, self.window_resolution,
+                       C).transpose(2, 3).reshape(B, pH, pW, C)
+            if padding:
+                x = x[:, :H, :W].contiguous()
+            x = x.permute(0, 3, 1, 2)
+        return x
+
+class EfficientViTBlock(torch.nn.Module):    
+    """ A basic EfficientViT building block.
+
+    Args:
+        ed (int): Number of input channels.
+        kd (int): Dimension for query and key in the token mixer.
+        nh (int): Number of attention heads.
+        ar (int): Multiplier for the query dim for value dimension.
+        resolution (int): Input resolution.
+        window_resolution (int): Local window resolution.
+        kernels (List[int]): The kernel size of the dw conv on query.
+    """
+    def __init__(self,ed, kd, nh=8,
+                 ar=4,
+                 resolution=14,
+                 window_resolution=7,
+                 kernels=[5, 5, 5, 5],):
+        super().__init__()
+            
+        self.dw0 = ResidualDrop(ConvBN(ed, ed, 3, 1, 1, groups=ed, bn_weight_init=0.))
+        self.ffn0 = ResidualDrop(FFN(ed, int(ed * 2)))
+
+        self.mixer = ResidualDrop(
+            LocalWindowAttention(ed, kd, nh, attn_ratio=ar, resolution=resolution,
+                                    window_resolution=window_resolution, kernels=kernels))
+                
+        self.dw1 = ResidualDrop(ConvBN(ed, ed, 3, 1, 1, groups=ed, bn_weight_init=0.))
+        self.ffn1 = ResidualDrop(FFN(ed, int(ed * 2)))
+
+    def forward(self, x):
+        return self.ffn1(self.dw1(self.mixer(self.ffn0(self.dw0(x)))))
+
+class PatchEmbedding(torch.nn.Sequential):
+    def __init__(self, in_chans, dim):
+        super().__init__()
+        self.add_module('conv1', ConvBN(in_chans, dim // 8, 3, 2, 1))
+        self.add_module('relu1', torch.nn.ReLU())
+        self.add_module('conv2', ConvBN(dim // 8, dim // 4, 3, 2, 1))
+        self.add_module('relu2', torch.nn.ReLU())
+        self.add_module('conv3', ConvBN(dim // 4, dim // 2, 3, 2, 1))
+        self.add_module('relu3', torch.nn.ReLU())
+        self.add_module('conv4', ConvBN(dim // 2, dim, 3, 2, 1))
+        self.patch_size = 16
+
+class EfficientViTMSRA(nn.Module):
+    def __init__(
+        self,
+        img_size=224,
+        in_chans=3,
+        num_classes=1000,
+        embed_dim=[64, 128, 192],
+        key_dim=[16, 16, 16],
+        depth=[1, 2, 3],
+        num_heads=[4, 4, 4],
+        window_size=[7, 7, 7],
+        kernels=[5, 5, 5, 5],
+        down_ops=[[''], ['subsample', 2], ['subsample', 2]],
+        global_pool='avg',
+    ):
+        super(EfficientViTMSRA, self).__init__()
+        self.grad_checkpointing = False
+        resolution = img_size
+        # Patch embedding
+        self.patch_embed = PatchEmbedding(in_chans, embed_dim[0])
+        stride = self.patch_embed.patch_size
+        resolution = img_size // self.patch_embed.patch_size
+
+        attn_ratio = [embed_dim[i] / (key_dim[i] * num_heads[i]) for i in range(len(embed_dim))]
+        self.feature_info = []
+        stages = []
+        self.feature_info += [dict(num_chs=embed_dim[0], reduction=stride, module=f'stages.{0}')]
+
+         # Build EfficientViT blocks
+        for i, (ed, kd, dpth, nh, ar, wd, do) in enumerate(
+                zip(embed_dim, key_dim, depth, num_heads, attn_ratio, window_size, down_ops)):
+            blocks = []
+            if do[0] == 'subsample':
+                # Build EfficientViT downsample block
+                resolution_ = (resolution - 1) // do[1] + 1
+                blocks.append(torch.nn.Sequential(ResidualDrop(ConvBN(embed_dim[i], embed_dim[i], 3, 1, 1, groups=embed_dim[i])),
+                                    ResidualDrop(FFN(embed_dim[i], int(embed_dim[i] * 2))),))
+                blocks.append(PatchMerging(*embed_dim[i:i + 2], resolution))
+                resolution = resolution_
+                blocks.append(torch.nn.Sequential(ResidualDrop(ConvBN(embed_dim[i + 1], embed_dim[i + 1], 3, 1, 1, groups=embed_dim[i + 1])),
+                                    ResidualDrop(FFN(embed_dim[i + 1], int(embed_dim[i + 1] * 2))),))
+                stride *= 2
+            for d in range(dpth):
+                blocks.append(EfficientViTBlock(ed, kd, nh, ar, resolution, wd, kernels))
+            stages.append(nn.Sequential(*blocks))
+            self.feature_info += [dict(num_chs=embed_dim[i+1], reduction=stride, module=f'stages.{i+1}')]
+        
+        self.stages = nn.Sequential(*stages)
+
+        self.global_pool = SelectAdaptivePool2d(pool_type=global_pool, flatten=True, input_fmt='NCHW')
+        self.head = BNLinear(embed_dim[-1], num_classes) if num_classes > 0 else torch.nn.Identity()
+
+    @torch.jit.ignore
+    def group_matcher(self, coarse=False):
+        matcher = dict(
+            stem=r'^patch_embed',
+            blocks=[(r'^stages\.(\d+)', None)]
+        )
+        return matcher
+
+    @torch.jit.ignore
+    def set_grad_checkpointing(self, enable=True):
+        self.grad_checkpointing = enable
+
+    @torch.jit.ignore
+    def get_classifier(self):
+        return self.head
+
+    def reset_classifier(self, num_classes, global_pool=None):
+        self.num_classes = num_classes
+        if global_pool is not None:
+            self.global_pool = SelectAdaptivePool2d(pool_type=global_pool, flatten=True, input_fmt='NCHW')
+        self.head = BNLinear(embed_dim[-1], num_classes) if num_classes > 0 else torch.nn.Identity()
+
+    def forward_features(self, x):
+        x = self.patch_embed(x)
+        if self.grad_checkpointing and not torch.jit.is_scripting():
+            x = checkpoint_seq(self.stages, x)
+        else:
+            x = self.stages(x)
+        return x
+
+    def forward_head(self, x, pre_logits: bool = False):
+        return x if pre_logits else self.head(x)
+
+    def forward(self, x):
+        x = self.forward_features(x)
+        x = self.forward_head(x)
+        return x
+
+
+def checkpoint_filter_fn(state_dict, model):
+    target_keys = list(model.state_dict().keys())
+    if 'state_dict' in state_dict.keys():
+        state_dict = state_dict['state_dict']
+    out_dict = {}
+    for i, (k, v) in enumerate(state_dict.items()):
+        out_dict[target_keys[i]] = v
+    return out_dict
+
+
+def _cfg(url='', **kwargs):
+    return {
+        'url': url,
+        'num_classes': 1000,
+        'mean': IMAGENET_DEFAULT_MEAN,
+        'std': IMAGENET_DEFAULT_STD,
+        'first_conv': 'stem.in_conv.conv',
+        'classifier': 'head',
+        **kwargs,
+    }
+
+
+default_cfgs = generate_default_cfgs(
+    {
+        'efficientvit_m0.r224_in1k': _cfg(
+            url='https://github.com/xinyuliu-jeffrey/EfficientViT_Model_Zoo/releases/download/v1.0/efficientvit_m0.pth'
+        ),
+    }
+)
+
+
+def _create_efficientvit_msra(variant, pretrained=False, **kwargs):
+    model = build_model_with_cfg(
+        EfficientViTMSRA,
+        variant,
+        pretrained,
+        pretrained_filter_fn=checkpoint_filter_fn,
+        **kwargs
+    )
+    return model
+
+
+@register_model
+def efficientvit_m0(pretrained=False, **kwargs):
+    model_args = dict(img_size=224,
+                      embed_dim=[64, 128, 192],
+                      depth=[1, 2, 3],
+                      num_heads=[4, 4, 4],
+                      window_size=[7, 7, 7],
+                      kernels=[5, 5, 5, 5])
+    return _create_efficientvit_msra('efficientvit_m0', pretrained=pretrained, **dict(model_args, **kwargs))


### PR DESCRIPTION
Implement of two completely different models with the same name: “EfficientViT”

**EfficientViT (MIT)**:
EfficientViT: Lightweight Multi-Scale Attention for On-Device Semantic Segmentation
From MIT (Song Han's Lab). 

EfficientViT is a new family of vision models for efficient high-resolution vision, especially segmentation. The model is relatively larger.

github: https://github.com/mit-han-lab/efficientvit
paper: https://arxiv.org/abs/2205.14756

![image](https://github.com/huggingface/pytorch-image-models/assets/19152032/27b74e95-5251-4596-a656-531fa139f470)
![image](https://github.com/huggingface/pytorch-image-models/assets/19152032/dfc375fb-d994-4edd-8829-5a7e4c2dec4c)

**EfficientViT (MSRA)**:
EfficientViT: Memory Efficient Vision Transformer with Cascaded Group Attention
From MicroSoft Research Asia(MSRA).

This EfficientViT is relatively smaller for edge devices.

github: https://github.com/microsoft/Cream/tree/main/EfficientViT
paper: https://arxiv.org/abs/2305.07027

![image](https://github.com/huggingface/pytorch-image-models/assets/19152032/77f9d025-a23c-406d-8e3b-b1bafed181bf)


**I have verified:**
The weight loading of these models are right. The Inference result is also aligned with the original imple.

**Need help:**
* In ‘efficientvit_mit.py’, the url of original model weights is Google Drive links, and needs to be uploaded to HuggingFace Hub.
* In 'efficientvit_msra', the small model only has 3 stages of features,  so it cannot pass the test : "all models here should have at least 4 feature levels by default "

