### PR TITLE
hotfix: broken compatibility with py3.7 and import `Literal`

### DIFF
--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -27,7 +27,7 @@ import logging
 import math
 from collections import OrderedDict
 from functools import partial
-from typing import Any, Callable, Dict, Optional, Sequence, Set, Tuple, Type, Union, Literal, List
+from typing import Any, Callable, Dict, Optional, Sequence, Set, Tuple, Type, Union, List
 
 import torch
 import torch.nn as nn
@@ -43,6 +43,11 @@ from timm.layers import PatchEmbed, Mlp, DropPath, AttentionPoolLatent, RmsNorm,
 from ._builder import build_model_with_cfg
 from ._manipulate import named_apply, checkpoint_seq, adapt_input_conv
 from ._registry import generate_default_cfgs, register_model, register_model_deprecations
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 __all__ = ['VisionTransformer']  # model_registry will add each entrypoint fn to this
 

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -25,6 +25,7 @@ Hacked together by / Copyright 2020, Ross Wightman
 """
 import logging
 import math
+import sys
 from collections import OrderedDict
 from functools import partial
 from typing import Any, Callable, Dict, Optional, Sequence, Set, Tuple, Type, Union, List


### PR DESCRIPTION
The package can't be loaded with py3.8, so using the same pattern for `Literal` as it is already in the codebase