### PR TITLE
Fix feature_info.reduction

### DIFF
--- a/timm/models/davit.py
+++ b/timm/models/davit.py
@@ -556,19 +556,19 @@ class DaVit(nn.Module):
 
         dpr = [x.tolist() for x in torch.linspace(0, drop_path_rate, sum(depths)).split(depths)]
         stages = []
-        for stage_idx in range(num_stages):
-            out_chs = embed_dims[stage_idx]
+        for i in range(num_stages):
+            out_chs = embed_dims[i]
             stage = DaVitStage(
                 in_chs,
                 out_chs,
-                depth=depths[stage_idx],
-                downsample=stage_idx > 0,
+                depth=depths[i],
+                downsample=i > 0,
                 attn_types=attn_types,
-                num_heads=num_heads[stage_idx],
+                num_heads=num_heads[i],
                 window_size=window_size,
                 mlp_ratio=mlp_ratio,
                 qkv_bias=qkv_bias,
-                drop_path_rates=dpr[stage_idx],
+                drop_path_rates=dpr[i],
                 norm_layer=norm_layer,
                 norm_layer_cl=norm_layer_cl,
                 ffn=ffn,
@@ -579,7 +579,7 @@ class DaVit(nn.Module):
             )
             in_chs = out_chs
             stages.append(stage)
-            self.feature_info += [dict(num_chs=out_chs, reduction=2, module=f'stages.{stage_idx}')]
+            self.feature_info += [dict(num_chs=out_chs, reduction=2**(i+2), module=f'stages.{i}')]
 
         self.stages = nn.Sequential(*stages)
 

--- a/timm/models/efficientformer.py
+++ b/timm/models/efficientformer.py
@@ -407,7 +407,7 @@ class EfficientFormer(nn.Module):
             )
             prev_dim = embed_dims[i]
             stages.append(stage)
-            self.feature_info += [dict(num_chs=embed_dims[i], reduction=2**(1+i), module=f'stages.{i}')]
+            self.feature_info += [dict(num_chs=embed_dims[i], reduction=2**(i+2), module=f'stages.{i}')]
         self.stages = nn.Sequential(*stages)
 
         # Classifier head

--- a/timm/models/metaformer.py
+++ b/timm/models/metaformer.py
@@ -541,7 +541,7 @@ class MetaFormer(nn.Module):
                 **kwargs,
             )]
             prev_dim = dims[i]
-            self.feature_info += [dict(num_chs=dims[i], reduction=2, module=f'stages.{i}')]
+            self.feature_info += [dict(num_chs=dims[i], reduction=2**(i+2), module=f'stages.{i}')]
 
         self.stages = nn.Sequential(*stages)
 


### PR DESCRIPTION
Hi @rwightman , 

This PR fix `feature_info.reduction` for:
- MetaFormer (CaFormer, ConvFormer, PoolFormer, PoolFormerV2)
- DaViT
- EfficientFormer

## Test code

```python
import timm
import torch

model_list = [
    ["caformer_s18", 224],
    ["convformer_s18", 224],
    ["poolformer_s12", 224],
    ["poolformerv2_s12", 224],
    ["davit_tiny", 224],
    ["efficientformer_l1", 224]
]

if __name__ == "__main__":
    for model_name, img_size in model_list:
        x = torch.rand(1, 3, img_size, img_size)
        model = timm.create_model(f"{model_name}", features_only=True).eval()
        y = model(x)
        print(f"timm-{model_name}-(C, H, W) = {(3, img_size, img_size)}")
        print(f"    Feature shape: {[f.detach().numpy().shape[1:] for f in y]}")
        print(f"    Feature channels: {model.feature_info.channels()}")
        print(f"    Feature reduction: {model.feature_info.reduction()}")
```

## Before this PR
https://github.com/huggingface/pytorch-image-models/blob/ea231079f59e65f0ef0a1d8486efd811c1d86a73/timm/models/metaformer.py#L544
### Output
```python
timm-caformer_s18-(C, H, W) = (3, 224, 224)
    Feature shape: [(64, 56, 56), (128, 28, 28), (320, 14, 14), (512, 7, 7)]
    Feature channels: [64, 128, 320, 512]
    Feature reduction: [2, 2, 2, 2]
```
## After this PR
```python
self.feature_info += [dict(num_chs=dims[i], reduction=2**(i+2), module=f'stages.{i}')]
```
### Output
```python
timm-caformer_s18-(C, H, W) = (3, 224, 224)
    Feature shape: [(64, 56, 56), (128, 28, 28), (320, 14, 14), (512, 7, 7)]
    Feature channels: [64, 128, 320, 512]
    Feature reduction: [4, 8, 16, 32]
```