### PR TITLE
Fix typo in efficientformer_v2

### DIFF
--- a/timm/models/efficientformer_v2.py
+++ b/timm/models/efficientformer_v2.py
@@ -232,7 +232,7 @@ class Attention2dDownsample(torch.nn.Module):
 
         self.attention_biases = nn.Parameter(torch.zeros(num_heads, self.N))
         k_pos = torch.stack(torch.meshgrid(torch.arange(
-            self.resolution[1]),
+            self.resolution[0]),
             torch.arange(self.resolution[1]))).flatten(1)
         q_pos = torch.stack(torch.meshgrid(
             torch.arange(0, self.resolution[0], step=2),


### PR DESCRIPTION
Typo fix in efficientformer_v2.py
`torch.arange(self.resolution[1]), torch.arange(self.resolution[1])`
-> `torch.arange(self.resolution[0]), torch.arange(self.resolution[1])`