### PR TITLE
Update eva.py

### DIFF
--- a/timm/models/eva.py
+++ b/timm/models/eva.py
@@ -479,7 +479,7 @@ class Eva(nn.Module):
         self.apply(self._init_weights)
         if self.pos_embed is not None:
             trunc_normal_(self.pos_embed, std=.02)
-        if self.cls_token:
+        if self.cls_token is not None:
             trunc_normal_(self.cls_token, std=.02)
 
         self.fix_init_weight()

--- a/timm/models/eva.py
+++ b/timm/models/eva.py
@@ -479,7 +479,8 @@ class Eva(nn.Module):
         self.apply(self._init_weights)
         if self.pos_embed is not None:
             trunc_normal_(self.pos_embed, std=.02)
-        trunc_normal_(self.cls_token, std=.02)
+        if self.cls_token:
+            trunc_normal_(self.cls_token, std=.02)
 
         self.fix_init_weight()
         if isinstance(self.head, nn.Linear):


### PR DESCRIPTION
When argument class token = False, self.cls_token = None.

Prevents error from attempting trunc_normal_ on None: AttributeError: 'NoneType' object has no attribute 'uniform_'