### PR TITLE
Fix num_classes update in reset_classifier and RDNet forward head call

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -265,6 +265,7 @@ def test_model_default_cfgs(model_name, batch_size):
 
         # test forward after deleting the classifier, output should be poooled, size(-1) == model.num_features
         model.reset_classifier(0)
+        assert model.num_classes == 0, f'Expected num_classes to be 0 after reset_classifier(0), but got {model.num_classes}'
         model.to(torch_device)
         outputs = model.forward(input_tensor)
         assert len(outputs.shape) == 2
@@ -339,6 +340,7 @@ def test_model_default_cfgs_non_std(model_name, batch_size):
 
     # test forward after deleting the classifier, output should be poooled, size(-1) == model.num_features
     model.reset_classifier(0)
+    assert model.num_classes == 0, f'Expected num_classes to be 0 after reset_classifier(0), but got {model.num_classes}'
     model.to(torch_device)
     outputs = model.forward(input_tensor)
     if isinstance(outputs,  (tuple, list)):

--- a/timm/models/davit.py
+++ b/timm/models/davit.py
@@ -633,6 +633,7 @@ class DaVit(nn.Module):
         return self.head.fc
 
     def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None):
+        self.num_classes = num_classes
         self.head.reset(num_classes, global_pool)
 
     def forward_features(self, x):

--- a/timm/models/focalnet.py
+++ b/timm/models/focalnet.py
@@ -455,6 +455,7 @@ class FocalNet(nn.Module):
         return self.head.fc
 
     def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None):
+        self.num_classes = num_classes
         self.head.reset(num_classes, pool_type=global_pool)
 
     def forward_features(self, x):

--- a/timm/models/metaformer.py
+++ b/timm/models/metaformer.py
@@ -584,6 +584,7 @@ class MetaFormer(nn.Module):
         return self.head.fc
 
     def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None):
+        self.num_classes = num_classes
         if global_pool is not None:
             self.head.global_pool = SelectAdaptivePool2d(pool_type=global_pool)
             self.head.flatten = nn.Flatten(1) if global_pool else nn.Identity()

--- a/timm/models/nextvit.py
+++ b/timm/models/nextvit.py
@@ -557,6 +557,7 @@ class NextViT(nn.Module):
         return self.head.fc
 
     def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None):
+        self.num_classes = num_classes
         self.head.reset(num_classes, pool_type=global_pool)
 
     def forward_features(self, x):

--- a/timm/models/nfnet.py
+++ b/timm/models/nfnet.py
@@ -434,6 +434,7 @@ class NormFreeNet(nn.Module):
         return self.head.fc
 
     def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None):
+        self.num_classes = num_classes
         self.head.reset(num_classes, global_pool)
 
     def forward_features(self, x):

--- a/timm/models/pvt_v2.py
+++ b/timm/models/pvt_v2.py
@@ -384,7 +384,7 @@ class PyramidVisionTransformerV2(nn.Module):
         if global_pool is not None:
             assert global_pool in ('avg', '')
             self.global_pool = global_pool
-        self.head = nn.Linear(self.embed_dim, num_classes) if num_classes > 0 else nn.Identity()
+        self.head = nn.Linear(self.num_features, num_classes) if num_classes > 0 else nn.Identity()
 
     def forward_features(self, x):
         x = self.patch_embed(x)

--- a/timm/models/rdnet.py
+++ b/timm/models/rdnet.py
@@ -349,6 +349,7 @@ class RDNet(nn.Module):
         return self.head.fc
 
     def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None):
+        self.num_classes = num_classes
         self.head.reset(num_classes, global_pool)
 
     def forward_features(self, x):

--- a/timm/models/rdnet.py
+++ b/timm/models/rdnet.py
@@ -362,7 +362,7 @@ class RDNet(nn.Module):
 
     def forward(self, x):
         x = self.forward_features(x)
-        x = self.head(x)
+        x = self.forward_head(x)
         return x
 
     @torch.jit.ignore

--- a/timm/models/regnet.py
+++ b/timm/models/regnet.py
@@ -515,6 +515,7 @@ class RegNet(nn.Module):
         return self.head.fc
 
     def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None):
+        self.num_classes = num_classes
         self.head.reset(num_classes, pool_type=global_pool)
 
     def forward_intermediates(

--- a/timm/models/tresnet.py
+++ b/timm/models/tresnet.py
@@ -225,6 +225,7 @@ class TResNet(nn.Module):
         return self.head.fc
 
     def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None):
+        self.num_classes = num_classes
         self.head.reset(num_classes, pool_type=global_pool)
 
     def forward_features(self, x):

--- a/timm/models/vision_transformer_sam.py
+++ b/timm/models/vision_transformer_sam.py
@@ -537,6 +537,7 @@ class VisionTransformerSAM(nn.Module):
         return self.head
 
     def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None):
+        self.num_classes = num_classes
         self.head.reset(num_classes, global_pool)
 
     def forward_intermediates(

--- a/timm/models/xception_aligned.py
+++ b/timm/models/xception_aligned.py
@@ -275,6 +275,7 @@ class XceptionAligned(nn.Module):
         return self.head.fc
 
     def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None):
+        self.num_classes = num_classes
         self.head.reset(num_classes, pool_type=global_pool)
 
     def forward_features(self, x):


### PR DESCRIPTION
Hi @rwightman ,


1. `self.reset_classifier` Bug:
The `self.reset_classifier` method now properly updates `self.num_classes` when the `num_classes` parameter is used. (Only a few models lacked this update, while most already had it correctly implemented)

2. RDNet forward Method Bug:
Fixed the forward method of RDNet, where it incorrectly called `self.head(x)`. It now correctly calls `self.forward_head(x)` to ensure proper functionality during the forward pass.