### PR TITLE
Fix bad import path

### DIFF
--- a/timm/layers/create_norm.py
+++ b/timm/layers/create_norm.py
@@ -11,7 +11,7 @@ from typing import Type
 import torch.nn as nn
 
 from .norm import GroupNorm, GroupNorm1, LayerNorm, LayerNorm2d, RmsNorm
-from torchvision.ops import FrozenBatchNorm2d
+from torchvision.ops.misc import FrozenBatchNorm2d
 
 _NORM_MAP = dict(
     batchnorm=nn.BatchNorm2d,


### PR DESCRIPTION
This fixes the error:
```
ImportError: cannot import name 'FrozenBatchNorm2d' from 'torchvision.ops' (/usr/local/lib/python3.9/dist-packages/torchvision/ops/__init__.py)
```