### PR TITLE
Add trust_remote_code argument to ReaderHfds

### DIFF
--- a/timm/data/readers/reader_hfds.py
+++ b/timm/data/readers/reader_hfds.py
@@ -38,6 +38,7 @@ class ReaderHfds(Reader):
             input_key: str = 'image',
             target_key: str = 'label',
             download: bool = False,
+            trust_remote_code: bool = False
     ):
         """
         """
@@ -48,6 +49,7 @@ class ReaderHfds(Reader):
             name,  # 'name' maps to path arg in hf datasets
             split=split,
             cache_dir=self.root,  # timm doesn't expect hidden cache dir for datasets, specify a path
+            trust_remote_code=trust_remote_code
         )
         # leave decode for caller, plus we want easy access to original path names...
         self.dataset = self.dataset.cast_column(input_key, datasets.Image(decode=False))


### PR DESCRIPTION
Hi ! 

Some datasets on huggingface require the execution of code downloaded from the hub. 
Since a few months, this now requires to set the flag `trust_remote_code=True` in [`load_dataset()`](https://huggingface.co/docs/datasets/v3.1.0/en/package_reference/loading_methods#datasets.load_dataset).

This PR adds the `trust_remote_code` argument to `ReaderHfds`. This means that we can now do: 
```python
from timm.data import create_dataset

imagenet = create_dataset(
    "hfds/imagenet-1k",
    root="data/,
    download=True,
    split="train",
    trust_remote_code=True,
)
```

Best,
Augustin