### PR TITLE
Add inception_next_atto

### DIFF
--- a/timm/models/inception_next.py
+++ b/timm/models/inception_next.py
@@ -375,6 +375,10 @@ def _cfg(url='', **kwargs):
 
 
 default_cfgs = generate_default_cfgs({
+    'inception_next_atto.sail_in1k': _cfg(
+        hf_hub_id='timm/',
+        # url='https://github.com/sail-sg/inceptionnext/releases/download/model/inceptionnext_atto.pth',
+    ),
     'inception_next_tiny.sail_in1k': _cfg(
         hf_hub_id='timm/',
         # url='https://github.com/sail-sg/inceptionnext/releases/download/model/inceptionnext_tiny.pth',
@@ -403,6 +407,15 @@ def _create_inception_next(variant, pretrained=False, **kwargs):
         **kwargs,
     )
     return model
+
+
+@register_model
+def inception_next_atto(pretrained=False, **kwargs):
+    model_args = dict(
+        depths=(2, 2, 6, 2), dims=(40, 80, 160, 320),
+        token_mixers=partial(InceptionDWConv2d, band_kernel_size=9, branch_ratio=0.25)
+    )
+    return _create_inception_next('inception_next_tiny', pretrained=pretrained, **dict(model_args, **kwargs))
 
 
 @register_model


### PR DESCRIPTION
Hi Ross,

Thank you so much for your great contribution to our research community. I added inception_next_atto (4.2M, 0.51GMACs, 75.3% top-1) which is supplemented in the InceptionNext CVPR 2024 camera-ready version (https://openaccess.thecvf.com/content/CVPR2024/papers/Yu_InceptionNeXt_When_Inception_Meets_ConvNeXt_CVPR_2024_paper.pdf).

The checkpoint can be found on
https://github.com/sail-sg/inceptionnext/releases/download/model/inceptionnext_atto.pth
OR
https://huggingface.co/whyu/inception_next_atto.sail_in1k

Thank you very much.