### PR TITLE
Implement labels argument for create_dataset (and downstream functions)

### DIFF
--- a/timm/data/dataset.py
+++ b/timm/data/dataset.py
@@ -24,6 +24,7 @@ class ImageDataset(data.Dataset):
             self,
             root,
             reader=None,
+            labels=None,
             split='train',
             class_map=None,
             load_bytes=False,
@@ -36,6 +37,7 @@ class ImageDataset(data.Dataset):
             reader = create_reader(
                 reader or '',
                 root=root,
+                labels=labels,
                 split=split,
                 class_map=class_map,
                 **kwargs,
@@ -89,6 +91,7 @@ class IterableImageDataset(data.IterableDataset):
             self,
             root,
             reader=None,
+            labels=None,
             split='train',
             class_map=None,
             is_training=False,
@@ -110,6 +113,7 @@ class IterableImageDataset(data.IterableDataset):
             self.reader = create_reader(
                 reader,
                 root=root,
+                labels=labels,
                 split=split,
                 class_map=class_map,
                 is_training=is_training,

--- a/timm/data/dataset_factory.py
+++ b/timm/data/dataset_factory.py
@@ -3,7 +3,7 @@
 Hacked together by / Copyright 2021, Ross Wightman
 """
 import os
-from typing import Optional
+from typing import Optional, Union, Dict
 
 from torchvision.datasets import CIFAR100, CIFAR10, MNIST, KMNIST, FashionMNIST, ImageFolder
 try:
@@ -63,6 +63,7 @@ def _search_split(root, split):
 def create_dataset(
         name: str,
         root: Optional[str] = None,
+        labels: Optional[Union[Dict, str]] = None,
         split: str = 'validation',
         search_split: bool = True,
         class_map: dict = None,
@@ -91,6 +92,7 @@ def create_dataset(
     Args:
         name: Dataset name, empty is okay for folder based datasets
         root: Root folder of dataset (All)
+        labels: Specify filename -> label mapping via file or dict (Folder)
         split: Dataset split (All)
         search_split: Search for split specific child fold from root so one can specify
             `imagenet/` instead of `/imagenet/val`, etc on cmd line / config. (Folder, Torch)
@@ -112,6 +114,7 @@ def create_dataset(
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
     name = name.lower()
     if name.startswith('torch/'):
+        assert labels is None, "Argument 'labels' incompatible with name 'torch/...'"
         name = name.split('/', 2)[-1]
         torch_kwargs = dict(root=root, download=download, **kwargs)
         if name in _TORCH_BASIC_DS:
@@ -162,6 +165,7 @@ def create_dataset(
         ds = ImageDataset(
             root,
             reader=name,
+            labels=labels,
             split=split,
             class_map=class_map,
             input_img_mode=input_img_mode,
@@ -172,6 +176,7 @@ def create_dataset(
         ds = IterableImageDataset(
             root,
             reader=name,
+            labels=labels,
             split=split,
             class_map=class_map,
             is_training=is_training,
@@ -188,6 +193,7 @@ def create_dataset(
         ds = IterableImageDataset(
             root,
             reader=name,
+            labels=labels,
             split=split,
             class_map=class_map,
             is_training=is_training,
@@ -203,6 +209,7 @@ def create_dataset(
         ds = IterableImageDataset(
             root,
             reader=name,
+            labels=labels,
             split=split,
             class_map=class_map,
             is_training=is_training,
@@ -221,6 +228,7 @@ def create_dataset(
         ds = ImageDataset(
             root,
             reader=name,
+            labels=labels,
             class_map=class_map,
             load_bytes=load_bytes,
             input_img_mode=input_img_mode,

--- a/timm/data/readers/reader_factory.py
+++ b/timm/data/readers/reader_factory.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional
+from typing import Optional, Union, Dict
 
 from .reader_image_folder import ReaderImageFolder
 from .reader_image_in_tar import ReaderImageInTar
@@ -8,6 +8,7 @@ from .reader_image_in_tar import ReaderImageInTar
 def create_reader(
         name: str,
         root: Optional[str] = None,
+        labels: Optional[Union[Dict, str]] = None,
         split: str = 'train',
         **kwargs,
 ):
@@ -18,6 +19,13 @@ def create_reader(
     if len(name) > 1:
         prefix = name[0]
     name = name[-1]
+
+    if isinstance(labels, str):
+        import json
+        with open(labels, 'r') as labels_file:
+            labels = json.load(labels_file)
+    if labels is not None:
+        kwargs["labels"] = labels
 
     # FIXME improve the selection right now just tfds prefix or fallback path, will need options to
     # explicitly select other options shortly

--- a/train.py
+++ b/train.py
@@ -85,6 +85,8 @@ parser.add_argument('--data-dir', metavar='DIR',
                     help='path to dataset (root dir)')
 parser.add_argument('--dataset', metavar='NAME', default='',
                     help='dataset type + name ("<type>/<name>") (default: ImageFolder or ImageTar if empty)')
+group.add_argument('--labels', metavar='FILENAME',
+                   help='File containing the filename to label associations.')
 group.add_argument('--train-split', metavar='NAME', default='train',
                    help='dataset train split (default: train)')
 group.add_argument('--val-split', metavar='NAME', default='validation',
@@ -656,6 +658,7 @@ def main():
     dataset_train = create_dataset(
         args.dataset,
         root=args.data_dir,
+        labels=args.labels,
         split=args.train_split,
         is_training=True,
         class_map=args.class_map,
@@ -674,6 +677,7 @@ def main():
         dataset_eval = create_dataset(
             args.dataset,
             root=args.data_dir,
+            labels=args.labels,
             split=args.val_split,
             is_training=False,
             class_map=args.class_map,


### PR DESCRIPTION
Implement support for providing the labels with a json file for the "Folder" dataset. Support for other file formats could also be added easily.

I train on pseudo-labels and having to realize the pseudo-labeling using the file system is very slow.

It was not entirely clear to me at which level I should load the actual file, i.e. when to convert the `Union[Dict, str]` to `Dict`. I decided on `create_reader` but it could theoretically also be done one level later, i.e. in `find_images_and_targets`.