### PR TITLE
Added missing RuntimeError to builder functions of models that do not currently support feature extraction

### DIFF
--- a/timm/models/convmixer.py
+++ b/timm/models/convmixer.py
@@ -101,6 +101,9 @@ class ConvMixer(nn.Module):
 
 
 def _create_convmixer(variant, pretrained=False, **kwargs):
+    if kwargs.get('features_only', None):
+        raise RuntimeError('features_only not implemented for ConvMixer models.')
+
     return build_model_with_cfg(ConvMixer, variant, pretrained, **kwargs)
 
 

--- a/timm/models/efficientformer.py
+++ b/timm/models/efficientformer.py
@@ -534,6 +534,9 @@ default_cfgs = generate_default_cfgs({
 
 
 def _create_efficientformer(variant, pretrained=False, **kwargs):
+    if kwargs.get('features_only', None):
+        raise RuntimeError('features_only not implemented for EfficientFormer models.')
+
     model = build_model_with_cfg(
         EfficientFormer, variant, pretrained,
         pretrained_filter_fn=_checkpoint_filter_fn,

--- a/timm/models/mvitv2.py
+++ b/timm/models/mvitv2.py
@@ -948,6 +948,9 @@ model_cfgs = dict(
 
 
 def _create_mvitv2(variant, cfg_variant=None, pretrained=False, **kwargs):
+    if kwargs.get('features_only', None):
+        raise RuntimeError('features_only not implemented for Multiscale Vision Transformer models.')
+
     return build_model_with_cfg(
         MultiScaleVit,
         variant,

--- a/timm/models/xcit.py
+++ b/timm/models/xcit.py
@@ -497,6 +497,9 @@ def checkpoint_filter_fn(state_dict, model):
 
 
 def _create_xcit(variant, pretrained=False, default_cfg=None, **kwargs):
+    if kwargs.get('features_only', None):
+        raise RuntimeError('features_only not implemented for Cross-Covariance Image Transformers models.')
+
     model = build_model_with_cfg(
         Xcit,
         variant,


### PR DESCRIPTION
The following 4 models are missing RuntimeErrors to be raised when `features_only=True` is passed during model creation:

 - ConvMixer
 - EfficientFormer
 - MultiScaleVit
 - Xcit

I added the missing guard statement to each constructor function matching the style of the other guard statements from other models. For the model's name in the error message, I used the name given by the designer of the model architecture in the associated white paper. The names are:

 - ConvMixer -> "ConvMixer"
 - EfficientFormer -> "EfficientFormer"
 - MultiScaleVit -> "Multiscale Vision Transformer"
 - Xcit -> "Cross-Covariance Image Transformers"

Let me know if any changes need to be made.

The associated issue is #1957 
