### PR TITLE
VGG ConvMlp: fix layer defaults/types

### DIFF
--- a/timm/models/vgg.py
+++ b/timm/models/vgg.py
@@ -38,8 +38,8 @@ class ConvMlp(nn.Module):
             kernel_size=7,
             mlp_ratio=1.0,
             drop_rate: float = 0.2,
-            act_layer: Optional[Type[nn.Module]] = None,
-            conv_layer: Optional[Type[nn.Module]] = None,
+            act_layer: Type[nn.Module] = nn.ReLU,
+            conv_layer: Type[nn.Module] = nn.Conv2d,
     ):
         super(ConvMlp, self).__init__()
         self.input_kernel_size = kernel_size


### PR DESCRIPTION
Although the default is `None`, a value of `None` is invalid and will cause the `__init__` method to crash. Using mypy would have caught this issue. This PR changes the default to be a valid input.