### PR TITLE
timm: add __all__ to __init__

### DIFF
--- a/timm/__init__.py
+++ b/timm/__init__.py
@@ -1,4 +1,30 @@
 from .version import __version__
 from .layers import is_scriptable, is_exportable, set_scriptable, set_exportable
-from .models import create_model, list_models, list_pretrained, is_model, list_modules, model_entrypoint, \
-    is_model_pretrained, get_pretrained_cfg, get_pretrained_cfg_value
+from .models import (
+    create_model,
+    list_models,
+    list_pretrained,
+    is_model,
+    list_modules,
+    model_entrypoint,
+    is_model_pretrained,
+    get_pretrained_cfg,
+    get_pretrained_cfg_value,
+)
+
+__all__ = [
+    "__version__",
+    "is_scriptable",
+    "is_exportable",
+    "set_scriptable",
+    "set_exportable",
+    "create_model",
+    "list_models",
+    "list_pretrained",
+    "is_model",
+    "list_modules",
+    "model_entrypoint",
+    "is_model_pretrained",
+    "get_pretrained_cfg",
+    "get_pretrained_cfg_value",
+]


### PR DESCRIPTION
This fixes mypy errors on files like:
```python
import timm

timm.create_model("resnet18")
```
The error can be reproduced using:
```
> mypy --strict test.py
test.py:3: error: Module "timm" does not explicitly export attribute "create_model"  [attr-defined]
Found 1 error in 1 file (checked 1 source file)
```