### PR TITLE
Initialize weights of reg_token for ViT

### DIFF
--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -590,6 +590,8 @@ class VisionTransformer(nn.Module):
             trunc_normal_(self.pos_embed, std=.02)
         if self.cls_token is not None:
             nn.init.normal_(self.cls_token, std=1e-6)
+        if self.reg_token is not None:
+            nn.init.normal_(self.reg_token, std=1e-6)
         named_apply(get_init_weights_vit(mode, head_bias), self)
 
     def _init_weights(self, m: nn.Module) -> None:


### PR DESCRIPTION
The reg_tokens in VisionTransformer are not initialzed in the init_weights() function. Therefore, when setting `reg_tokens>0` and `no_embed_class=True`, all reg_tokens are initialized as 0 and remain the same during training, unless ROPE is used to break the symmetry. As a result, all of the models from [Searching for Better ViT Baselines](https://huggingface.co/collections/timm/searching-for-better-vit-baselines-663eb74f64f847d2f35a9c19) with `reg_tokens=4` have 4 reg_tokens of the same weight, except `vit_betwixt_patch16_rope_reg4_gap_256.sbb_in1k`. To verify this, run
```
import timm
models = [
    'vit_mediumd_patch16_reg4_gap_256.sbb_in12k_ft_in1k',
    'vit_medium_patch16_reg4_gap_256.sbb_in12k_ft_in1k',
    'vit_medium_patch16_reg4_gap_256.sbb_in1k',
    'vit_betwixt_patch16_reg4_gap_256.sbb_in12k_ft_in1k',
    'vit_betwixt_patch16_reg4_gap_256.sbb_in1k',
    'vit_little_patch16_reg4_gap_256.sbb_in1k',
    'vit_betwixt_patch16_rope_reg4_gap_256.sbb_in1k',
]
for m in models:
    model = timm.create_model(m, pretrained=True)
    print(m, (model.reg_token.std(dim=1) == 0).all())
```
Therefore, the reg_tokens should be randomly initialized in the init_weights() function.