### PR TITLE
Fix positional embedding resampling for non-square inputs in ViT

### DIFF
--- a/timm/models/deit.py
+++ b/timm/models/deit.py
@@ -75,9 +75,11 @@ class VisionTransformerDistilled(VisionTransformer):
     def _pos_embed(self, x):
         if self.dynamic_img_size:
             B, H, W, C = x.shape
+            prev_grid_size = self.patch_embed.grid_size
             pos_embed = resample_abs_pos_embed(
                 self.pos_embed,
-                (H, W),
+                new_size=(H, W),
+                old_size=prev_grid_size,
                 num_prefix_tokens=0 if self.no_embed_class else self.num_prefix_tokens,
             )
             x = x.view(B, -1, C)

--- a/timm/models/eva.py
+++ b/timm/models/eva.py
@@ -560,9 +560,11 @@ class Eva(nn.Module):
         if self.dynamic_img_size:
             B, H, W, C = x.shape
             if self.pos_embed is not None:
+                prev_grid_size = self.patch_embed.grid_size
                 pos_embed = resample_abs_pos_embed(
                     self.pos_embed,
-                    (H, W),
+                    new_size=(H, W),
+                    old_size=prev_grid_size,
                     num_prefix_tokens=self.num_prefix_tokens,
                 )
             else:

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -669,9 +669,11 @@ class VisionTransformer(nn.Module):
 
         if self.dynamic_img_size:
             B, H, W, C = x.shape
+            prev_grid_size = self.patch_embed.grid_size
             pos_embed = resample_abs_pos_embed(
                 self.pos_embed,
-                (H, W),
+                new_size=(H, W),
+                old_size=prev_grid_size,
                 num_prefix_tokens=0 if self.no_embed_class else self.num_prefix_tokens,
             )
             x = x.view(B, -1, C)


### PR DESCRIPTION
I have been doing some experiments with ViTs for Object Detection. When I `set_input_size` to a larger, non-square size like `[800, 1008]` and then expect the `dynamic_img_size` option to do its job when passing a different size image as input, it breaks.

When using the `dynamic_img_size` option, we dynamically resample (interpolate) positional embeddings. The `resample_abs_pos_embed` function by default assumes the previous grid is square, which I guess is true in most cases. But why assume when we can always pass the old size explicitly?

https://github.com/huggingface/pytorch-image-models/blob/d4dde48dd516d3583128d9ba6548a62cccd93fbc/timm/layers/pos_embed.py#L17-L57

