### PR TITLE
(nit) Fix <Tip> style in docs

### DIFF
--- a/hfdocs/source/quickstart.mdx
+++ b/hfdocs/source/quickstart.mdx
@@ -22,7 +22,9 @@ Here, we load the pretrained `mobilenetv3_large_100` model.
 ```
 
 <Tip>
-    Note: The returned PyTorch model is set to train mode by default, so you must call .eval() on it if you plan to use it for inference.
+
+    **Note:** The returned PyTorch model is set to train mode by default, so you must call `.eval()` on it if you plan to use it for inference.
+
 </Tip>
 
 ## List Models with Pretrained Weights
@@ -151,7 +153,9 @@ Compose(
 ```
 
 <Tip>
-    Note: Here, the pretrained model's config happens to be the same as the generic config we made earlier. This is not always the case. So, it's safer to use the data config to create the transform as we did here instead of using the generic transform.
+
+    **Note:** Here, the pretrained model's config happens to be the same as the generic config we made earlier. This is not always the case. So, it's safer to use the data config to create the transform as we did here instead of using the generic transform.
+
 </Tip>
 
 ## Using Pretrained Models for Inference

--- a/timm/models/_factory.py
+++ b/timm/models/_factory.py
@@ -51,8 +51,10 @@ def create_model(
     Lookup model's entrypoint function and pass relevant args to create a new model.
 
     <Tip>
-        **kwargs will be passed through entrypoint fn to ``timm.models.build_model_with_cfg()``
+
+        **kwargs will be passed through entrypoint fn to `timm.models.build_model_with_cfg()`
         and then the model class __init__(). kwargs values set to None are pruned before passing.
+
     </Tip>
 
     Args:


### PR DESCRIPTION
When using the [doc-builder](https://github.com/huggingface/doc-builder), one must add newlines inside the `<Tip>` section to make it compatible with markdown styling (don't know if it's a feature or a bug, but that's how it is ^^).

That's how it currently looks without this PR: 
![image](https://github.com/user-attachments/assets/3817b4cf-e78a-4580-9b31-5b0c09c3deb9)

With this PR:

![image](https://github.com/user-attachments/assets/1fe8b1b1-cec9-431d-aa9f-c20087f2b79e)
