### PR TITLE
Add DependencyViT

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,7 +52,7 @@ NON_STD_FILTERS = [
     'vit_*', 'tnt_*', 'pit_*', 'coat_*', 'cait_*', '*mixer_*', 'gmlp_*', 'resmlp_*', 'twins_*',
     'convit_*', 'levit*', 'visformer*', 'deit*', 'jx_nest_*', 'nest_*', 'xcit_*', 'crossvit_*', 'beit*',
     'poolformer_*', 'volo_*', 'sequencer2d_*', 'pvt_v2*', 'mvitv2*', 'gcvit*', 'efficientformer*',
-    'eva_*', 'flexivit*', 'eva02*', 'samvit_*', 'efficientvit_m*', 'tiny_vit_*'
+    'eva_*', 'flexivit*', 'eva02*', 'samvit_*', 'efficientvit_m*', 'tiny_vit_*', 'dependencyvit_*'
 ]
 NUM_NON_STD = len(NON_STD_FILTERS)
 

--- a/timm/models/__init__.py
+++ b/timm/models/__init__.py
@@ -11,6 +11,7 @@ from .cspnet import *
 from .davit import *
 from .deit import *
 from .densenet import *
+from .dependencyvit import *
 from .dla import *
 from .dpn import *
 from .edgenext import *

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -225,7 +225,7 @@ class DependencyViT(VisionTransformer):
             assert self.prune_ratio * len(self.prune_layers) < 1, "prune_ratio too big, ensure len(prune_layers) * prune_ratio is less than 1"
             
             self.prune_layers = [x-1 for x in self.prune_layers] # convert counting numbers to nn.Sequential indicess
-            for prune_index, layer in enumerate(prune_layers, 1):
+            for prune_index, layer in enumerate(self.prune_layers, 1):
                 self.blocks[layer].token_pruner = TokenPruner(self.prune_ratio, prune_index)
         
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -77,7 +77,7 @@ class ReversedAttention(nn.Module):
 
         p = (self.head_selector(x) / self.head_selector_temperature).softmax(dim=-1)
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
-
+        print(m)
         m = self.message_controller(x).sigmoid().reshape(B, 1, 1, N)# * m
         print(m)
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -48,7 +48,7 @@ class ReversedAttention(nn.Module):
         self.scale = self.head_dim ** -0.5
         self.track_dependency_mask = False
         self.dependency_mask = None
-        self.head_selector_temperature = 0.1 # appendix D.1
+        self.head_selector_temperature = 1 # appendix D.1
 
         self.head_selector = nn.Linear(dim, num_heads, bias=False) # paper only mentions a weight matrix, assuming no bias
 
@@ -184,7 +184,7 @@ class DependencyViT(VisionTransformer):
         else:
             x, m = self.blocks((x, m))
         
-        x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
+        #x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
 
         x = self.norm(x)
         return x

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -78,7 +78,7 @@ class ReversedAttention(nn.Module):
         p = (self.head_selector(x) / self.head_selector_temperature).softmax(dim=-1)
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
 
-        m = self.message_controller(x).sigmoid().reshape(B, 1, 1, N) * m
+        m = self.message_controller(x).sigmoid().reshape(B, 1, 1, N)# * m
         print(m)
 
         q = q * self.scale

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -124,8 +124,8 @@ class ReversedAttention(nn.Module):
         #prune_mask = attn.detach().abs().sum((1, -1))
         #prune_mask = attn.sum(1).sum(-1)
         #prune_mask = attn.sum(1).abs().sum(-1)
-        prune_mask = attn.abs().sum((1, -1))
-        #prune_mask = m.reshape(B, N)
+        #prune_mask = attn.abs().sum((1, -1))
+        prune_mask = m.reshape(B, N)
         
         x = self.proj(x)
         x = self.proj_drop(x)

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -169,7 +169,7 @@ class DependencyViT(VisionTransformer):
             class_token=False,
             global_pool='avg', 
             qkv_bias=False, 
-            init_values=1e-6, 
+            init_values=None, 
             fc_norm=False,
         )
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -48,7 +48,7 @@ class ReversedAttention(nn.Module):
         self.scale = self.head_dim ** -0.5
         self.track_dependency_mask = False
         self.dependency_mask = None
