### PR TITLE
Set self.num_features to neck_chans if neck_chans > 0 for vision_transformer_sam

### DIFF
--- a/timm/models/vision_transformer_sam.py
+++ b/timm/models/vision_transformer_sam.py
@@ -434,6 +434,7 @@ class VisionTransformerSAM(nn.Module):
                 ),
                 LayerNorm2d(neck_chans),
             )
+            self.num_features = neck_chans
         else:
             self.neck = nn.Identity()
             neck_chans = embed_dim


### PR DESCRIPTION
Knowing the number of feature channels is crucial when this neural network is used as a backbone in other systems. It allows for better integration and adaptability with various architectures that might require information about the dimensions of the output features. I think that self.num_features should be neck_chans if neck_chans > 0.