### PR TITLE
Adjust support for register tokens and add support for DINOv2 backbones with registers

### DIFF
--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -486,7 +486,7 @@ class VisionTransformer(nn.Module):
         self.reg_token = nn.Parameter(torch.zeros(1, reg_tokens, embed_dim)) if reg_tokens else None
         pos_embed_len = num_patches
         if not no_embed_class:
-            pos_embed_len += 1
+            pos_embed_len += 1 if self.cls_token is not None else 0
         if not no_embed_register:
             pos_embed_len += reg_tokens
         self.pos_embed = nn.Parameter(torch.randn(1, pos_embed_len, embed_dim) * .02)
@@ -585,7 +585,7 @@ class VisionTransformer(nn.Module):
             B, H, W, C = x.shape
             num_prefix_tokens = 0
             if not self.no_embed_class:
-                num_prefix_tokens += 1
+                num_prefix_tokens += 1 if self.cls_token is not None else 0
             if not self.no_embed_register:
                 num_prefix_tokens += self.reg_tokens
             print(num_prefix_tokens)


### PR DESCRIPTION
- Make applying positional encoding to register tokens optional (not done in DINOv2)
- Add missing initialization for register tokens
- Add support for DINOv2 backbones with registers (from [Vision Transformers Need Registers](https://arxiv.org/abs/2309.16588))

Test: loaded DINOv2 backbones w/ registers with both `timm` and DINOv2's [reference codebase](https://github.com/facebookresearch/dinov2) and matched inference results to 1e-4 absolute tolerance (same as for DINOv2 backbones w/o registers) .