-        self.head_selector_temperature = 1.0 # appendix D.1, causes nan when 0.1, 0 when 10.0
+        self.head_selector_temperature = 0.1 # appendix D.1, causes nan when 0.1, 0 when 10.0
 
         self.head_selector = nn.Linear(dim, num_heads)
 
@@ -78,7 +78,7 @@ class ReversedAttention(nn.Module):
         p = (self.head_selector(x) / self.head_selector_temperature).softmax(dim=-1)
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
 
-        m = self.message_controller(x).sigmoid().reshape(B, 1, 1, N)
+        m = m * self.message_controller(x).sigmoid().reshape(B, 1, 1, N)
 
         q = q * self.scale
         attn = q @ k.transpose(-2, -1)
@@ -187,7 +187,7 @@ class DependencyViT(VisionTransformer):
         #x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
 
         x = self.norm(x)
-        #x = x * m.transpose(1, 3).squeeze(-1)
+        x = x * m.transpose(1, 3).squeeze(-1)
         return x
 
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -48,7 +48,7 @@ class ReversedAttention(nn.Module):
         self.scale = self.head_dim ** -0.5
         self.track_dependency_mask = False
         self.dependency_mask = None
-        self.head_selector_temperature = 0.1 # appendix D.1
+        self.head_selector_temperature = 10.0 # appendix D.1
 
         self.head_selector = nn.Linear(dim, num_heads, bias=False) # paper only mentions a weight matrix, assuming no bias
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -184,7 +184,7 @@ class DependencyViT(VisionTransformer):
         else:
             x, m = self.blocks((x, m))
         x = self.norm(x)
-        x = x * m.transpose(1, 3).squeeze(-1)
+        #x = x * m.transpose(1, 3).squeeze(-1)
         return x
 
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -48,7 +48,7 @@ class ReversedAttention(nn.Module):
         self.scale = self.head_dim ** -0.5
         self.track_dependency_mask = False
         self.dependency_mask = None
-        self.head_selector_temperature = 1.0 # appendix D.1, causes nan when 0.1, 0 when 10.0
+        self.head_selector_temperature = 10.0 # appendix D.1, causes nan when 0.1, 0 when 10.0
 
         self.head_selector = nn.Linear(dim, num_heads, bias=False) # paper only mentions a weight matrix, assuming no bias
 
@@ -187,6 +187,7 @@ class DependencyViT(VisionTransformer):
         #x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
 
         x = self.norm(x)
