### PR TITLE
timm.models: explicitly export attributes

### DIFF
--- a/timm/models/__init__.py
+++ b/timm/models/__init__.py
@@ -81,20 +81,82 @@ from .xception import *
 from .xception_aligned import *
 from .xcit import *
 
-from ._builder import build_model_with_cfg, load_pretrained, load_custom_pretrained, resolve_pretrained_cfg, \
-    set_pretrained_download_progress, set_pretrained_check_hash
-from ._factory import create_model, parse_model_name, safe_model_name
-from ._features import FeatureInfo, FeatureHooks, FeatureHookNet, FeatureListNet, FeatureDictNet
-from ._features_fx import FeatureGraphNet, GraphExtractNet, create_feature_extractor, get_graph_node_names, \
-    register_notrace_module, is_notrace_module, get_notrace_modules, \
-    register_notrace_function, is_notrace_function, get_notrace_functions
-from ._helpers import clean_state_dict, load_state_dict, load_checkpoint, remap_state_dict, resume_checkpoint
-from ._hub import load_model_config_from_hf, load_state_dict_from_hf, push_to_hf_hub
-from ._manipulate import model_parameters, named_apply, named_modules, named_modules_with_params, \
-    group_modules, group_parameters, checkpoint_seq, checkpoint, adapt_input_conv
-from ._pretrained import PretrainedCfg, DefaultCfg, filter_pretrained_cfg
-from ._prune import adapt_model_from_string
-from ._registry import split_model_name_tag, get_arch_name, generate_default_cfgs, register_model, \
-    register_model_deprecations, model_entrypoint, list_models, list_pretrained, get_deprecated_models, \
-    is_model, list_modules, is_model_in_modules, is_model_pretrained, get_pretrained_cfg, get_pretrained_cfg_value, \
-    get_arch_pretrained_cfgs
+from ._builder import (
+    build_model_with_cfg as build_model_with_cfg,
+    load_pretrained as load_pretrained,
+    load_custom_pretrained as load_custom_pretrained,
+    resolve_pretrained_cfg as resolve_pretrained_cfg,
+    set_pretrained_download_progress as set_pretrained_download_progress,
+    set_pretrained_check_hash as set_pretrained_check_hash,
+)
+from ._factory import (
+    create_model as create_model,
+    parse_model_name as parse_model_name,
+    safe_model_name as safe_model_name,
+)
+from ._features import (
+    FeatureInfo as FeatureInfo,
+    FeatureHooks as FeatureHooks,
+    FeatureHookNet as FeatureHookNet,
+    FeatureListNet as FeatureListNet,
+    FeatureDictNet as FeatureDictNet,
+)
+from ._features_fx import (
+    FeatureGraphNet as FeatureGraphNet,
+    GraphExtractNet as GraphExtractNet,
+    create_feature_extractor as create_feature_extractor,
+    get_graph_node_names as get_graph_node_names,
+    register_notrace_module as register_notrace_module,
+    is_notrace_module as is_notrace_module,
+    get_notrace_modules as get_notrace_modules,
+    register_notrace_function as register_notrace_function,
+    is_notrace_function as is_notrace_function,
+    get_notrace_functions as get_notrace_functions,
+)
+from ._helpers import (
+    clean_state_dict as clean_state_dict,
+    load_state_dict as load_state_dict,
+    load_checkpoint as load_checkpoint,
+    remap_state_dict as remap_state_dict,
+    resume_checkpoint as resume_checkpoint,
+)
+from ._hub import (
+    load_model_config_from_hf as load_model_config_from_hf,
+    load_state_dict_from_hf as load_state_dict_from_hf,
+    push_to_hf_hub as push_to_hf_hub,
+)
+from ._manipulate import (
+    model_parameters as model_parameters,
+    named_apply as named_apply,
+    named_modules as named_modules,
+    named_modules_with_params as named_modules_with_params,
+    group_modules as group_modules,
+    group_parameters as group_parameters,
+    checkpoint_seq as checkpoint_seq,
+    checkpoint as checkpoint,
+    adapt_input_conv as adapt_input_conv,
+)
+from ._pretrained import (
+    PretrainedCfg as PretrainedCfg,
+    DefaultCfg as DefaultCfg,
+    filter_pretrained_cfg as filter_pretrained_cfg,
+)
+from ._prune import adapt_model_from_string as adapt_model_from_string
+from ._registry import (
+    split_model_name_tag as split_model_name_tag,
+    get_arch_name as get_arch_name,
+    generate_default_cfgs as generate_default_cfgs,
+    register_model as register_model,
+    register_model_deprecations as register_model_deprecations,
+    model_entrypoint as model_entrypoint,
+    list_models as list_models,
+    list_pretrained as list_pretrained,
+    get_deprecated_models as get_deprecated_models,
+    is_model as is_model,
+    list_modules as list_modules,
+    is_model_in_modules as is_model_in_modules,
+    is_model_pretrained as is_model_pretrained,
+    get_pretrained_cfg as get_pretrained_cfg,
+    get_pretrained_cfg_value as get_pretrained_cfg_value,
+    get_arch_pretrained_cfgs as get_arch_pretrained_cfgs,
+)


### PR DESCRIPTION
Same as #2399 but for `timm.models`. I didn't bother with any other `__init__.py` or star imports because I'm not currently using them.