### PR TITLE
add input_size & batch_size to onnx_export

### DIFF
--- a/onnx_export.py
+++ b/onnx_export.py
@@ -90,6 +90,8 @@ def main():
         check_forward=args.check_forward,
         training=args.training,
         verbose=args.verbose,
+        input_size=(3, args.img_size, args.img_size),
+        batch_size=args.batch_size,
     )
 
 


### PR DESCRIPTION
After exporting custom model to onnx, noticed the input size was `(3, 224, 224)` despite having trained the model on image size of `640`.
After looking at the export script, I noticed that the input size is not passed to the export function.

I also passed the batch size, since the default batch size in `export_onnx()` is 64 and when working with a large image size, it consumes a lot of memory during the export.