### PR TITLE
Fix typo in type annotations in timm.models.hrnet

### DIFF
--- a/timm/models/hrnet.py
+++ b/timm/models/hrnet.py
@@ -834,7 +834,7 @@ class HighResolutionNetFeatures(HighResolutionNet):
     def forward_features(self, x):
         assert False, 'Not supported'
 
-    def forward(self, x) -> List[torch.tensor]:
+    def forward(self, x) -> List[torch.Tensor]:
         out = []
         x = self.conv1(x)
         x = self.bn1(x)


### PR DESCRIPTION
Minor fix to correct a type annotation from `torch.tensor` to `torch.Tensor`.

---


**Background**:

I noticed this by getting the following error when running `torch.jit.script` on the model.

```
RuntimeError: 
Unknown type name 'torch.tensor':
  File "/opt/conda/lib/python3.10/site-packages/timm/models/hrnet.py", line 837
    def forward(self, x) -> List[torch.tensor]:
                                 ~~~~~~~~~~~~ <--- HERE
        out = []
        x = self.conv1(x)
```