### PR TITLE
Removing unused self.drop

### DIFF
--- a/timm/layers/mlp.py
+++ b/timm/layers/mlp.py
@@ -130,8 +130,6 @@ class SwiGLU(nn.Module):
         self.fc2 = nn.Linear(hidden_features, out_features, bias=bias[1])
         self.drop2 = nn.Dropout(drop_probs[1])
 
-        self.drop = nn.Dropout(drop)
-
     def init_weights(self):
         # override init of fc1 w/ gate portion set to weight near zero, bias=1
         nn.init.ones_(self.fc1_g.bias)


### PR DESCRIPTION
I'm playing around with some custom SwiGlu MLP stuff & found this that seems to be unused that will cause the code to crash if `drop=(0.0,0.0)` is passed into the constructor (which is allowed by `to_2tuple()`). Removing as it seems like an artifact from an older API.