### PR TITLE
Fix index out of range error in resume functionality

### DIFF
--- a/train.py
+++ b/train.py
@@ -912,7 +912,7 @@ def main():
 
     results = {'all': results}
     if best_metric is not None:
-        results['best'] = results['all'][best_epoch]
+        results['best'] = results['all'][best_epoch - start_epoch]
         _logger.info('*** Best metric: {0} (epoch {1})'.format(best_metric, best_epoch))
     print(f'--result\n{json.dumps(results, indent=4)}')
 


### PR DESCRIPTION
This pull request fixes an issue where an index out of range error occurred in the resume functionality. The error was caused by accessing an incorrect index in the 'results' dictionary. This PR corrects the index to ensure the resume functionality works as expected.