### PR TITLE
fix doc typo in resnetv2

### DIFF
--- a/timm/models/resnetv2.py
+++ b/timm/models/resnetv2.py
@@ -1,6 +1,6 @@
 """Pre-Activation ResNet v2 with GroupNorm and Weight Standardization.
 
-A PyTorch implementation of ResNetV2 adapted from the Google Big-Transfoer (BiT) source code
+A PyTorch implementation of ResNetV2 adapted from the Google Big-Transfer (BiT) source code
 at https://github.com/google-research/big_transfer to match timm interfaces. The BiT weights have
 been included here as pretrained models from their original .NPZ checkpoints.
 


### PR DESCRIPTION
I found there is a little typo in thd doc string on the implementation of resnetv2. Just change it!