### PR TITLE
Update timm torchvision resnet weight urls to the updated urls in torchvision

### DIFF
--- a/timm/models/resnet.py
+++ b/timm/models/resnet.py
@@ -855,15 +855,15 @@ default_cfgs = generate_default_cfgs({
     # torchvision resnet weights
     'resnet18.tv_in1k': _cfg(
         hf_hub_id='timm/',
-        url='https://download.pytorch.org/models/resnet18-5c106cde.pth',
+        url='https://download.pytorch.org/models/resnet18-f37072fd.pth',
         license='bsd-3-clause', origin_url='https://github.com/pytorch/vision'),
     'resnet34.tv_in1k': _cfg(
         hf_hub_id='timm/',
-        url='https://download.pytorch.org/models/resnet34-333f7ec4.pth',
+        url='https://download.pytorch.org/models/resnet34-b627a593.pth',
         license='bsd-3-clause', origin_url='https://github.com/pytorch/vision'),
     'resnet50.tv_in1k': _cfg(
         hf_hub_id='timm/',
-        url='https://download.pytorch.org/models/resnet50-19c8e357.pth',
+        url='https://download.pytorch.org/models/resnet50-0676ba61.pth',
         license='bsd-3-clause', origin_url='https://github.com/pytorch/vision'),
     'resnet50.tv2_in1k': _cfg(
         hf_hub_id='timm/',
@@ -872,7 +872,7 @@ default_cfgs = generate_default_cfgs({
         license='bsd-3-clause', origin_url='https://github.com/pytorch/vision'),
     'resnet101.tv_in1k': _cfg(
         hf_hub_id='timm/',
-        url='https://download.pytorch.org/models/resnet101-5d3b4d8f.pth',
+        url='https://download.pytorch.org/models/resnet101-63fe2227.pth',
         license='bsd-3-clause', origin_url='https://github.com/pytorch/vision'),
     'resnet101.tv2_in1k': _cfg(
         hf_hub_id='timm/',
@@ -881,7 +881,7 @@ default_cfgs = generate_default_cfgs({
         license='bsd-3-clause', origin_url='https://github.com/pytorch/vision'),
     'resnet152.tv_in1k': _cfg(
         hf_hub_id='timm/',
-        url='https://download.pytorch.org/models/resnet152-b121ed2d.pth',
+        url='https://download.pytorch.org/models/resnet152-394f9c45.pth',
         license='bsd-3-clause', origin_url='https://github.com/pytorch/vision'),
     'resnet152.tv2_in1k': _cfg(
         hf_hub_id='timm/',


### PR DESCRIPTION
This fix updates the weight urls of timm to be in sync again with torchvision resnet*.IMAGENET1K_V1 models.

During my work, I found that resnet weight urls in timm and torchvision are different and was wondering why. 

A quick search revealed that models have been re-uploaded with new serialization in 2020 (see https://github.com/pytorch/vision/issues/2068 ). The new files have a different hash and hence, a different url. This PR updates the urls in timm to the updated urls in torchvision:

- ResNet18: https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py#L312
- ResNet34: https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py#L334
- ResNet50: https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py#L356
- ResNet101: https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py#L399
- ResNet151: https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py#L442

Note that the old urls are still online for BC. 

In summary, it's probably not super important to change urls but at the same time, why not fix it :)

