### PR TITLE
fix grad_checkpoint feature for torch2.5.x

### DIFF
--- a/timm/models/eva.py
+++ b/timm/models/eva.py
@@ -677,7 +677,7 @@ class Eva(nn.Module):
         x, rot_pos_embed = self._pos_embed(x)
         for blk in self.blocks:
             if self.grad_checkpointing and not torch.jit.is_scripting():
-                x = checkpoint(blk, x, rope=rot_pos_embed)
+                x = checkpoint(blk, x, rope=rot_pos_embed, use_reentrant=False)
             else:
                 x = blk(x, rope=rot_pos_embed)
         x = self.norm(x)


### PR DESCRIPTION
In PyTorch version 2.5.x, passing `kwargs` alongside `use_reentrant=True` in `torch.utils.checkpoint` results in an error. To address this, it needs to explicitly set `use_reentrant=False` to avoid runtime issues.
