### PR TITLE
Add NPU backend support for val and inference

### DIFF
--- a/timm/data/loader.py
+++ b/timm/data/loader.py
@@ -114,12 +114,16 @@ class PrefetchLoader:
         else:
             self.random_erasing = None
         self.is_cuda = torch.cuda.is_available() and device.type == 'cuda'
+        self.is_npu = torch.npu.is_available() and device.type == 'npu'
 
     def __iter__(self):
         first = True
         if self.is_cuda:
             stream = torch.cuda.Stream()
             stream_context = partial(torch.cuda.stream, stream=stream)
+        elif self.is_npu:
+            stream = torch.npu.Stream()
+            stream_context = partial(torch.npu.stream, stream=stream)
         else:
             stream = None
             stream_context = suppress
@@ -139,7 +143,10 @@ class PrefetchLoader:
                 first = False
 
             if stream is not None:
-                torch.cuda.current_stream().wait_stream(stream)
+                if self.is_cuda:
+                    torch.cuda.current_stream().wait_stream(stream)
+                elif self.is_npu:
+                    torch.npu.current_stream().wait_stream(stream)
 
             input = next_input
             target = next_target

--- a/timm/data/loader.py
+++ b/timm/data/loader.py
@@ -113,8 +113,8 @@ class PrefetchLoader:
             )
         else:
             self.random_erasing = None
-        self.is_cuda = torch.cuda.is_available() and device.type == 'cuda'
-        self.is_npu = torch.npu.is_available() and device.type == 'npu'
+        self.is_cuda = device.type == 'cuda' and torch.cuda.is_available()
+        self.is_npu = device.type == 'npu' and torch.npu.is_available()
 
     def __iter__(self):
         first = True

--- a/timm/utils/distributed.py
+++ b/timm/utils/distributed.py
@@ -116,6 +116,7 @@ def init_distributed_device_so(
             "xpu": "ccl",
             "hpu": "hccl",
             "cuda": "nccl",
+            "npu": "hccl",
         }
         dist_backend = dist_backends.get(device_type, 'gloo')
     dist_url = dist_url or 'env://'
@@ -159,6 +160,8 @@ def init_distributed_device_so(
 
     if device_type == 'cuda':
         assert torch.cuda.is_available(), f'CUDA is not available but {device} was specified.'
+    if device_type == 'npu':
+        assert torch.npu.is_available(), f'Ascend NPU is not available but {device} was specified.'
 
     if distributed and device != 'cpu':
         # Ignore manually specified device index in distributed mode and

--- a/train.py
+++ b/train.py
@@ -1054,8 +1054,11 @@ def train_one_epoch(
         if model_ema is not None:
             model_ema.update(model, step=num_updates)
 
-        if args.synchronize_step and device.type == 'cuda':
-            torch.cuda.synchronize()
+        if args.synchronize_step:
+            if device.type == 'cuda':
+                torch.cuda.synchronize()
+            elif device.type == 'npu':
+                torch.npu.synchronize()
         time_now = time.time()
         update_time_m.update(time.time() - update_start_time)
         update_start_time = time_now
@@ -1155,6 +1158,8 @@ def validate(
 
             if device.type == 'cuda':
                 torch.cuda.synchronize()
+            elif device.type == "npu":
+                torch.npu.synchronize()
 
             losses_m.update(reduced_loss.item(), input.size(0))
             top1_m.update(acc1.item(), output.size(0))

--- a/validate.py
+++ b/validate.py
@@ -395,9 +395,9 @@ def _try_run(args, initial_batch_size):
     while batch_size:
         args.batch_size = batch_size * args.num_gpu  # multiply by num-gpu for DataParallel case
         try:
-            if torch.cuda.is_available() and 'cuda' in args.device:
+            if 'cuda' in args.device and torch.cuda.is_available():
                 torch.cuda.empty_cache()
-            elif torch.npu.is_available() and "npu" in args.device:
+            elif  "npu" in args.device and torch.npu.is_available():
                 torch.npu.empty_cache()
             results = validate(args)
             return results

--- a/validate.py
+++ b/validate.py
@@ -397,6 +397,8 @@ def _try_run(args, initial_batch_size):
         try:
             if torch.cuda.is_available() and 'cuda' in args.device:
                 torch.cuda.empty_cache()
+            elif torch.npu.is_available() and "npu" in args.device:
+                torch.npu.empty_cache()
             results = validate(args)
             return results
         except RuntimeError as e:


### PR DESCRIPTION
I am a user of NPU. When I used TIMM recently, I found that it does not support NPU natively. It's pleasure to see that someone has made some contributions on leveraging NPU to TIMM #2102. But it currently only offers the feature of using NPU during training. This PR extends NPU support to the validate and inference entries, thus addressing this limitation.



**Specify the device as `"npu"`**, then you can use NPU as accelerator during inferencing and validating.



It is tested on:

- model: **tiny_vit_21m_512** 
- dataset: the `val` subset of **ImageNet-1K**

#### Validate Scripts

```python
python validate.py ../open_clip/data/ImageNet-1000/val/ --device npu --model ./model_ckpts/tiny_vit_21m_512 --batch-size 64 --pretrained
```

#### ScreenShot

It shows the validation results on  `val` subset of ImageNet-1K are as following:

| top-1 acc | top-5 acc |
| --------- | --------- |
| 86.040%   | 97.750%   |

![image-20240314164130874](https://github.com/huggingface/pytorch-image-models/assets/52243582/20bbbaed-af10-48a0-98f4-410b956b4f64)



#### Inference Scripts

```python
python inference.py ./data/ --device npu --batch-size 64 --model ./model_ckpts/tiny_vit_21m_512 --label-type detail --topk 5
```

#### ScreenShot

![image-20240314171146196](https://github.com/huggingface/pytorch-image-models/assets/52243582/36971001-e2e9-4512-9600-5fedd0cd3c3e)

#### results

Here offers some results of predicting the top-5 classification results by inferencing on **tiny_vit_21m_512**. Everything  goes well on npu.

![image-20240314170101799](https://github.com/huggingface/pytorch-image-models/assets/52243582/48ed0855-e421-4645-990c-4ec2509d793e)
