### PR TITLE
Add warnings for duplicate registry names

### DIFF
--- a/timm/models/_registry.py
+++ b/timm/models/_registry.py
@@ -86,6 +86,12 @@ def register_model(fn: Callable[..., Any]) -> Callable[..., Any]:
         mod.__all__ = [model_name]  # type: ignore
 
     # add entries to registry dict/sets
+    if model_name in _model_entrypoints:
+        warnings.warn(
+            f'Overwriting {model_name} in registry with {fn.__module__}.{model_name}. This is because the name being '
+            'registered conflicts with an existing name. Please check if this is not expected.',
+            stacklevel=2,
+        )
     _model_entrypoints[model_name] = fn
     _model_to_module[model_name] = module_name
     _module_to_models[module_name].add(model_name)


### PR DESCRIPTION
Recently when I was working with a new model, I accidentally registered two models with the same name and it takes me forever to find out what's wrong. As far as I know, some other frameworks (mmpretrain, etc.) with model registries throw an error when duplicate names are registered, so I think it would be nice to output some warning messages when names are duplicated.