### PR TITLE
FastViT bug fix for returning intermediate output

### DIFF
--- a/timm/models/fastvit.py
+++ b/timm/models/fastvit.py
@@ -1164,8 +1164,10 @@ class FastVit(nn.Module):
 
         # For segmentation and detection, extract intermediate output
         if self.fork_feat:
-            # add a norm layer for each output
-            self.out_indices = [0, 2, 4, 6]
+            # Add a norm layer for each output. self.stages is slightly different than self.network
+            # in the original code, the PatchEmbed layer is part of self.stages in this code where
+            # it was part of self.network in the original code. So we do not need to skip out indices.
+            self.out_indices = [0, 1, 2, 3]
             for i_emb, i_layer in enumerate(self.out_indices):
                 if i_emb == 0 and os.environ.get("FORK_LAST3", None):
                     """For RetinaNet, `start_level=1`. The first norm layer will not used.


### PR DESCRIPTION
The Timm implementation of FastViT uses a slightly different set of stages for the internal network where it has only 4 stages while the original FastViT has 8 stages. This causes an issue when you want to return the intermediate feature outputs because the indices are [0, 2, 4, 6] but for the Timm model they should be [0, 1, 2, 3]. I've added some images of each repo's network stages to show that stages are the same.

Here's FastViT stage 0
![fastvit_0](https://github.com/huggingface/pytorch-image-models/assets/3057947/b94aa3b7-b1a0-4ed7-90c1-3468d7b17d52)

Which is the same as Timm's stage 0
![timm_0](https://github.com/huggingface/pytorch-image-models/assets/3057947/f10c29c7-90c7-43ef-87d0-4a7c4aa1877c)

And then FastViT's stages 1 and 2 (where 1 is the PatchEmbed)
![fastvit_1](https://github.com/huggingface/pytorch-image-models/assets/3057947/de9e7095-9f58-4b84-bfca-826cdb1818c7)

![fastvit_2](https://github.com/huggingface/pytorch-image-models/assets/3057947/9f0b75ed-3d76-48a1-b9cd-5ae51ee80c37)

Is the same as Timm's 1 (which contains the PatchEmbed in the stage)
![timm_1](https://github.com/huggingface/pytorch-image-models/assets/3057947/419dee9a-8dcd-4b2e-bd77-ee93e74416c6)

