### PR TITLE
Fix install directory in hfdocs.

### DIFF
--- a/hfdocs/source/installation.mdx
+++ b/hfdocs/source/installation.mdx
@@ -63,7 +63,7 @@ Building `timm` from source lets you make changes to the code base. To install f
 
 ```bash
 git clone https://github.com/rwightman/pytorch-image-models.git
-cd timm
+cd pytorch-image-models
 pip install -e .
 ```
 


### PR DESCRIPTION
Change from "timm" to "pytorch-image-models"

Fixes #2262.
