### PR TITLE
pyproject.toml: add required dep versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ classifiers = [
         'Topic :: Software Development :: Libraries :: Python Modules',
 ]
 dependencies = [
-        'torch',
+        'torch>=1.7',
         'torchvision',
         'pyyaml',
         'huggingface_hub',
-        'safetensors',
+        'safetensors>=0.2',
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
These versions are listed in `requirements.txt` and used to be listed in `setup.py`. If these are known lower bounds, we should document them in `pyproject.toml` so that `pip` and friends can use them to make better decisions.