### PR TITLE
Update hf_hub.mdx with new import, rename labels

### DIFF
--- a/hfdocs/source/hf_hub.mdx
+++ b/hfdocs/source/hf_hub.mdx
@@ -39,8 +39,8 @@ Here is where you would normally train or fine-tune the model. We'll skip that f
 Let's pretend we've now fine-tuned the model. The next step would be to push it to the Hub! We can do this with the `timm.models.hub.push_to_hf_hub` function.
 
 ```py
->>> model_cfg = dict(labels=['a', 'b', 'c', 'd'])
->>> timm.models.hub.push_to_hf_hub(model, 'resnet18-random', model_config=model_cfg)
+>>> model_cfg = dict(label_names=['a', 'b', 'c', 'd'])
+>>> timm.models.push_to_hf_hub(model, 'resnet18-random', model_config=model_cfg)
 ```
 
 Running the above would push the model to `<your-username>/resnet18-random` on the Hub. You can now share this model with your friends, or use it in your own code!


### PR DESCRIPTION
Change suggested import from `timm.models.hub.push_to_hf_hub` to `timm.models.push_to_hf_hub`

`timm.models.hub.push_to_hf_hub` import fails because of refactor. timm now uses `_hub.py`

https://github.com/huggingface/pytorch-image-models/blob/main/timm/models/_hub.py#L270

which is imported into timm.models.__init__

https://github.com/huggingface/pytorch-image-models/blob/6ccb7d6a7c6f10fcb126313ef80034bca8fcd268/timm/models/__init__.py#L87

Also update `model_cfg=dict(labels...)` to `model_cfg=dict(label_names...)` as per deprecation warning, while we're here.

Thank you for all your work creating this, it's a brilliant library!