### PR TITLE
[RFC] Faster load time for large models

### DIFF
--- a/timm/models/_builder.py
+++ b/timm/models/_builder.py
@@ -2,8 +2,10 @@ import dataclasses
 import logging
 import os
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
+from contextlib import nullcontext
 
+import torch
 from torch import nn as nn
 from torch.hub import load_state_dict_from_url
 
@@ -411,10 +413,13 @@ def build_model_with_cfg(
             feature_cfg['feature_cls'] = kwargs.pop('feature_cls')
 
     # Instantiate the model
-    if model_cfg is None:
-        model = model_cls(**kwargs)
-    else:
-        model = model_cls(cfg=model_cfg, **kwargs)
+    with torch.device("meta") if pretrained else nullcontext():
+        if model_cfg is None:
+            model = model_cls(**kwargs)
+        else:
+            model = model_cls(cfg=model_cfg, **kwargs)
+    if pretrained:
+        model.to_empty(device="cpu")
     model.pretrained_cfg = pretrained_cfg
     model.default_cfg = model.pretrained_cfg  # alias for backwards compat
 

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -539,7 +539,8 @@ class VisionTransformer(nn.Module):
             self.patch_drop = nn.Identity()
         self.norm_pre = norm_layer(embed_dim) if pre_norm else nn.Identity()
 
-        dpr = [x.item() for x in torch.linspace(0, drop_path_rate, depth)]  # stochastic depth decay rule
+        with torch.device("cpu"):
+            dpr = [x.item() for x in torch.linspace(0, drop_path_rate, depth)]  # stochastic depth decay rule
         self.blocks = nn.Sequential(*[
             block_fn(
                 dim=embed_dim,


### PR DESCRIPTION
While playing around with Flux-Redux, which used siglip-so400m, I noticed that loading time is pretty slow. I think we can bring some of the loading-time optimizations for LLMs to timm too. Hence, I open this RFC to ask for feedback if you think it is a useful improvement to timm.

As a proof-of-concept, I added [meta device](https://pytorch.org/docs/2.5/meta) to skip weight initialization.

Benchmark script (lmk if you want to use a different way to benchmark weight loading time)

```python
import torch
import timm
import time

model = timm.create_model("vit_so400m_patch14_siglip_378.webli", pretrained=True)

N = 4
time0 = time.perf_counter()
for _ in range(N):
    model = timm.create_model("vit_so400m_patch14_siglip_378.webli", pretrained=True)
print((time.perf_counter() - time0) / N)

model(torch.randn(1, 3, 378, 378))  # make sure model forward works
```

| Name | Time (s) |
|--------|--------|
| Baseline | 4.20 |
| w/ meta device | 0.72 | 

Some considerations about meta device
- meta device only exists for PyTorch>=2.3 I think. Need to guard the usage of meta device against PyTorch version
- In some cases, we need to bypass meta device during model init, such as what I did in ViT model file for calculating stochastic depth. I believe there are such cases for other models too.
- I'm not aware of any other caveats for meta device.

Do let me know your thoughts and whether I should proceed with this PR.

Apart from using meta device, some other optimizations we can look into (possibly in future PRs):
- Use `torch.load(mmap=True)` (I believe safetensors already uses memory-map by default?)
- Use `model.load_state_dict(assign=True)`