### PR TITLE
Fix LR scheduler help in train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -210,7 +210,7 @@ group.add_argument('--opt-kwargs', nargs='*', default={}, action=utils.ParseKwar
 # Learning rate schedule parameters
 group = parser.add_argument_group('Learning rate schedule parameters')
 group.add_argument('--sched', type=str, default='cosine', metavar='SCHEDULER',
-                   help='LR scheduler (default: "step"')
+                   help='LR scheduler (default: "cosine"')
 group.add_argument('--sched-on-updates', action='store_true', default=False,
                    help='Apply LR scheduler step on update instead of epoch end.')
 group.add_argument('--lr', type=float, default=None, metavar='LR',


### PR DESCRIPTION
The default is and always has been the cosine scheduler, yet the help states that the default would be the step scheduler. Whatever the intended one was, for backwards compatibility the default should definitely remain cosine, which is why I changed the help comment to reflect that.