### PR TITLE
Fixed unfused attn2d scale

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,7 +1,8 @@
+import pytest
 import torch
 import torch.nn as nn
 
-from timm.layers import create_act_layer, set_layer_config, get_act_layer, get_act_fn
+from timm.layers import create_act_layer, set_layer_config, get_act_layer, get_act_fn, Attention2d
 
 import importlib
 import os
@@ -119,3 +120,27 @@ def test_get_act_fn_none():
     assert get_act_fn(None) is None
     assert get_act_fn('') is None
 
+
+@pytest.mark.parametrize("bias", [True, False])
+@pytest.mark.parametrize("expand_first", [True, False])
+@pytest.mark.parametrize("head_first", [True, False])
+@pytest.mark.parametrize("attn_mask", [True, False])
+def test_attn2d(bias, expand_first, head_first, attn_mask):
+    x = torch.randn(1, 128, 32, 48)
+    attn = Attention2d(
+        128, 128, num_heads=4, bias=bias, expand_first=expand_first, head_first=head_first
+    )
+    
+    if attn_mask:
+        mask = torch.randint(0, 1, size=(32 * 48, 32 * 48), dtype=torch.float32)
+    else:
+        mask = None
+    
+    o1 = attn(x, mask)
+    attn.fused_attn = False
+    o2 = attn(x, mask)
+    
+    assert torch.allclose(o1, o2, atol=1e-5), f"{torch.abs(o1 - o2).max()}"
+
+    
+    


### PR DESCRIPTION
This PR fixes the scale parameter of the `Attention2d` unfused implementation (#2385).

Two aspects were corrected:

* The scale was changed to `q.size(-1) ** -0.5`, i.e the rsqrt of the number of queries / sequence length. This matches the default value of `torch.nn.functional.scaled_dot_product_attention`.
* Some transpositions were made in the wrong order, resulting in different results. The implementation now closely matches the PyTorch implementation as described in `torch.nn.functional.scaled_dot_product_attention`.

Tests were added to check the new implementation against the fused one.