### PR TITLE
Vision Transformer (ViT) get_intermediate_layers: enhanced to support dynamic image size and saved computational costs from unused blocks

### DIFF
--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -635,13 +635,14 @@ class VisionTransformer(nn.Module):
     ) -> List[torch.Tensor]:
         outputs, num_blocks = [], len(self.blocks)
         take_indices = set(range(num_blocks - n, num_blocks) if isinstance(n, int) else n)
+        last_index_to_take = max(take_indices)
 
         # forward pass
         x = self.patch_embed(x)
         x = self._pos_embed(x)
         x = self.patch_drop(x)
         x = self.norm_pre(x)
-        for i, blk in enumerate(self.blocks):
+        for i, blk in enumerate(self.blocks[: last_index_to_take + 1]):
             x = blk(x)
             if i in take_indices:
                 outputs.append(x)

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -667,9 +667,12 @@ class VisionTransformer(nn.Module):
         outputs = [out[:, self.num_prefix_tokens:] for out in outputs]
 
         if reshape:
-            grid_size = self.patch_embed.grid_size
+            patch_size = self.patch_embed.patch_size
+            batch, _, height, width = x.size()
             outputs = [
-                out.reshape(x.shape[0], grid_size[0], grid_size[1], -1).permute(0, 3, 1, 2).contiguous()
+                out.reshape(batch, int(math.ceil(height / patch_size[0])), int(math.ceil(width / patch_size[1])), -1)
+                .permute(0, 3, 1, 2)
+                .contiguous()
                 for out in outputs
             ]
 


### PR DESCRIPTION
Thanks for your helpful work.

With TIMM, it's convenient to do backbone benchmarking for custom experiments.
While trying with ViT features, I discovered some enhancement could be applied to get_intermediate_layers to make it more effective and efficient.

It's my pleasure to contribute to this project.
Please let me know if any modifications are required.

### Enhanced to support dynamic image size

The grid size of the output features is changed and re-evaluated based on the image size and patch size to adapt to dynamic input sizes.

Test code:

```python
import torch
import timm

model = timm.create_model(
    'vit_large_patch14_dinov2.lvd142m', pretrained=True, dynamic_img_size=True, dynamic_img_pad=True
)
for feature in model.get_intermediate_layers(torch.randn(1, 3, 300, 300), n=[7, 15, 21], reshape=True, norm=True):
    print(feature.size())
```

Outputs before this patch:

```python
Traceback (most recent call last):
  File "/home/james/CodeProject/pytorch-image-models/test_vit_get_intermediate_layers_draft.py", line 7, in <module>
    for feature in model.get_intermediate_layers(torch.randn(1, 3, 300, 300), n=[7, 15, 21], reshape=True, norm=True):
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/james/CodeProject/pytorch-image-models/timm/models/vision_transformer.py", line 671, in get_intermediate_layers
    outputs = [
              ^
  File "/home/james/CodeProject/pytorch-image-models/timm/models/vision_transformer.py", line 672, in <listcomp>
    out.reshape(x.shape[0], grid_size[0], grid_size[1], -1).permute(0, 3, 1, 2).contiguous()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: shape '[1, 37, 37, -1]' is invalid for input of size 495616
```

Outputs after this patch:

```
torch.Size([1, 1024, 22, 22])
torch.Size([1, 1024, 22, 22])
torch.Size([1, 1024, 22, 22])
```

### Saved computational costs from unused blocks

If the last requested feature block has already been processed, the inference could be stopped early to save computational costs.

Test code:

```python
import time

import torch
import timm

model = timm.create_model('vit_large_patch14_dinov2.lvd142m', pretrained=True)

start_time = time.time()
for _ in range(5):
    model.get_intermediate_layers(torch.randn(1, 3, 518, 518), n=[3, 5, 7], reshape=True, norm=True)

time_elapsed = time.time() - start_time
print(f'Time cost: {time_elapsed:.2f} seconds')
```

Outputs before this patch:

```
Time cost: 9.21 seconds
```

Outputs after this patch:

```
Time cost: 3.03 seconds
```