### PR TITLE
Fix cosine LR scheduler for warmup

### DIFF
--- a/timm/scheduler/cosine_lr.py
+++ b/timm/scheduler/cosine_lr.py
@@ -87,12 +87,12 @@ class CosineLRScheduler(Scheduler):
 
             if self.cycle_mul != 1:
                 i = math.floor(math.log(1 - t / self.t_initial * (1 - self.cycle_mul), self.cycle_mul))
-                t_i = self.cycle_mul ** i * self.t_initial
-                t_curr = t - (1 - self.cycle_mul ** i) / (1 - self.cycle_mul) * self.t_initial
+                t_i = self.cycle_mul ** i * (self.t_initial - self.warmup_t)
+                t_curr = t - (1 - self.cycle_mul ** i) / (1 - self.cycle_mul) * t_i
             else:
                 i = t // self.t_initial
-                t_i = self.t_initial
-                t_curr = t - (self.t_initial * i)
+                t_i = self.t_initial - self.warmup_t
+                t_curr = t - (t_i * i)
 
             gamma = self.cycle_decay ** i
             lr_max_values = [v * gamma for v in self.base_values]


### PR DESCRIPTION
I noticed that when using cosine scheduler with warmup (and `warmup_prefix = True`), the LR will not reach `lr_min`, which can be problematic the larger `warmup_t` is. For example, for `epochs, initial_lr, lr_min, warmup_lr, warmup_t = 500, 1e-4, 1e-7, 1e-7, 100`, we will have the following progression for LR:
![default](https://github.com/user-attachments/assets/3c85dbc9-ba4c-4f00-96e2-a2e36ccbdf16)

I propose to change the code in a way to generate the following:
![proposed](https://github.com/user-attachments/assets/faf78b38-d09d-40ea-b606-d4f556458797)

Hope I have changed the correct lines in the code.