+        x = x * m.transpose(1, 3).squeeze(-1)
         return x
 
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -113,7 +113,7 @@ class DependencyViTBlock(nn.Module):
         super().__init__()
         self.norm1 = norm_layer(dim)
         self.attn = ReversedAttention(
-            dim,
+            dim=dim,
             num_heads=num_heads,
             qkv_bias=qkv_bias,
             qk_norm=qk_norm,

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -154,6 +154,7 @@ class DependencyViTBlock(nn.Module):
         x_new, m = self.attn((self.norm1(x), m))
         x = x + self.drop_path1(self.ls1(x_new))
         x = x + self.drop_path2(self.ls2(self.mlp(self.norm2(x))))
+        print((x, m))
         return (x, m)
 
 # FIXME lite model variants

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -78,7 +78,7 @@ class ReversedAttention(nn.Module):
         p = (self.head_selector(x) / self.head_selector_temperature).softmax(dim=-1)
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
 
-        m = m * self.message_controller(x).sigmoid().reshape(B, 1, 1, N)
+        m = self.message_controller(x).sigmoid().reshape(B, 1, 1, N)
 
         q = q * self.scale
         attn = q @ k.transpose(-2, -1)
@@ -187,7 +187,7 @@ class DependencyViT(VisionTransformer):
         #x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
 
         x = self.norm(x)
-        x = x * m.transpose(1, 3).squeeze(-1)
+        #x = x * m.transpose(1, 3).squeeze(-1)
         return x
 
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -48,7 +48,7 @@ class ReversedAttention(nn.Module):
         self.scale = self.head_dim ** -0.5
         self.track_dependency_mask = False
         self.dependency_mask = None
-        self.head_selector_temperature = 0.1 # appendix D.1, causes nan when 0.1, 0 when 10.0
+        self.head_selector_temperature = 1.0 # appendix D.1, causes nan when 0.1, 0 when 10.0
 
         self.head_selector = nn.Linear(dim, num_heads)
 
@@ -151,8 +151,8 @@ class DependencyViTBlock(nn.Module):
 
     def forward(self, in_tuple: Tuple[torch.Tensor, torch.Tensor]) -> Tuple[torch.Tensor, torch.Tensor]:
         x, m = in_tuple
-        x, m = self.attn((self.norm1(x), m))
-        x = x + self.drop_path1(self.ls1(x))
+        x_new, m = self.attn((self.norm1(x), m))
+        x = x + self.drop_path1(self.ls1(x_new))
         x = x + self.drop_path2(self.ls2(self.mlp(self.norm2(x))))
         return (x, m)
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -48,7 +48,7 @@ class ReversedAttention(nn.Module):
         self.scale = self.head_dim ** -0.5
         self.track_dependency_mask = False
         self.dependency_mask = None
-        self.head_selector_temperature = 0.1 # appendix D.1, causes nan when 0.1, 0 when 10.0
+        self.head_selector_temperature = 1.0 # appendix D.1, causes nan when 0.1, 0 when 10.0
 
         self.head_selector = nn.Linear(dim, num_heads)
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -83,7 +83,7 @@ class ReversedAttention(nn.Module):
         q = q * self.scale
         attn = q @ k.transpose(-2, -1)
         attn = attn.softmax(dim=-1)
-        attn = self.attn_drop(attn).transpose(-2, -1)
+        attn = self.attn_drop(attn).transpose(-2, -1) # this transpose prevents use of sdpa
         attn = attn * p * m # [B, n_h, N, N]
         x = attn @ v
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -184,10 +184,9 @@ class DependencyViT(VisionTransformer):
         else:
             x, m = self.blocks((x, m))
         
-
-        x = self.norm(x)
         x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
 
+        x = self.norm(x)
         return x
 
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -121,7 +121,7 @@ class ReversedAttention(nn.Module):
         
         prune_mask = attn.detach().sum(1).sum(-1)
         #prune_mask = attn.detach().sum(1).abs().sum(-1)
-        #prune_mask = attn.detach().abs().sum(1).sum(-1)
+        #prune_mask = attn.detach().abs().sum((1, -1))
         #prune_mask = m.reshape(B, N)
         
         x = self.proj(x)

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -119,12 +119,12 @@ class ReversedAttention(nn.Module):
         '''
         self.dependency_mask = attn.detach().sum(1) if self.track_dependency_mask else None # [B, N, N]
         
-        prune_mask = attn.detach().sum(1).sum(-1)
+        #prune_mask = attn.detach().sum(1).sum(-1)
         #prune_mask = attn.detach().sum(1).abs().sum(-1)
         #prune_mask = attn.detach().abs().sum((1, -1))
         #prune_mask = attn.sum(1).sum(-1)
         #prune_mask = attn.sum(1).abs().sum(-1)
-        #prune_mask = attn.abs().sum((1, -1))
+        prune_mask = attn.abs().sum((1, -1))
         #prune_mask = m.reshape(B, N)
         
         x = self.proj(x)

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -247,7 +247,7 @@ class DependencyViT(VisionTransformer):
         # L' * [B, N, N]
         # L' * [B, N', N']
         result = []
-        layers = range(len(self.blocks)) if not layers
+        layers = layers if layers else range(len(self.blocks))
         for layer in layers:
             result.append(self.blocks[layer].attn.dependency_mask)
         return result

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -94,7 +94,7 @@ class LayerScale(nn.Module):
         return x.mul_(self.gamma) if self.inplace else x * self.gamma
 
 
-class DependencyVitBlock(nn.Module):
+class DependencyViTBlock(nn.Module):
     def __init__(
             self,
             dim: int,

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -78,7 +78,7 @@ class ReversedAttention(nn.Module):
         p = (self.head_selector(x) / self.head_selector_temperature).softmax(dim=-1)
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
 
-        m = self.message_controller(x).sigmoid().reshape(B, 1, 1, N)
+        m = self.message_controller(x).sigmoid().reshape(B, 1, 1, N) * m
 
         q = q * self.scale
         attn = q @ k.transpose(-2, -1)
@@ -169,7 +169,7 @@ class DependencyViT(VisionTransformer):
             class_token=False,
             global_pool='avg', 
             qkv_bias=False, 
-            init_values=None, 
+            init_values=1e-6, 
             fc_norm=False,
         )
 
@@ -187,7 +187,7 @@ class DependencyViT(VisionTransformer):
         #x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
 
         x = self.norm(x)
-        #x = x * m.transpose(1, 3).squeeze(-1)
+        x = x * m.transpose(1, 3).squeeze(-1)
         return x
 
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -48,7 +48,7 @@ class ReversedAttention(nn.Module):
         self.scale = self.head_dim ** -0.5
         self.track_dependency_mask = False
         self.dependency_mask = None
-        self.head_selector_temperature = 1.0 # appendix D.1, causes nan when 0.1, 0 when 10.0
+        self.head_selector_temperature = 0.1 # appendix D.1, causes nan when 0.1, 0 when 10.0
 
         self.head_selector = nn.Linear(dim, num_heads, bias=False) # paper only mentions a weight matrix, assuming no bias
 
@@ -78,7 +78,7 @@ class ReversedAttention(nn.Module):
         p = (self.head_selector(x) / self.head_selector_temperature).softmax(dim=-1)
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
 
-        m = m * self.message_controller(x).sigmoid().reshape(B, 1, 1, N)
+        m = self.message_controller(x).sigmoid().reshape(B, 1, 1, N)
 
         q = q * self.scale
         attn = q @ k.transpose(-2, -1)

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -184,7 +184,7 @@ class DependencyViT(VisionTransformer):
         else:
             x, m = self.blocks((x, m))
         x = self.norm(x)
-        x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
+        #x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
         return x
 
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -48,7 +48,7 @@ class ReversedAttention(nn.Module):
         self.scale = self.head_dim ** -0.5
         self.track_dependency_mask = False
         self.dependency_mask = None
-        self.head_selector_temperature = 10.0 # appendix D.1
+        self.head_selector_temperature = 1.0 # appendix D.1, causes nan when 0.1, 0 when 10.0
 
         self.head_selector = nn.Linear(dim, num_heads, bias=False) # paper only mentions a weight matrix, assuming no bias
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -38,9 +38,10 @@ class ReversedAttention(nn.Module):
 
         self.head_selector = nn.Linear(dim, num_heads, bias=False) # paper only mentions a weight matrix, assuming no bias
 
+        print(dim)
         self.message_controller = Mlp(
             in_features = dim,
-            hidden_features = dim/2,
+            hidden_features = int(dim/2),
             out_features = 1,
             act_layer = nn.GELU,
             bias = False, # FIXME is there a bias term?

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -77,7 +77,7 @@ class ReversedAttention(nn.Module):
 
         p = (self.head_selector(x) / self.head_selector_temperature).softmax(dim=-1)
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
-        
+        print(m)
         m = m * self.message_controller(x).sigmoid().reshape(B, 1, 1, N)
 
         q = q * self.scale
@@ -179,7 +179,8 @@ class DependencyViT(VisionTransformer):
         x = self.patch_drop(x)
         x = self.norm_pre(x)
         B, N, _ = x.shape
-        m = torch.ones(B, 1, 1, N).to(x)
+        #m = torch.ones(B, 1, 1, N).to(x)
+        m = torch.Tensor([1]).to(x)
         if self.grad_checkpointing and not torch.jit.is_scripting():
             x, m = checkpoint_seq(self.blocks, (x, m))
         else:

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -38,7 +38,6 @@ class ReversedAttention(nn.Module):
 
         self.head_selector = nn.Linear(dim, num_heads, bias=False) # paper only mentions a weight matrix, assuming no bias
 
-        print(dim)
         self.message_controller = Mlp(
             in_features = dim,
             hidden_features = int(dim/2),

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -11,7 +11,7 @@ Implementation for timm by / Copyright 2023, Fredo Guan
 """
 
 import math
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -48,16 +48,16 @@ class ReversedAttention(nn.Module):
         self.scale = self.head_dim ** -0.5
         self.track_dependency_mask = False
         self.dependency_mask = None
-        self.head_selector_temperature = 1.0 # appendix D.1, causes nan when 0.1, 0 when 10.0
+        self.head_selector_temperature = 0.1 # appendix D.1, causes nan when 0.1, 0 when 10.0
 
-        self.head_selector = nn.Linear(dim, num_heads)
+        self.head_selector = nn.Linear(dim, num_heads, bias=False)
 
         self.message_controller = Mlp(
             in_features = dim,
             hidden_features = int(dim/2),
             out_features = 1,
             act_layer = nn.GELU,
-            bias = True, # FIXME is there a bias term?
+            bias = False, # FIXME is there a bias term?
         )
 
         self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
@@ -169,7 +169,7 @@ class DependencyViT(VisionTransformer):
             class_token=False,
             global_pool='avg', 
             qkv_bias=False, 
-            init_values=1e-6, 
+            init_values=None, 
             fc_norm=False,
         )
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -184,9 +184,10 @@ class DependencyViT(VisionTransformer):
         else:
             x, m = self.blocks((x, m))
         
-        #x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
 
         x = self.norm(x)
+        x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
+
         return x
 
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -50,14 +50,14 @@ class ReversedAttention(nn.Module):
         self.dependency_mask = None
         self.head_selector_temperature = 0.1 # appendix D.1, causes nan when 0.1, 0 when 10.0
 
-        self.head_selector = nn.Linear(dim, num_heads, bias=False) # paper only mentions a weight matrix, assuming no bias
+        self.head_selector = nn.Linear(dim, num_heads)
 
         self.message_controller = Mlp(
             in_features = dim,
             hidden_features = int(dim/2),
             out_features = 1,
             act_layer = nn.GELU,
-            bias = False, # FIXME is there a bias term?
+            bias = True, # FIXME is there a bias term?
         )
 
         self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -48,7 +48,7 @@ class ReversedAttention(nn.Module):
         self.scale = self.head_dim ** -0.5
         self.track_dependency_mask = False
         self.dependency_mask = None
-        self.head_selector_temperature = 1 # appendix D.1
+        self.head_selector_temperature = 0.1 # appendix D.1
 
         self.head_selector = nn.Linear(dim, num_heads, bias=False) # paper only mentions a weight matrix, assuming no bias
 
@@ -184,7 +184,7 @@ class DependencyViT(VisionTransformer):
         else:
             x, m = self.blocks((x, m))
         
-        x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
+        #x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
 
         x = self.norm(x)
         return x

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -78,7 +78,7 @@ class ReversedAttention(nn.Module):
         p = (self.head_selector(x) / self.head_selector_temperature).softmax(dim=-1)
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
 
-        m = self.message_controller(x).sigmoid().reshape(B, 1, 1, N) * m
+        m = self.message_controller(x).sigmoid().reshape(B, 1, 1, N)# * m
 
         q = q * self.scale
         attn = q @ k.transpose(-2, -1)

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -105,7 +105,7 @@ class ReversedAttention(nn.Module):
         x = attn @ v
         
         # FIXME messy way to handle
-        if self.track_dependency_mask or not isinstance(self.token_pruner, nn.Identity()):
+        if self.track_dependency_mask or self.token_pruner:
             dependency_mask = attn.detach().sum(1) # [B, N, N]
             self.dependency_mask = dependency_mask if self.track_dependency_mask else None
             #FIXME how to prune

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -169,7 +169,7 @@ class DependencyViT(VisionTransformer):
             class_token=False,
             global_pool='avg', 
             qkv_bias=False, 
-            init_values=None, 
+            init_values=1e-6, 
             fc_norm=False,
         )
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -78,7 +78,7 @@ class ReversedAttention(nn.Module):
         p = (self.head_selector(x) / self.head_selector_temperature).softmax(dim=-1)
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
 
-        m = self.message_controller(x).sigmoid().reshape(B, 1, 1, N)# * m
+        m = self.message_controller(x).sigmoid().reshape(B, 1, 1, N) * m
 
         q = q * self.scale
         attn = q @ k.transpose(-2, -1)

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -180,7 +180,8 @@ class DependencyViT(VisionTransformer):
         x = self._pos_embed(x)
         x = self.patch_drop(x)
         x = self.norm_pre(x)
-        m = torch.Tensor(1).to(x)
+        B, N, _ = x.shape
+        m = torch.ones(B, 1, 1, N).to(x)
         if self.grad_checkpointing and not torch.jit.is_scripting():
             x, m = checkpoint_seq(self.blocks, (x, m))
         else:

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -77,7 +77,7 @@ class ReversedAttention(nn.Module):
 
         p = (self.head_selector(x) / self.head_selector_temperature).softmax(dim=-1)
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
-        print(m)
+        
         m = m * self.message_controller(x).sigmoid().reshape(B, 1, 1, N)
 
         q = q * self.scale

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -17,6 +17,7 @@ __all__ = ['DependencyViT']
 
 # FIXME there is nearly no difference between this and stock attn, allowing sdpa to be used if a workaround can be found
 class ReversedAttention(nn.Module):
+    dependency_mask: Optional[torch.Tensor]
 
     def __init__(
             self,
@@ -34,7 +35,7 @@ class ReversedAttention(nn.Module):
         self.head_dim = dim // num_heads
         self.scale = self.head_dim ** -0.5
         self.track_dependency_mask = False
-        self.dependency_mask: Optional[Tensor] = None
+        self.dependency_mask = None
 
         self.head_selector = nn.Linear(dim, num_heads, bias=False) # paper only mentions a weight matrix, assuming no bias
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -184,7 +184,7 @@ class DependencyViT(VisionTransformer):
         else:
             x, m = self.blocks((x, m))
         x = self.norm(x)
-        x = x * m.transpose(1, 3).squeeze(-1)
+        #x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
         return x
 
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -78,7 +78,7 @@ class ReversedAttention(nn.Module):
         p = (self.head_selector(x) / self.head_selector_temperature).softmax(dim=-1)
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
         print(m)
-        m = self.message_controller(x).sigmoid().reshape(B, 1, 1, N)# * m
+        m = m * self.message_controller(x).sigmoid().reshape(B, 1, 1, N)# * m
         print(m)
 
         q = q * self.scale

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -38,7 +38,7 @@ class TokenPruner(nn.Module):
     
     def forward(self, x: torch.Tensor, scores: torch.Tensor): # [B, N, C], [B, N]
         _, N, C = x.shape
-        topk_indices = scores.topk(math.floor(self.pct_kept_tokens * N), sorted=False) # [B, N']
+        topk_indices = scores.topk(math.floor(self.pct_kept_tokens * N), sorted=False)[1] # [B, N']
         topk_indices = topk_indices.unsqueeze(-1).expand(-1, -1, C) # [B, N', C]
         return x.gather(1, topk_indices)
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -183,8 +183,10 @@ class DependencyViT(VisionTransformer):
             x, m = checkpoint_seq(self.blocks, (x, m))
         else:
             x, m = self.blocks((x, m))
+        
+        x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
+
         x = self.norm(x)
-        #x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
         return x
 
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -184,7 +184,7 @@ class DependencyViT(VisionTransformer):
         else:
             x, m = self.blocks((x, m))
         x = self.norm(x)
-        #x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
+        x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
         return x
 
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -180,10 +180,11 @@ class DependencyViT(VisionTransformer):
         x = self.norm_pre(x)
         m = torch.Tensor(1).to(x)
         if self.grad_checkpointing and not torch.jit.is_scripting():
-            x, _ = checkpoint_seq(self.blocks, (x, m))
+            x, m = checkpoint_seq(self.blocks, (x, m))
         else:
-            x, _ = self.blocks((x, m))
+            x, m = self.blocks((x, m))
         x = self.norm(x)
+        x = x * m.transpose(1, 3).squeeze(-1)
         return x
 
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -79,6 +79,7 @@ class ReversedAttention(nn.Module):
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
 
         m = self.message_controller(x).sigmoid().reshape(B, 1, 1, N) * m
+        print(m)
 
         q = q * self.scale
         attn = q @ k.transpose(-2, -1)
@@ -154,7 +155,7 @@ class DependencyViTBlock(nn.Module):
         x_new, m = self.attn((self.norm1(x), m))
         x = x + self.drop_path1(self.ls1(x_new))
         x = x + self.drop_path2(self.ls2(self.mlp(self.norm2(x))))
-        print((x, m))
+        #print((x, m))
         return (x, m)
 
 # FIXME lite model variants

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -75,7 +75,7 @@ class ReversedAttention(nn.Module):
         q, k, v = qkv.unbind(0)
         q, k = self.q_norm(q), self.k_norm(k)
 
-        p = (self.head_selector(x) / self.head_selector_temperature).softmax(dim=-1)
+        p = (self.head_selector(x) * self.head_selector_temperature).softmax(dim=-1)
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
 
         m = m * self.message_controller(x).sigmoid().reshape(B, 1, 1, N)
@@ -184,7 +184,7 @@ class DependencyViT(VisionTransformer):
         else:
             x, m = self.blocks((x, m))
         x = self.norm(x)
-        #x = x * m.transpose(1, 3).squeeze(-1)
+        x = x * m.transpose(1, 3).squeeze(-1)
         return x
 
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -48,7 +48,7 @@ class ReversedAttention(nn.Module):
         self.scale = self.head_dim ** -0.5
         self.track_dependency_mask = False
         self.dependency_mask = None
-        self.head_selector_temperature = 10.0 # appendix D.1, causes nan when 0.1, 0 when 10.0
+        self.head_selector_temperature = 1.0 # appendix D.1, causes nan when 0.1, 0 when 10.0
 
         self.head_selector = nn.Linear(dim, num_heads, bias=False) # paper only mentions a weight matrix, assuming no bias
 
@@ -187,7 +187,7 @@ class DependencyViT(VisionTransformer):
         #x = x * m.transpose(1, 3).squeeze(-1) # FIXME before or after norm
 
         x = self.norm(x)
-        x = x * m.transpose(1, 3).squeeze(-1)
+        #x = x * m.transpose(1, 3).squeeze(-1)
         return x
 
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -75,7 +75,7 @@ class ReversedAttention(nn.Module):
         q, k, v = qkv.unbind(0)
         q, k = self.q_norm(q), self.k_norm(k)
 
-        p = (self.head_selector(x) * self.head_selector_temperature).softmax(dim=-1)
+        p = (self.head_selector(x) / self.head_selector_temperature).softmax(dim=-1)
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
 
         m = m * self.message_controller(x).sigmoid().reshape(B, 1, 1, N)

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -122,6 +122,9 @@ class ReversedAttention(nn.Module):
         prune_mask = attn.detach().sum(1).sum(-1)
         #prune_mask = attn.detach().sum(1).abs().sum(-1)
         #prune_mask = attn.detach().abs().sum((1, -1))
+        #prune_mask = attn.sum(1).sum(-1)
+        #prune_mask = attn.sum(1).abs().sum(-1)
+        #prune_mask = attn.abs().sum((1, -1))
         #prune_mask = m.reshape(B, N)
         
         x = self.proj(x)

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -18,7 +18,7 @@ import torch.nn.functional as F
 from torch.jit import Final
 
 from timm.data import IMAGENET_INCEPTION_MEAN, IMAGENET_INCEPTION_STD
-from timm.layers import Mlp
+from timm.layers import DropPath, Mlp
 from timm.models.vision_transformer import VisionTransformer
 from ._builder import build_model_with_cfg
 from ._manipulate import checkpoint_seq

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -142,6 +142,10 @@ class DependencyViTBlock(nn.Module):
         x = x + self.drop_path2(self.ls2(self.mlp(self.norm2(x))))
         return (x, m)
 
+# FIXME lite model variants
+# FIXME toggle and retrieve dependency masks
+# FIXME verify against reference impl
+
 class DependencyViT(VisionTransformer):
     def __init__(self, *args, **kwargs):
         super().__init__(
@@ -208,6 +212,12 @@ def _create_dependencyvit(variant: str, pretrained: bool = False, **kwargs) -> D
 
 @register_model
 def dependencyvit_tiny_patch16_224(pretrained: bool = False, **kwargs) -> DependencyViT:
-    model_args = dict(patch_size=16, embed_dim=192, depth=12, num_heads=3)
+    model_args = dict(patch_size=16, embed_dim=192, depth=12, num_heads=12)
+    model = _create_dependencyvit('dependencyvit_tiny_patch16_224', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
+
+@register_model
+def dependencyvit_small_patch16_224(pretrained: bool = False, **kwargs) -> DependencyViT:
+    model_args = dict(patch_size=16, embed_dim=384, depth=12, num_heads=12)
     model = _create_dependencyvit('dependencyvit_tiny_patch16_224', pretrained=pretrained, **dict(model_args, **kwargs))
     return model

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -34,7 +34,7 @@ class ReversedAttention(nn.Module):
         self.head_dim = dim // num_heads
         self.scale = self.head_dim ** -0.5
         self.track_dependency_mask = False
-        self.dependency_mask = None
+        self.dependency_mask: Optional[Tensor] = None
 
         self.head_selector = nn.Linear(dim, num_heads, bias=False) # paper only mentions a weight matrix, assuming no bias
 

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -103,6 +103,8 @@ class ReversedAttention(nn.Module):
         attn = self.attn_drop(attn).transpose(-2, -1) # this transpose prevents use of sdpa
         attn = attn * p * m # [B, n_h, N, N]
         x = attn @ v
+        x = x.transpose(1, 2).reshape(B, N, C)
+        
         
         # FIXME messy way to handle
         if self.track_dependency_mask or self.token_pruner:
@@ -115,7 +117,7 @@ class ReversedAttention(nn.Module):
             #x = self.token_pruner(x, m.reshape(B, N)) if self.token_pruner else x # m
             
 
-        x = x.transpose(1, 2).reshape(B, N, C)
+        
         x = self.proj(x)
         x = self.proj_drop(x)
         return (x, m)

--- a/timm/models/dependencyvit.py
+++ b/timm/models/dependencyvit.py
@@ -77,9 +77,8 @@ class ReversedAttention(nn.Module):
 
         p = (self.head_selector(x) / self.head_selector_temperature).softmax(dim=-1)
         p = p.transpose(-2, -1).reshape(B, self.num_heads, 1, N)
-        print(m)
-        m = m * self.message_controller(x).sigmoid().reshape(B, 1, 1, N)# * m
-        print(m)
+        
+        m = m * self.message_controller(x).sigmoid().reshape(B, 1, 1, N)
 
         q = q * self.scale
         attn = q @ k.transpose(-2, -1)
@@ -155,7 +154,6 @@ class DependencyViTBlock(nn.Module):
         x_new, m = self.attn((self.norm1(x), m))
         x = x + self.drop_path1(self.ls1(x_new))
         x = x + self.drop_path2(self.ls2(self.mlp(self.norm2(x))))
-        #print((x, m))
         return (x, m)
 
 # FIXME lite model variants


### PR DESCRIPTION
From-scratch impl of [DependencyViT](https://arxiv.org/abs/2304.03282). [Official impl](https://github.com/dingmyu/DependencyViT) not published. Not competitive with sota hierarchical models, advantage over isometric models is lost due to inability to use `F.sdpa`, but interesting mechanism. Mainly just ViT with a different attn/block, but the cumulative m and topk pruning makes stuff a bit messy. Block exploits `nn.Sequential`'s untyped intermediate states and feeds tuples through for the cumulative m calculation. I messed around a bit with building dependency trees using the dependency masks, but I have no clue what I'm doing. Currently training weights, have a tiny@72.2% and playing around with a few implementation details and training recipe. Contacted @dingmyu for reference code and weights but no response yet.