### PR TITLE
fast_vit: propagate act_layer argument

### DIFF
--- a/timm/models/fastvit.py
+++ b/timm/models/fastvit.py
@@ -421,7 +421,8 @@ class ReparamLargeKernelConv(nn.Module):
 def convolutional_stem(
         in_chs: int,
         out_chs: int,
-        inference_mode: bool = False
+        inference_mode: bool = False,
+        act_layer: nn.Module = nn.GELU,
 ) -> nn.Sequential:
     """Build convolutional stem with MobileOne blocks.
 
@@ -439,6 +440,7 @@ def convolutional_stem(
             out_chs=out_chs,
             kernel_size=3,
             stride=2,
+            act_layer=act_layer,
             inference_mode=inference_mode,
         ),
         MobileOneBlock(
@@ -447,13 +449,15 @@ def convolutional_stem(
             kernel_size=3,
             stride=2,
             group_size=1,
+            act_layer=act_layer,
             inference_mode=inference_mode,
         ),
         MobileOneBlock(
             in_chs=out_chs,
             out_chs=out_chs,
             kernel_size=1,
-            stride=1,            
+            stride=1,
+            act_layer=act_layer,
             inference_mode=inference_mode,
         ),
     )
@@ -1121,6 +1125,7 @@ class FastVit(nn.Module):
             in_chans,
             embed_dims[0],
             inference_mode,
+            act_layer
         )
 
         # Build the main stages of the network architecture

--- a/timm/models/fastvit.py
+++ b/timm/models/fastvit.py
@@ -421,8 +421,8 @@ class ReparamLargeKernelConv(nn.Module):
 def convolutional_stem(
         in_chs: int,
         out_chs: int,
-        inference_mode: bool = False,
         act_layer: nn.Module = nn.GELU,
+        inference_mode: bool = False
 ) -> nn.Sequential:
     """Build convolutional stem with MobileOne blocks.
 
@@ -1124,8 +1124,8 @@ class FastVit(nn.Module):
         self.stem = convolutional_stem(
             in_chans,
             embed_dims[0],
+            act_layer,
             inference_mode,
-            act_layer
         )
 
         # Build the main stages of the network architecture
@@ -1187,6 +1187,7 @@ class FastVit(nn.Module):
                 group_size=1,
                 inference_mode=inference_mode,
                 use_se=True,
+                act_layer=act_layer,
                 num_conv_branches=1,
             )
             self.head = ClassifierHead(


### PR DESCRIPTION
Currently GELU will still be used in some modules of fast_vit even if the act_layer argument is set. 