### PR TITLE
Change davit head forward to match convnext

### DIFF
--- a/timm/models/davit.py
+++ b/timm/models/davit.py
@@ -568,11 +568,7 @@ class DaViT(nn.Module):
         return x
 
     def forward_head(self, x, pre_logits: bool = False):
-        x = self.head.global_pool(x)
-        x = self.head.norm(x)
-        x = self.head.flatten(x)
-        x = self.head.drop(x)
-        return x if pre_logits else self.head.fc(x)
+        return self.head(x, pre_logits=True) if pre_logits else self.head(x)
 
     def forward(self, x):
         x = self.forward_features(x)


### PR DESCRIPTION
Davit's `forward_head` can be handled the same way as Convnext.