### PR TITLE
Initial NaFlex ViT model and training support

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,12 +56,12 @@ FEAT_INTER_FILTERS = [
     'regnet', 'byobnet', 'byoanet', 'mlp_mixer', 'hiera', 'fastvit', 'hieradet_sam2', 'aimv2*', 'tnt',
     'tiny_vit', 'vovnet', 'tresnet', 'rexnet', 'resnetv2', 'repghost', 'repvit', 'pvt_v2', 'nextvit', 'nest',
     'mambaout', 'inception_next', 'inception_v4', 'hgnet', 'gcvit', 'focalnet', 'efficientformer_v2', 'edgenext',
-    'davit', 'rdnet', 'convnext', 'pit', 'starnet', 'shvit', 'fasternet', 'swiftformer', 'ghostnet',
+    'davit', 'rdnet', 'convnext', 'pit', 'starnet', 'shvit', 'fasternet', 'swiftformer', 'ghostnet', 'naflexvit'
 ]
 
 # transformer / hybrid models don't support full set of spatial / feature APIs and/or have spatial output.
 NON_STD_FILTERS = [
-    'vit_*', 'tnt_*', 'pit_*', 'coat_*', 'cait_*', '*mixer_*', 'gmlp_*', 'resmlp_*', 'twins_*',
+    'vit_*', 'naflexvit*', 'tnt_*', 'pit_*', 'coat_*', 'cait_*', '*mixer_*', 'gmlp_*', 'resmlp_*', 'twins_*',
     'convit_*', 'levit*', 'visformer*', 'deit*', 'xcit_*', 'crossvit_*', 'beit*', 'aimv2*', 'swiftformer_*',
     'poolformer_*', 'volo_*', 'sequencer2d_*', 'mvitv2*', 'gcvit*', 'efficientformer*', 'sam_hiera*',
     'eva_*', 'flexivit*', 'eva02*', 'samvit_*', 'efficientvit_m*', 'tiny_vit_*', 'hiera_*', 'vitamin*', 'test_vit*',

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -78,7 +78,7 @@ else:
     EXCLUDE_FILTERS = ['*enormous*']
     NON_STD_EXCLUDE_FILTERS = ['*gigantic*', '*enormous*', '*_3b_*']
 
-EXCLUDE_JIT_FILTERS = ['hiera_*']
+EXCLUDE_JIT_FILTERS = ['hiera_*', '*naflex*']
 
 TARGET_FWD_SIZE = MAX_FWD_SIZE = 384
 TARGET_BWD_SIZE = 128

--- a/timm/data/__init__.py
+++ b/timm/data/__init__.py
@@ -10,6 +10,7 @@ from .loader import create_loader
 from .mixup import Mixup, FastCollateMixup
 from .naflex_dataset import VariableSeqMapWrapper
 from .naflex_loader import create_naflex_loader
+from .naflex_mixup import NaFlexMixup, pairwise_mixup_target, mix_batch_variable_size
 from .naflex_transforms import (
     ResizeToSequence,
     CenterCropToSequence,

--- a/timm/data/__init__.py
+++ b/timm/data/__init__.py
@@ -8,6 +8,8 @@ from .dataset_info import DatasetInfo, CustomDatasetInfo
 from .imagenet_info import ImageNetInfo, infer_imagenet_subset
 from .loader import create_loader
 from .mixup import Mixup, FastCollateMixup
+from .naflex_dataset import VariableSeqMapWrapper
+from .naflex_loader import create_naflex_loader
 from .naflex_transforms import (
     ResizeToSequence,
     CenterCropToSequence,

--- a/timm/data/__init__.py
+++ b/timm/data/__init__.py
@@ -8,6 +8,13 @@ from .dataset_info import DatasetInfo, CustomDatasetInfo
 from .imagenet_info import ImageNetInfo, infer_imagenet_subset
 from .loader import create_loader
 from .mixup import Mixup, FastCollateMixup
+from .naflex_transforms import (
+    ResizeToSequence,
+    CenterCropToSequence,
+    RandomCropToSequence,
+    RandomResizedCropToSequence,
+    ResizeKeepRatioToSequence,
+)
 from .readers import create_reader
 from .readers import get_img_extensions, is_img_extension, set_img_extensions, add_img_extensions, del_img_extensions
 from .real_labels import RealLabelsImagenet

--- a/timm/data/__init__.py
+++ b/timm/data/__init__.py
@@ -8,7 +8,7 @@ from .dataset_info import DatasetInfo, CustomDatasetInfo
 from .imagenet_info import ImageNetInfo, infer_imagenet_subset
 from .loader import create_loader
 from .mixup import Mixup, FastCollateMixup
-from .naflex_dataset import VariableSeqMapWrapper, calculate_naflex_batch_size
+from .naflex_dataset import NaFlexMapDatasetWrapper, calculate_naflex_batch_size
 from .naflex_loader import create_naflex_loader
 from .naflex_mixup import NaFlexMixup, pairwise_mixup_target, mix_batch_variable_size
 from .naflex_transforms import (

--- a/timm/data/__init__.py
+++ b/timm/data/__init__.py
@@ -8,7 +8,7 @@ from .dataset_info import DatasetInfo, CustomDatasetInfo
 from .imagenet_info import ImageNetInfo, infer_imagenet_subset
 from .loader import create_loader
 from .mixup import Mixup, FastCollateMixup
-from .naflex_dataset import VariableSeqMapWrapper
+from .naflex_dataset import VariableSeqMapWrapper, calculate_naflex_batch_size
 from .naflex_loader import create_naflex_loader
 from .naflex_mixup import NaFlexMixup, pairwise_mixup_target, mix_batch_variable_size
 from .naflex_transforms import (
@@ -17,6 +17,8 @@ from .naflex_transforms import (
     RandomCropToSequence,
     RandomResizedCropToSequence,
     ResizeKeepRatioToSequence,
+    Patchify,
+    patchify_image,
 )
 from .readers import create_reader
 from .readers import get_img_extensions, is_img_extension, set_img_extensions, add_img_extensions, del_img_extensions

--- a/timm/data/loader.py
+++ b/timm/data/loader.py
@@ -33,6 +33,7 @@ def fast_collate(batch):
     if isinstance(batch[0][0], tuple):
         # This branch 'deinterleaves' and flattens tuples of input tensors into one tensor ordered by position
         # such that all tuple of position n will end up in a torch.split(tensor, batch_size) in nth position
+        is_np = isinstance(batch[0][0], np.ndarray)
         inner_tuple_size = len(batch[0][0])
         flattened_batch_size = batch_size * inner_tuple_size
         targets = torch.zeros(flattened_batch_size, dtype=torch.int64)
@@ -41,7 +42,10 @@ def fast_collate(batch):
             assert len(batch[i][0]) == inner_tuple_size  # all input tensor tuples must be same length
             for j in range(inner_tuple_size):
                 targets[i + j * batch_size] = batch[i][1]
-                tensor[i + j * batch_size] += torch.from_numpy(batch[i][0][j])
+                if is_np:
+                    tensor[i + j * batch_size] += torch.from_numpy(batch[i][0][j])
+                else:
+                    tensor[i + j * batch_size] += batch[i][0][j]
         return tensor, targets
     elif isinstance(batch[0][0], np.ndarray):
         targets = torch.tensor([b[1] for b in batch], dtype=torch.int64)

--- a/timm/data/naflex_dataset.py
+++ b/timm/data/naflex_dataset.py
@@ -1,0 +1,422 @@
+"""
+Dynamic Sequence Length Datasets for Variable Resolution Image Processing
+
+Implements two dataset wrappers:
+1. DynamicSeqMapDataset - Map-style dataset that returns batches with variable sequence lengths
+2. DynamicSeqIterDataset - Iterable dataset that yields batches with variable sequence lengths
+
+Both support:
+- Pre-initialized transforms for efficiency
+- Distributed training
+- Multiple workers
+- Variable batch sizes based on sequence length
+"""
+
+import math
+import random
+import warnings
+from functools import partial
+from typing import Any, Iterator, List, Tuple, Dict, Optional, Union, Callable
+
+import torch
+from torch.utils.data import Dataset, IterableDataset, DataLoader
+from torchvision import transforms
+from PIL import Image
+
+
+from .naflex_transforms import Patchify, patchify
+
+
+def calculate_batch_size(
+        tokens_per_batch: int,
+        seq_len: int,
+        max_size: Optional[int] = None,
+        divisor: int = 1,
+        rounding: str ='floor',
+):
+    """Calculate batch size based on sequence length with divisibility constraints."""
+    # Calculate raw batch size based on sequence length
+    raw_batch_size = tokens_per_batch / seq_len
+
+    # Apply divisibility with specified rounding method
+    if divisor > 1:
+        if rounding == 'floor':
+            batch_size = math.floor(raw_batch_size / divisor) * divisor
+        elif rounding == 'ceil':
+            batch_size = math.ceil(raw_batch_size / divisor) * divisor
+        else:  # 'round' is the default
+            batch_size = round(raw_batch_size / divisor) * divisor
+    else:
+        # If no divisor specified, just use integer division
+        batch_size = int(raw_batch_size)
+
+    # Ensure batch size is valid
+    batch_size = max(1, batch_size)  # At least 1
+
+    if max_size is not None:
+        batch_size = min(batch_size, max_size)
+
+    return batch_size
+
+
+def _collate_batch(
+    batch_samples: List[Tuple[Dict[str, torch.Tensor], Any]],
+    target_seq_len: int
+    ) -> Tuple[Dict[str, torch.Tensor], torch.Tensor]:
+    """Collates processed samples into a batch, padding/truncating to target_seq_len."""
+    batch_patch_data = [item[0] for item in batch_samples]
+    batch_labels = [item[1] for item in batch_samples]
+
+    if not batch_patch_data:
+         return {}, torch.empty(0)
+
+    batch_size = len(batch_patch_data)
+    patch_dim = batch_patch_data[0]['patches'].shape[1]
+
+    # Initialize tensors with target sequence length
+    patches_batch = torch.zeros((batch_size, target_seq_len, patch_dim), dtype=torch.float32)
+    patch_coord_batch = torch.zeros((batch_size, target_seq_len, 2), dtype=torch.int64)
+    patch_valid_batch = torch.zeros((batch_size, target_seq_len), dtype=torch.bool) # Use bool
+
+    for i, data in enumerate(batch_patch_data):
+        num_patches = data['patches'].shape[0]
+        # Take min(num_patches, target_seq_len) patches
+        n_copy = min(num_patches, target_seq_len)
+
+        patches_batch[i, :n_copy] = data['patches'][:n_copy]
+        patch_coord_batch[i, :n_copy] = data['patch_coord'][:n_copy]
+        patch_valid_batch[i, :n_copy] = data['patch_valid'][:n_copy] # Copy validity flags
+
+    # Create the final input dict
+    input_dict = {
+        'patches': patches_batch,
+        'patch_coord': patch_coord_batch,
+        'patch_valid': patch_valid_batch, # Boolean mask
+        # Note: 'seq_length' might be ambiguous. The target length is target_seq_len.
+        # The actual number of valid patches per sample varies.
+        # 'patch_valid' mask is the most reliable source of truth.
+    }
+
+    # Attempt to stack labels if they are tensors, otherwise return list
+    try:
+        if isinstance(batch_labels[0], torch.Tensor):
+            labels_tensor = torch.stack(batch_labels)
+        else:
+            # Convert numerical types to tensor, keep others as list (or handle specific types)
+            if isinstance(batch_labels[0], (int, float)):
+                 labels_tensor = torch.tensor(batch_labels)
+            else:
+                 # Cannot convert non-numerical labels easily, return as list
+                 # Or handle specific conversion if needed
+                 # For FakeDataset, labels are ints, so this works
+                 labels_tensor = torch.tensor(batch_labels) # Assuming labels are numerical
+    except Exception:
+        # Fallback if stacking fails (e.g., different shapes, types)
+        print("Warning: Could not stack labels into a tensor. Returning list of labels.")
+        labels_tensor = batch_labels # Return as list
+
+    return input_dict, labels_tensor
+
+
+class VariableSeqMapWrapper(IterableDataset):
+    """
+    IterableDataset wrapper for a map-style base dataset.
+
+    Yields batches with variable sequence lengths. It calculates a canonical
+    batch schedule (sequence length, batch size pairs) once based on the
+    total dataset size (padded for distribution). Each epoch, it shuffles
+    the *order* of this canonical schedule and the dataset indices.
+    This ensures a consistent number of batches and samples per epoch
+    across all ranks. Handles distributed training and multiple workers.
+    """
+
+    def __init__(
+            self,
+            base_dataset: Dataset,
+            patch_size: Union[int, Tuple[int, int]] = 16,
+            seq_lens: List[int] = (128, 256, 576, 784, 1024),
+            max_tokens_per_batch: int = 4096 * 4, # Example: 16k tokens
+            transform_factory: Optional[Callable] = None,
+            seed: int = 42,
+            shuffle: bool = True,
+            distributed: bool = False,
+            rank: int = 0,
+            world_size: int = 1,
+            epoch: int = 0,
+            batch_divisor: int = 8, # Ensure batch size is divisible by this
+    ):
+        super().__init__()
+        if not hasattr(base_dataset, '__len__') or not hasattr(base_dataset, '__getitem__'):
+            raise TypeError("base_dataset must be a map-style dataset (implement __len__ and __getitem__)")
+
+        self.base_dataset = base_dataset
+        self.patch_size = patch_size if isinstance(patch_size, tuple) else (patch_size, patch_size)
+        self.seq_lens = sorted(list(set(seq_lens))) # Ensure unique and sorted
+        self.max_tokens_per_batch = max_tokens_per_batch
+        self.seed = seed
+        self.shuffle = shuffle
+        self.distributed = distributed
+        self.rank = rank if distributed else 0
+        self.world_size = world_size if distributed else 1
+        self.epoch = epoch
+        self.batch_divisor = batch_divisor
+
+        # Pre-initialize transforms for each sequence length
+        self.transforms: Dict[int, Optional[Callable]] = {}
+        if transform_factory:
+            for seq_len in self.seq_lens:
+                self.transforms[seq_len] = transform_factory(max_seq_len=seq_len, patch_size=self.patch_size)
+        else:
+             for seq_len in self.seq_lens:
+                 self.transforms[seq_len] = None # No transform
+
+        self.patchifier = Patchify(self.patch_size)
+
+        # --- Canonical Schedule Calculation (Done Once) ---
+        self._canonical_batch_schedule: List[Tuple[int, int]] = []
+        self._num_batches_per_rank: int = 0
+        self._padded_samples_per_rank: int = 0
+        self._create_canonical_schedule() # Calculate schedule based on padded size
+
+        # --- Per-Epoch State ---
+        # Stores (seq_len, list_of_indices) for the current epoch, specific to this rank
+        self._epoch_batches: List[Tuple[int, List[int]]] = []
+        self._prepare_epoch_batches(self.epoch)  # setup for initial epoch
+
+    def _create_canonical_schedule(self):
+        """
+        Calculates the canonical batch schedule (seq_len, batch_size pairs)
+        based on the dataset size, padded for distributed training.
+        This schedule is the *same* for all ranks and ensures consistent
+        epoch length. It is calculated once during initialization.
+        """
+        total_len = len(self.base_dataset)
+        padded_total_len = total_len
+        num_samples_per_rank = total_len
+
+        if self.distributed and self.world_size > 1:
+            # Calculate padding needed for even distribution
+            if total_len % self.world_size != 0:
+                 pad_size = self.world_size - (total_len % self.world_size)
+                 padded_total_len += pad_size
+                 print(f"Rank {self.rank}: Padding dataset with {pad_size} samples for distributed training (total size {padded_total_len}).")
+            else:
+                 pad_size = 0
+
+            if padded_total_len % self.world_size != 0:
+                 # This should not happen with the padding logic, but safeguard
+                 raise RuntimeError(f"Internal Error: Padded total length {padded_total_len} not divisible by world size {self.world_size}")
+
+            num_samples_per_rank = padded_total_len // self.world_size
+        elif self.distributed and self.world_size <= 1:
+             # Distributed flag set but world_size is 1, treat as non-distributed
+             pass # num_samples_per_rank remains total_len
+
+        self._padded_samples_per_rank = num_samples_per_rank
+
+        if num_samples_per_rank == 0:
+             self._canonical_batch_schedule = []
+             self._num_batches_per_rank = 0
+             return
+
+        # Use a fixed seed for generating the canonical schedule structure
+        g = torch.Generator()
+        g.manual_seed(self.seed) # Use base seed, NOT epoch seed
+
+        current_schedule: List[Tuple[int, int]] = []
+        remaining_samples = num_samples_per_rank
+        total_scheduled_samples = 0
+
+        while remaining_samples > 0:
+            # Sample sequence length deterministically based on base seed
+            seq_idx = torch.randint(0, len(self.seq_lens), (1,), generator=g).item()
+            seq_len = self.seq_lens[seq_idx]
+
+            # Calculate batch size
+            batch_size = calculate_batch_size(
+                tokens_per_batch=self.max_tokens_per_batch,
+                seq_len=seq_len,
+                # max_size should be remaining_samples to avoid overshooting
+                max_size=remaining_samples,
+                divisor=self.batch_divisor,
+                rounding='floor',
+            )
+            # Ensure batch size is positive and doesn't exceed remaining samples
+            batch_size = max(1, batch_size)
+            batch_size = min(batch_size, remaining_samples)
+
+            if batch_size <= 0:
+                 warnings.warn(f"Calculated batch size <= 0 (seq_len={seq_len}, remaining={remaining_samples}). Stopping schedule generation early.")
+                 break # Avoid infinite loop if something goes wrong
+
+            current_schedule.append((seq_len, batch_size))
+            remaining_samples -= batch_size
+            total_scheduled_samples += batch_size
+
+        # Sanity check: Ensure the schedule covers all samples for the rank
+        if total_scheduled_samples != num_samples_per_rank:
+            warnings.warn(
+                f"Rank {self.rank}: Canonical schedule accounts for {total_scheduled_samples} samples, "
+                f"but expected {num_samples_per_rank} samples per rank. "
+                f"This might happen if min_batch_size or batch_divisor constraints prevent utilizing all samples. "
+                f"Check parameters. Remaining samples: {remaining_samples}"
+            )
+            # Adjust if needed? Could add a final small batch, but might violate constraints.
+            # Current behavior: some samples might be dropped if schedule logic fails.
+
+        self._canonical_batch_schedule = current_schedule
+        self._num_batches_per_rank = len(current_schedule)
+        print(f"Rank {self.rank}: Created canonical schedule with {self._num_batches_per_rank} batches for {self._padded_samples_per_rank} samples/rank.")
+
+
+    def _prepare_epoch_batches(self, epoch: int):
+        """
+        Prepares the batches for the current epoch by:
+        1. Shuffling the full dataset indices (using epoch seed).
+        2. Applying padding if in distributed mode.
+        3. Selecting indices for the current rank.
+        4. Shuffling the *order* of the canonical batch schedule (using epoch seed).
+        5. Assigning the rank's indices to the shuffled batches.
+        """
+        g = torch.Generator()
+        g.manual_seed(self.seed + epoch) # Epoch-specific seed for shuffling
+
+        # 1. Get shuffled global indices
+        total_len = len(self.base_dataset)
+        if self.shuffle:
+            all_indices_shuffled = torch.randperm(total_len, generator=g).tolist()
+        else:
+            all_indices_shuffled = list(range(total_len))
+
+        # 2. Apply padding for distributed mode
+        indices_for_ranks = all_indices_shuffled
+        if self.distributed and self.world_size > 1:
+            padded_total_len = self._padded_samples_per_rank * self.world_size
+            if padded_total_len > total_len:
+                pad_size = padded_total_len - total_len
+                # Repeat initial elements from the *shuffled* list for padding
+                indices_for_ranks = all_indices_shuffled + all_indices_shuffled[:pad_size]
+            # Ensure length matches expectation
+            if len(indices_for_ranks) != padded_total_len:
+                 raise RuntimeError(f"Internal Error: Padded index list length {len(indices_for_ranks)} does not match expected {padded_total_len}")
+
+
+        # 3. Select indices for the current rank
+        if self.distributed and self.world_size > 1:
+            indices_this_rank = indices_for_ranks[self.rank::self.world_size]
+        else: # Non-distributed or world_size=1
+            indices_this_rank = indices_for_ranks
+
+        # Sanity check length
+        if len(indices_this_rank) != self._padded_samples_per_rank:
+             # This might happen if canonical schedule generation had warnings/issues
+             warnings.warn(
+                 f"Rank {self.rank}: Number of indices for this rank ({len(indices_this_rank)}) "
+                 f"does not match expected padded samples per rank ({self._padded_samples_per_rank}). "
+                 f"Epoch generation might be inconsistent."
+              )
+             # Adjust expected samples? Or truncate/pad indices? Let's proceed but warn.
+             # Using min() prevents IndexError later if indices are fewer than expected.
+             effective_samples_this_rank = min(len(indices_this_rank), self._padded_samples_per_rank)
+             indices_this_rank = indices_this_rank[:effective_samples_this_rank]
+
+        else:
+             effective_samples_this_rank = self._padded_samples_per_rank
+
+        # 4. Shuffle the order of the canonical batch schedule for this epoch
+        if self.shuffle:
+            schedule_perm = torch.randperm(self._num_batches_per_rank, generator=g).tolist()
+            shuffled_schedule = [self._canonical_batch_schedule[i] for i in schedule_perm]
+        else:
+            shuffled_schedule = list(self._canonical_batch_schedule) # Keep original order
+
+        # 5. Assign indices to the shuffled batches
+        self._epoch_batches = []
+        idx_pos = 0
+        scheduled_samples_count = 0
+        for seq_len, bs in shuffled_schedule:
+            # Ensure we don't try to grab more indices than available for the rank
+            actual_bs = min(bs, effective_samples_this_rank - idx_pos)
+            if actual_bs <= 0:
+                 if scheduled_samples_count < effective_samples_this_rank:
+                     # This indicates mismatch between schedule total and actual samples
+                     warnings.warn(f"Rank {self.rank}: Ran out of samples ({idx_pos}/{effective_samples_this_rank}) before processing entire schedule. Check schedule generation.")
+                 break # Stop if no more indices or batch size is zero
+
+            batch_indices = indices_this_rank[idx_pos : idx_pos + actual_bs]
+            self._epoch_batches.append((seq_len, batch_indices))
+            idx_pos += actual_bs
+            scheduled_samples_count += actual_bs
+
+        # Final check
+        if scheduled_samples_count != effective_samples_this_rank:
+             warnings.warn(
+                f"Rank {self.rank}: Assigned {scheduled_samples_count} samples to batches, "
+                f"but expected {effective_samples_this_rank} effective samples this epoch. "
+                f"Indices remaining: {effective_samples_this_rank - scheduled_samples_count}."
+             )
+
+    def set_epoch(self, epoch: int):
+        """Updates the epoch, regenerating the epoch-specific batches."""
+        # Only regenerate if the epoch actually changes
+        if epoch != self.epoch:
+            self.epoch = epoch
+            self._prepare_epoch_batches(epoch)
+
+    def __len__(self) -> int:
+        """
+        Returns the number of batches per **worker** for the current epoch.
+        Calculated based on the fixed number of batches per rank divided by
+        the number of workers.
+        """
+        return self._num_batches_per_rank
+
+    def __iter__(self) -> Iterator[Tuple[Dict[str, torch.Tensor], torch.Tensor]]:
+        """
+        Iterates through the pre-calculated batches for the current epoch,
+        distributing them among workers.
+        """
+        worker_info = torch.utils.data.get_worker_info()
+        num_workers = worker_info.num_workers if worker_info else 1
+        worker_id = worker_info.id if worker_info else 0
+
+        # Distribute pre-calculated batches among workers for this rank
+        # Each worker processes a slice of the batches prepared in _prepare_epoch_batches
+        batches_for_worker = self._epoch_batches[worker_id::num_workers]
+        for seq_len, indices in batches_for_worker:
+            if not indices: # Skip if a batch ended up with no indices (shouldn't happen often)
+                 continue
+
+            # Get the pre-initialized transform for this sequence length
+            transform = self.transforms.get(seq_len)
+
+            batch_samples = []
+            for idx in indices:
+                try:
+                    # Get original image and label from map-style dataset
+                    img, label = self.base_dataset[idx]
+
+                    # Apply transform if available
+                    # Handle cases where transform might return None or fail
+                    processed_img = transform(img) if transform else img
+                    if processed_img is None:
+                        warnings.warn(f"Transform returned None for index {idx}. Skipping sample.")
+                        continue
+
+                    # Apply patching
+                    patch_data = self.patchifier(processed_img)
+                    batch_samples.append((patch_data, label))
+
+                except IndexError:
+                     warnings.warn(f"IndexError encountered for index {idx} (possibly due to padding/repeated indices). Skipping sample.")
+                     continue
+                except Exception as e:
+                    # Log other potential errors during data loading/processing
+                    warnings.warn(f"Error processing sample index {idx}. Error: {e}. Skipping sample.")
+                    continue # Skip problematic sample
+
+            # Collate the processed samples into a batch
+            if batch_samples: # Only yield if we successfully processed samples
+                yield _collate_batch(batch_samples, seq_len)
+
+            # If batch_samples is empty after processing 'indices', an empty batch is skipped.

--- a/timm/data/naflex_dataset.py
+++ b/timm/data/naflex_dataset.py
@@ -123,7 +123,7 @@ class NaFlexCollator:
         }, targets
 
 
-class VariableSeqMapWrapper(IterableDataset):
+class NaFlexMapDatasetWrapper(IterableDataset):
     """
     IterableDataset wrapper for a map-style base dataset.
 

--- a/timm/data/naflex_dataset.py
+++ b/timm/data/naflex_dataset.py
@@ -24,10 +24,10 @@ from torchvision import transforms
 from PIL import Image
 
 
-from .naflex_transforms import Patchify, patchify
+from .naflex_transforms import Patchify, patchify_image
 
 
-def calculate_batch_size(
+def calculate_naflex_batch_size(
         tokens_per_batch: int,
         seq_len: int,
         max_size: Optional[int] = None,
@@ -240,7 +240,7 @@ class VariableSeqMapWrapper(IterableDataset):
             seq_len = self.seq_lens[seq_idx]
 
             # Calculate batch size
-            batch_size = calculate_batch_size(
+            batch_size = calculate_naflex_batch_size(
                 tokens_per_batch=self.max_tokens_per_batch,
                 seq_len=seq_len,
                 # max_size should be remaining_samples to avoid overshooting

--- a/timm/data/naflex_loader.py
+++ b/timm/data/naflex_loader.py
@@ -8,7 +8,7 @@ import torch
 
 from .constants import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
 from .loader import _worker_init, adapt_to_chs
-from .naflex_dataset import VariableSeqMapWrapper, NaFlexCollator
+from .naflex_dataset import NaFlexMapDatasetWrapper, NaFlexCollator
 from .naflex_random_erasing import PatchRandomErasing
 from .transforms_factory import create_transform
 
@@ -215,7 +215,7 @@ def create_naflex_loader(
         if isinstance(dataset, torch.utils.data.IterableDataset):
             assert False, "IterableDataset Wrapper is a WIP"
 
-        naflex_dataset = VariableSeqMapWrapper(
+        naflex_dataset = NaFlexMapDatasetWrapper(
             dataset,
             transform_factory=transform_factory,
             patch_size=patch_size,
@@ -231,18 +231,12 @@ def create_naflex_loader(
         )
 
         # NOTE: Collation is handled by the dataset wrapper for training
-        # Create the collator (handles fixed-size collation)
-        # collate_fn = NaFlexCollator(
-        #     max_seq_len=max(seq_lens) + 1,  # +1 for class token
-        # )
-
         loader = torch.utils.data.DataLoader(
             naflex_dataset,
             batch_size=None,
             shuffle=False,
             num_workers=num_workers,
             sampler=None,
-            #collate_fn=collate_fn,
             pin_memory=pin_memory,
             worker_init_fn=partial(_worker_init, worker_seeding=worker_seeding),
             persistent_workers=persistent_workers

--- a/timm/data/naflex_loader.py
+++ b/timm/data/naflex_loader.py
@@ -1,0 +1,341 @@
+import math
+from contextlib import suppress
+from functools import partial
+from typing import Callable, List, Optional, Tuple, Union
+
+import torch
+
+from .constants import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
+from .loader import _worker_init
+from .naflex_dataset import VariableSeqMapWrapper
+from .transforms_factory import create_transform
+
+
+class NaFlexCollator:
+    """Custom collator for batching NaFlex-style variable-resolution images."""
+
+    def __init__(
+            self,
+            patch_size=16,
+            max_seq_len=None,
+    ):
+        self.patch_size = patch_size
+        self.max_seq_len = max_seq_len or 576  # Default ViT-B/16 sequence length (577 = 24*24)
+
+    def __call__(self, batch):
+        """
+        Args:
+            batch: List of tuples (patch_dict, target)
+
+        Returns:
+            A tuple of (input_dict, targets) where input_dict contains:
+                - patches: Padded tensor of patches
+                - patch_coord: Coordinates for each patch (y, x)
+                - patch_valid: Valid indicators
+        """
+        assert isinstance(batch[0], tuple)
+        batch_size = len(batch)
+
+        # FIXME
+        # get seq len from sampler schedule
+
+        # resize to final size based on seq_len and patchify
+
+        # Extract targets
+        targets = torch.tensor([item[1] for item in batch], dtype=torch.int64)
+
+        # Get patch dictionaries
+        patch_dicts = [item[0] for item in batch]
+
+        # If we have a maximum sequence length constraint, ensure we don't exceed it
+        if self.max_seq_len is not None:
+            max_patches = self.max_seq_len
+        else:
+            # Find the maximum number of patches in this batch
+            max_patches = max(item['patches'].shape[0] for item in patch_dicts)
+
+        # Get patch dimensionality
+        patch_dim = patch_dicts[0]['patches'].shape[1]
+
+        # Prepare tensors for the batch
+        patches = torch.zeros((batch_size, max_patches, patch_dim), dtype=torch.float32)
+        patch_coord = torch.zeros((batch_size, max_patches, 2), dtype=torch.int64)  # [B, N, 2] for (y, x)
+        patch_valid = torch.zeros((batch_size, max_patches), dtype=torch.bool)
+
+        # Fill in the tensors
+        for i, patch_dict in enumerate(patch_dicts):
+            num_patches = min(patch_dict['patches'].shape[0], max_patches)
+
+            patches[i, :num_patches] = patch_dict['patches'][:num_patches]
+            patch_coord[i, :num_patches] = patch_dict['patch_coord'][:num_patches]
+            patch_valid[i, :num_patches] = patch_dict['patch_valid'][:num_patches]
+
+        return {
+            'patches': patches,
+            'patch_coord': patch_coord,
+            'patch_valid': patch_valid,
+            'seq_len': max_patches,
+        }, targets
+
+
+class NaFlexPrefetchLoader:
+    """Data prefetcher for NaFlex format which normalizes patches."""
+
+    def __init__(
+            self,
+            loader,
+            mean=(0.485, 0.456, 0.406),
+            std=(0.229, 0.224, 0.225),
+            img_dtype=torch.float32,
+            device=torch.device('cuda')
+        ):
+        self.loader = loader
+        self.device = device
+        self.img_dtype = img_dtype or torch.float32
+
+        # Create mean/std tensors for normalization (will be applied to patches)
+        self.mean = torch.tensor([x * 255 for x in mean], device=device, dtype=self.img_dtype).view(1, 1, 3)
+        self.std = torch.tensor([x * 255 for x in std], device=device, dtype=self.img_dtype).view(1, 1, 3)
+
+        # Check for CUDA/NPU availability
+        self.is_cuda = device.type == 'cuda' and torch.cuda.is_available()
+        self.is_npu = device.type == 'npu' and torch.npu.is_available()
+
+    def __iter__(self):
+        first = True
+        if self.is_cuda:
+            stream = torch.cuda.Stream()
+            stream_context = partial(torch.cuda.stream, stream=stream)
+        elif self.is_npu:
+            stream = torch.npu.Stream()
+            stream_context = partial(torch.npu.stream, stream=stream)
+        else:
+            stream = None
+            stream_context = suppress
+
+        for next_input_dict, next_target in self.loader:
+            with stream_context():
+                # Move all tensors in input_dict to device
+                for k, v in next_input_dict.items():
+                    if isinstance(v, torch.Tensor):
+                        dtype = self.img_dtype if k == 'patches' else None
+                        next_input_dict[k] = next_input_dict[k].to(
+                            device=self.device,
+                            non_blocking=True,
+                            dtype=dtype,
+                        )
+
+                next_target = next_target.to(device=self.device, non_blocking=True)
+
+                # Normalize patch values (assuming patches are in format [B, N, P*P*C])
+                batch_size, num_patches, patch_pixels = next_input_dict['patches'].shape
+                patches = next_input_dict['patches'].view(batch_size, -1, 3) # to [B*N, P*P, C] for normalization
+                patches = patches.sub(self.mean).div(self.std)
+
+                # Reshape back
+                next_input_dict['patches'] = patches.reshape(batch_size, num_patches, patch_pixels)
+
+            if not first:
+                yield input_dict, target
+            else:
+                first = False
+
+            if stream is not None:
+                if self.is_cuda:
+                    torch.cuda.current_stream().wait_stream(stream)
+                elif self.is_npu:
+                    torch.npu.current_stream().wait_stream(stream)
+
+            input_dict = next_input_dict
+            target = next_target
+
+        yield input_dict, target
+
+    def __len__(self):
+        return len(self.loader)
+
+    @property
+    def sampler(self):
+        return self.loader.sampler
+
+    @property
+    def dataset(self):
+        return self.loader.dataset
+
+
+def create_naflex_loader(
+        dataset,
+        patch_size: Union[Tuple[int, int], int] = 16,
+        train_seq_lens: List[int] = (128, 256, 576, 784, 1024),  # Training sequence lengths
+        max_seq_len: int = 576,  # Fixed sequence length for validation
+        batch_size: int = 32,  # Used for max_seq_len and max(train_seq_lens)
+        is_training: bool = False,
+
+        no_aug: bool = False,
+        re_prob: float = 0.,
+        re_mode: str = 'const',
+        re_count: int = 1,
+        re_split: bool = False,
+        train_crop_mode: Optional[str] = None,
+        scale: Optional[Tuple[float, float]] = None,
+        ratio: Optional[Tuple[float, float]] = None,
+        hflip: float = 0.5,
+        vflip: float = 0.,
+        color_jitter: float = 0.4,
+        color_jitter_prob: Optional[float] = None,
+        grayscale_prob: float = 0.,
+        gaussian_blur_prob: float = 0.,
+        auto_augment: Optional[str] = None,
+        num_aug_repeats: int = 0,
+        num_aug_splits: int = 0,
+        interpolation: str = 'bilinear',
+        mean: Tuple[float, ...] = IMAGENET_DEFAULT_MEAN,
+        std: Tuple[float, ...] = IMAGENET_DEFAULT_STD,
+        crop_pct: Optional[float] = None,
+        crop_mode: Optional[str] = None,
+        crop_border_pixels: Optional[int] = None,
+
+        num_workers: int = 4,
+        distributed: bool = False,
+        rank: int = 0,
+        world_size: int = 1,
+        seed: int = 42,
+        epoch: int = 0,
+        use_prefetcher: bool = True,
+        pin_memory: bool = True,
+        img_dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = torch.device('cuda'),
+        persistent_workers: bool = True,
+        worker_seeding: str = 'all',
+    ):
+    """Create a data loader with dynamic sequence length sampling for training."""
+
+    if is_training:
+        # For training, use the dynamic sequence length mechanism
+        assert num_aug_repeats == 0, 'Augmentation repeats not currently supported in NaFlex loader'
+
+        transform_factory = partial(
+            create_transform,
+            is_training=True,
+            no_aug=no_aug,
+            train_crop_mode=train_crop_mode,
+            scale=scale,
+            ratio=ratio,
+            hflip=hflip,
+            vflip=vflip,
+            color_jitter=color_jitter,
+            color_jitter_prob=color_jitter_prob,
+            grayscale_prob=grayscale_prob,
+            gaussian_blur_prob=gaussian_blur_prob,
+            auto_augment=auto_augment,
+            interpolation=interpolation,
+            mean=mean,
+            std=std,
+            crop_pct=crop_pct,
+            crop_mode=crop_mode,
+            crop_border_pixels=crop_border_pixels,
+            re_prob=re_prob,
+            re_mode=re_mode,
+            re_count=re_count,
+            use_prefetcher=use_prefetcher,
+            naflex=True,
+        )
+
+        max_train_seq_len = max(train_seq_lens)
+        max_tokens_per_batch = batch_size * max_train_seq_len
+
+        if isinstance(dataset, torch.utils.data.IterableDataset):
+            assert False, "IterableDataset Wrapper is a WIP"
+
+        naflex_dataset = VariableSeqMapWrapper(
+            dataset,
+            transform_factory=transform_factory,
+            patch_size=patch_size,
+            seq_lens=train_seq_lens,
+            max_tokens_per_batch=max_tokens_per_batch,
+            seed=seed,
+            distributed=distributed,
+            rank=rank,
+            world_size=world_size,
+            shuffle=True,
+            epoch=epoch,
+        )
+
+        # NOTE: Collation is handled by the dataset wrapper for training
+        # Create the collator (handles fixed-size collation)
+        # collate_fn = NaFlexCollator(
+        #     patch_size=patch_size,
+        #     max_seq_len=max(seq_lens) + 1,  # +1 for class token
+        #     use_prefetcher=use_prefetcher
+        # )
+
+        loader = torch.utils.data.DataLoader(
+            naflex_dataset,
+            batch_size=None,
+            shuffle=False,
+            num_workers=num_workers,
+            sampler=None,
+            #collate_fn=collate_fn,
+            pin_memory=pin_memory,
+            worker_init_fn=partial(_worker_init, worker_seeding=worker_seeding),
+            persistent_workers=persistent_workers
+        )
+
+        if use_prefetcher:
+            loader = NaFlexPrefetchLoader(
+                loader,
+                mean=mean,
+                std=std,
+                img_dtype=img_dtype,
+                device=device,
+            )
+
+    else:
+        # For validation, use fixed sequence length (unchanged)
+        dataset.transform = create_transform(
+            is_training=False,
+            interpolation=interpolation,
+            mean=mean,
+            std=std,
+            # FIXME add crop args when sequence transforms support crop modes
+            use_prefetcher=use_prefetcher,
+            naflex=True,
+            patch_size=patch_size,
+            max_seq_len=max_seq_len,
+            patchify=True,
+        )
+
+        # Create the collator
+        collate_fn = NaFlexCollator(
+            patch_size=patch_size,
+            max_seq_len=max_seq_len,
+        )
+
+        # Handle distributed training
+        sampler = None
+        if distributed and not isinstance(dataset, torch.utils.data.IterableDataset):
+            # For validation, use OrderedDistributedSampler
+            from timm.data.distributed_sampler import OrderedDistributedSampler
+            sampler = OrderedDistributedSampler(dataset)
+
+        loader = torch.utils.data.DataLoader(
+            dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=num_workers,
+            sampler=sampler,
+            collate_fn=collate_fn,
+            pin_memory=pin_memory,
+            drop_last=False,
+        )
+
+        if use_prefetcher:
+            loader = NaFlexPrefetchLoader(
+                loader,
+                mean=mean,
+                std=std,
+                img_dtype=img_dtype,
+                device=device,
+            )
+
+    return loader

--- a/timm/data/naflex_loader.py
+++ b/timm/data/naflex_loader.py
@@ -36,10 +36,7 @@ class NaFlexCollator:
         assert isinstance(batch[0], tuple)
         batch_size = len(batch)
 
-        # FIXME
-        # get seq len from sampler schedule
-
-        # resize to final size based on seq_len and patchify
+        # Resize to final size based on seq_len and patchify
 
         # Extract targets
         targets = torch.tensor([item[1] for item in batch], dtype=torch.int64)

--- a/timm/data/naflex_loader.py
+++ b/timm/data/naflex_loader.py
@@ -1,3 +1,14 @@
+"""NaFlex data loader for dynamic sequence length training.
+
+This module provides a specialized data loader for Vision Transformer models that supports:
+- Dynamic sequence length sampling during training for improved efficiency
+- Variable patch size training with probabilistic selection
+- Patch-level random erasing augmentation
+- Efficient GPU prefetching with normalization
+
+Hacked together by / Copyright 2025, Ross Wightman, Hugging Face
+"""
+
 import math
 from contextlib import suppress
 from functools import partial

--- a/timm/data/naflex_mixup.py
+++ b/timm/data/naflex_mixup.py
@@ -11,6 +11,7 @@ This module provides:
   all augmentation hyper‑parameters in one place, making it easy to plug into
   different dataset wrappers.
 
+Hacked together by / Copyright 2025, Ross Wightman, Hugging Face
 """
 import math
 import random
@@ -113,7 +114,6 @@ def mix_batch_variable_size(
 
             corrected_lam = 1.0 - cut_area / float(dest_area)
             lam_list[i] = corrected_lam
-            #print(i, 'Doing cutmix', yl_i, xl_i, yl_j, xl_j, ch, cw, lam_raw, corrected_lam)
         else:
             # Mixup: blend the entire overlap region
             patch_i = xi[:, top_i:top_i + oh, left_i:left_i + ow]
@@ -125,7 +125,6 @@ def mix_batch_variable_size(
 
             corrected_lam = (dest_area - overlap_area) / dest_area + lam_raw * overlap_area / dest_area
             lam_list[i] = corrected_lam
-            #print(i, 'Doing mixup', top_i, left_i, top_j, left_j, (oh, ow), (hi, wi), (hj, wj), lam_raw, corrected_lam)
 
     return mixed_imgs, lam_list, pair_to
 

--- a/timm/data/naflex_mixup.py
+++ b/timm/data/naflex_mixup.py
@@ -1,0 +1,233 @@
+"""Variable‑size Mixup / CutMix utilities for NaFlex data loaders.
+
+This module provides:
+
+* `mix_batch_variable_size` – pixel‑level Mixup/CutMix that operates on a
+  list of images whose spatial sizes differ, mixing only their central overlap
+  so no resizing is required.
+* `pairwise_mixup_target` – builds soft‑label targets that exactly match the
+  per‑sample pixel provenance produced by the mixer.
+* `NaFlexMixup` – a callable functor that wraps the two helpers and stores
+  all augmentation hyper‑parameters in one place, making it easy to plug into
+  different dataset wrappers.
+
+"""
+import math
+import random
+from typing import Dict, List, Tuple
+
+import torch
+
+
+def mix_batch_variable_size(
+        imgs: List[torch.Tensor],
+        *,
+        mixup_alpha: float = 0.8,
+        cutmix_alpha: float = 1.0,
+        switch_prob: float = 0.5,
+        local_shuffle: int = 4,
+) -> Tuple[List[torch.Tensor], List[float], Dict[int, int], bool]:
+    """Apply Mixup or CutMix on a batch of variable‑sized images.
+
+    The function first sorts images by aspect ratio and pairs neighbouring
+    samples (optionally shuffling within small windows so pairs vary between
+    epochs).  Only the mutual central‑overlap region of each pair is mixed
+
+    Args:
+        imgs: List of transformed images shaped (C, H, W).  Heights and
+            widths may differ between samples.
+        mixup_alpha: Beta‑distribution *α* for Mixup.  Set to 0 to disable Mixup.
+        cutmix_alpha: Beta‑distribution *α* for CutMix.  Set to 0 to disable CutMix.
+        switch_prob: Probability of using CutMix when both Mixup and CutMix are enabled.
+        local_shuffle: Size of local windows that are randomly shuffled after aspect sorting.
+            A value of 0 turns shuffling off.
+
+    Returns:
+        mixed_imgs: List of mixed images.
+        lam_list: Per‑sample lambda values representing the degree of mixing.
+        pair_to: Mapping i -> j describing which sample was mixed with which (absent for unmatched odd sample).
+        use_cutmix: True if CutMix was used for this call, False if Mixup was used.
+    """
+    if len(imgs) < 2:
+        raise ValueError("Need at least two images to perform Mixup/CutMix.")
+
+    # Decide augmentation mode and raw λ
+    if mixup_alpha > 0.0 and cutmix_alpha > 0.0:
+        use_cutmix = torch.rand(()).item() < switch_prob
+        alpha = cutmix_alpha if use_cutmix else mixup_alpha
+    elif mixup_alpha > 0.0:
+        use_cutmix = False
+        alpha = mixup_alpha
+    elif cutmix_alpha > 0.0:
+        use_cutmix = True
+        alpha = cutmix_alpha
+    else:
+        raise ValueError("Both mixup_alpha and cutmix_alpha are zero – nothing to do.")
+
+    lam_raw = torch.distributions.Beta(alpha, alpha).sample().item()
+    lam_raw = max(0.0, min(1.0, lam_raw))  # numerical safety
+
+    # Pair images by nearest aspect ratio
+    order = sorted(range(len(imgs)), key=lambda i: imgs[i].shape[2] / imgs[i].shape[1])
+    if local_shuffle > 1:
+        for start in range(0, len(order), local_shuffle):
+            random.shuffle(order[start: start + local_shuffle])
+
+    pair_to: Dict[int, int] = {}
+    for a, b in zip(order[::2], order[1::2]):
+        pair_to[a] = b
+        pair_to[b] = a
+
+    odd_one = order[-1] if len(imgs) % 2 else None
+
+    mixed_imgs: List[torch.Tensor] = [None] * len(imgs)
+    lam_list: List[float] = [1.0] * len(imgs)
+
+    for i in range(len(imgs)):
+        if i == odd_one:
+            mixed_imgs[i] = imgs[i]
+            continue
+
+        j = pair_to[i]
+        xi, xj = imgs[i], imgs[j]
+        _, hi, wi = xi.shape
+        _, hj, wj = xj.shape
+        dest_area = hi * wi
+
+        # Central overlap common to both images
+        oh, ow = min(hi, hj), min(wi, wj)
+        overlap_area = oh * ow
+        top_i, left_i = (hi - oh) // 2, (wi - ow) // 2
+        top_j, left_j = (hj - oh) // 2, (wj - ow) // 2
+
+        xi = xi.clone()
+        if use_cutmix:
+            # CutMix: random rectangle inside the overlap
+            cut_ratio = math.sqrt(1.0 - lam_raw)
+            ch, cw = int(oh * cut_ratio), int(ow * cut_ratio)
+            cut_area = ch * cw
+            y_off = random.randint(0, oh - ch)
+            x_off = random.randint(0, ow - cw)
+
+            yl_i, xl_i = top_i + y_off, left_i + x_off
+            yl_j, xl_j = top_j + y_off, left_j + x_off
+            xi[:, yl_i: yl_i + ch, xl_i: xl_i + cw] = xj[:, yl_j: yl_j + ch, xl_j: xl_j + cw]
+            mixed_imgs[i] = xi
+
+            corrected_lam = 1.0 - cut_area / float(dest_area)
+            lam_list[i] = corrected_lam
+            #print(i, 'Doing cutmix', yl_i, xl_i, yl_j, xl_j, ch, cw, lam_raw, corrected_lam)
+        else:
+            # Mixup: blend the entire overlap region
+            patch_i = xi[:, top_i: top_i + oh, left_i: left_i + ow]
+            patch_j = xj[:, top_j: top_j + oh, left_j: left_j + ow]
+
+            blended = patch_i.mul(lam_raw).add_(patch_j, alpha=1.0 - lam_raw)
+            xi[:, top_i: top_i + oh, left_i: left_i + ow] = blended
+            mixed_imgs[i] = xi
+
+            corrected_lam = (dest_area - overlap_area) / dest_area + lam_raw * overlap_area / dest_area
+            lam_list[i] = corrected_lam
+            #print(i, 'Doing mixup', top_i, left_i, top_j, left_j, (oh, ow), (hi, wi), (hj, wj), lam_raw, corrected_lam)
+
+    return mixed_imgs, lam_list, pair_to, use_cutmix
+
+
+def pairwise_mixup_target(
+        labels: torch.Tensor,
+        pair_to: Dict[int, int],
+        lam_list: List[float],
+        *,
+        num_classes: int,
+        smoothing: float = 0.0,
+) -> torch.Tensor:
+    """Create soft targets that match the pixel‑level mixing performed.
+
+    Args:
+        labels: (B,) tensor of integer class indices.
+        pair_to: Mapping of sample index to its mixed partner as returned by mix_batch_variable_size().
+        lam_list: Per‑sample fractions of self pixels, also from the mixer.
+        num_classes: Total number of classes in the dataset.
+        smoothing: Label‑smoothing value in the range [0, 1).
+
+    Returns:
+        Tensor of shape (B, num_classes) whose rows sum to 1.
+    """
+    off_val = smoothing / num_classes
+    on_val = 1.0 - smoothing + off_val
+
+    y_onehot = torch.full((labels.size(0), num_classes), off_val, dtype=torch.float32, device=labels.device)
+    y_onehot.scatter_(1, labels.unsqueeze(1), on_val)
+
+    targets = y_onehot.clone()
+    for i, j in pair_to.items():
+        lam = lam_list[i]
+        targets[i].mul_(lam).add_(y_onehot[j], alpha=1.0 - lam)
+
+    return targets
+
+
+class NaFlexMixup:
+    """Callable wrapper that combines mixing and target generation."""
+
+    def __init__(
+            self,
+            *,
+            num_classes: int,
+            mixup_alpha: float = 0.8,
+            cutmix_alpha: float = 1.0,
+            switch_prob: float = 0.5,
+            local_shuffle: int = 4,
+            smoothing: float = 0.0,
+    ) -> None:
+        """Configure the augmentation.
+
+        Args:
+            num_classes: Total number of classes.
+            mixup_alpha: Beta α for Mixup. 0 disables Mixup.
+            cutmix_alpha: Beta α for CutMix. 0 disables CutMix.
+            switch_prob: Probability of selecting CutMix when both modes are enabled.
+            local_shuffle: Window size used to shuffle images after aspect sorting so pairings vary between epochs.
+            smoothing: Label‑smoothing value. 0 disables smoothing.
+        """
+        self.num_classes = num_classes
+        self.mixup_alpha = mixup_alpha
+        self.cutmix_alpha = cutmix_alpha
+        self.switch_prob = switch_prob
+        self.local_shuffle = local_shuffle
+        self.smoothing = smoothing
+
+    def __call__(
+            self,
+            imgs: List[torch.Tensor],
+            labels: torch.Tensor,
+    ) -> Tuple[List[torch.Tensor], torch.Tensor]:
+        """Apply the augmentation and generate matching targets.
+
+        Args:
+            imgs: List of already‑transformed images shaped (C, H, W).
+            labels: Hard labels with shape (B,).
+
+        Returns:
+            mixed_imgs: List of mixed images in the same order and shapes as the input.
+            targets: Soft‑label tensor shaped (B, num_classes) suitable for cross‑entropy with soft targets.
+        """
+        if isinstance(labels, (list, tuple)):
+            labels = torch.tensor(labels)
+
+        mixed_imgs, lam_list, pair_to, _ = mix_batch_variable_size(
+            imgs,
+            mixup_alpha=self.mixup_alpha,
+            cutmix_alpha=self.cutmix_alpha,
+            switch_prob=self.switch_prob,
+            local_shuffle=self.local_shuffle,
+        )
+
+        targets = pairwise_mixup_target(
+            labels,
+            pair_to,
+            lam_list,
+            num_classes=self.num_classes,
+            smoothing=self.smoothing,
+        )
+        return mixed_imgs, targets.unbind(0)

--- a/timm/data/naflex_mixup.py
+++ b/timm/data/naflex_mixup.py
@@ -14,7 +14,7 @@ This module provides:
 """
 import math
 import random
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 import torch
 
@@ -27,23 +27,23 @@ def mix_batch_variable_size(
         switch_prob: float = 0.5,
         local_shuffle: int = 4,
 ) -> Tuple[List[torch.Tensor], List[float], Dict[int, int]]:
-    """Apply Mixup or CutMix on a batch of variable‑sized images.
+    """Apply Mixup or CutMix on a batch of variable-sized images.
 
-    The function first sorts images by aspect ratio and pairs neighbouring
-    samples (optionally shuffling within small windows so pairs vary between
-    epochs).  Only the mutual central‑overlap region of each pair is mixed
+    Sorts images by aspect ratio and pairs neighboring samples. Only the mutual
+    central overlap region of each pair is mixed.
 
     Args:
-        imgs: List of transformed images shaped (C, H, W).  Heights and widths may differ between samples.
-        mixup_alpha: Beta‑distribution alpha for Mixup.  Set to 0 to disable Mixup.
-        cutmix_alpha: Beta‑distribution alpha for CutMix.  Set to 0 to disable CutMix.
-        switch_prob: Probability of using CutMix when both Mixup and CutMix are enabled.
-        local_shuffle: Size of local windows that are randomly shuffled after aspect sorting. Off if <= 1.
+        imgs: List of transformed images shaped (C, H, W).
+        mixup_alpha: Beta distribution alpha for Mixup. Set to 0 to disable.
+        cutmix_alpha: Beta distribution alpha for CutMix. Set to 0 to disable.
+        switch_prob: Probability of using CutMix when both modes are enabled.
+        local_shuffle: Size of local windows for shuffling after aspect sorting.
 
     Returns:
-        mixed_imgs: List of mixed images.
-        lam_list: Per‑sample lambda values representing the degree of mixing.
-        pair_to: Mapping i -> j describing which sample was mixed with which (absent for unmatched odd sample).
+        Tuple of (mixed_imgs, lam_list, pair_to) where:
+            - mixed_imgs: List of mixed images
+            - lam_list: Per-sample lambda values representing mixing degree
+            - pair_to: Mapping i -> j of which sample was mixed with which
     """
     if len(imgs) < 2:
         raise ValueError("Need at least two images to perform Mixup/CutMix.")

--- a/timm/data/naflex_random_erasing.py
+++ b/timm/data/naflex_random_erasing.py
@@ -1,0 +1,433 @@
+import random
+import math
+from typing import Optional, Union, Tuple
+
+import torch
+
+
+class PatchRandomErasing:
+    """
+    Random erasing for patchified images in NaFlex format.
+
+    Supports three modes:
+    1. 'patch': Simple mode that erases randomly selected valid patches
+    2. 'region': Erases spatial regions at patch granularity
+    3. 'subregion': Most sophisticated mode that erases spatial regions at sub-patch granularity,
+       partially erasing patches that are on the boundary of the erased region
+
+    Args:
+        erase_prob: Probability that the Random Erasing operation will be performed.
+        patch_drop_prob: Patch dropout probability. Remove random patches instead of erasing.
+        min_area: Minimum percentage of valid patches/area to erase.
+        max_area: Maximum percentage of valid patches/area to erase.
+        min_aspect: Minimum aspect ratio of erased area (only used in 'region'/'subregion' mode).
+        max_aspect: Maximum aspect ratio of erased area (only used in 'region'/'subregion' mode).
+        mode: Patch content mode, one of 'const', 'rand', or 'pixel'
+            'const' - erase patch is constant color of 0 for all channels
+            'rand'  - erase patch has same random (normal) value across all elements
+            'pixel' - erase patch has per-element random (normal) values
+        spatial_mode: Erasing strategy, one of 'patch', 'region', or 'subregion'
+        patch_size: Size of each patch (required for 'subregion' mode)
+        num_splits: Number of splits to apply erasing to (0 for all)
+        device: Computation device
+    """
+
+    def __init__(
+            self,
+            erase_prob: float = 0.5,
+            patch_drop_prob: float = 0.0,
+            min_count: int = 1,
+            max_count: Optional[int] = None,
+            min_area: float = 0.02,
+            max_area: float = 1 / 3,
+            min_aspect: float = 0.3,
+            max_aspect: Optional[float] = None,
+            mode: str = 'const',
+            value: float = 0.,
+            spatial_mode: str = 'region',
+            patch_size: Optional[Union[int, Tuple[int, int]]] = 16,
+            num_splits: int = 0,
+            device: Union[str, torch.device] = 'cuda',
+    ):
+        self.erase_prob = erase_prob
+        self.patch_drop_prob = patch_drop_prob
+        self.min_count = min_count
+        self.max_count = max_count or min_count
+        self.min_area = min_area
+        self.max_area = max_area
+
+        # Aspect ratio params (for region mode)
+        max_aspect = max_aspect or 1 / min_aspect
+        self.log_aspect_ratio = (math.log(min_aspect), math.log(max_aspect))
+
+        # Number of splits
+        self.num_splits = num_splits
+        self.device = device
+
+        # Strategy mode
+        self.spatial_mode = spatial_mode
+
+        # Patch size (needed for subregion mode)
+        self.patch_size = patch_size if isinstance(patch_size, tuple) else (patch_size, patch_size)
+
+        # Value generation mode flags
+        self.erase_mode = mode.lower()
+        assert self.erase_mode in ('rand', 'pixel', 'const')
+        self.const_value = value
+
+    def _get_values(
+            self,
+            shape: Union[Tuple[int,...], torch.Size],
+            value: Optional[torch.Tensor] = None,
+            dtype: torch.dtype = torch.float32,
+            device: Optional[Union[str, torch.device]] = None
+    ):
+        """Generate values for erased patches based on the specified mode.
+        Args:
+            shape: Shape of patches to erase.
+            value: Value to use in const (or rand) mode.
+            dtype: Data type to use.
+            device: Device to use.
+        """
+        device = device or self.device
+        if self.erase_mode == 'pixel':
+            # only mode with erase shape that includes pixels
+            return torch.empty(shape, dtype=dtype, device=device).normal_()
+        else:
+            shape = (1, 1, shape[-1]) if len(shape) == 3 else (1, shape[-1])
+            if self.erase_mode == 'const' or value is not None:
+                erase_value = value or self.const_value
+                if isinstance(erase_value, (int, float)):
+                    values = torch.full(shape, erase_value, dtype=dtype, device=device)
+                else:
+                    erase_value = torch.tensor(erase_value, dtype=dtype, device=device)
+                    values = torch.expand_copy(erase_value, shape)
+            else:
+                values = torch.empty(shape, dtype=dtype, device=device).normal_()
+            return values
+
+    def _drop_patches(
+            self,
+            patches: torch.Tensor,
+            patch_coord: torch.Tensor,
+            patch_valid: torch.Tensor,
+    ):
+        """ Patch Dropout
+
+        Fully drops patches from datastream. Only mode that saves compute BUT requires support
+        for non-contiguous patches and associated patch coordinate and valid handling.
+        """
+        # FIXME WIP, not completed. Downstream support in model needed for non-contiguous valid patches
+        if random.random() > self.erase_prob:
+            return
+
+        # Get indices of valid patches
+        valid_indices = torch.nonzero(patch_valid, as_tuple=True)[0].tolist()
+
+        # Skip if no valid patches
+        if not valid_indices:
+            return patches, patch_coord, patch_valid
+
+        num_valid = len(valid_indices)
+        if self.patch_drop_prob:
+            # patch dropout mode, completely remove dropped patches (FIXME needs downstream support in model)
+            num_keep = max(1, int(num_valid * (1. - self.patch_drop_prob)))
+            keep_indices = torch.argsort(torch.randn(1, num_valid, device=self.device), dim=-1)[:, :num_keep]
+            # maintain patch order, possibly useful for debug / visualization
+            keep_indices = keep_indices.sort(dim=-1)[0]
+            patches = patches.gather(1, keep_indices.unsqueeze(-1).expand((-1, -1) + patches.shape[2:]))
+
+        return patches, patch_coord, patch_valid
+
+    def _erase_patches(
+            self,
+            patches: torch.Tensor,
+            patch_coord: torch.Tensor,
+            patch_valid: torch.Tensor,
+            patch_shape: torch.Size,
+            dtype: torch.dtype = torch.float32,
+    ):
+        """Apply erasing by selecting individual patches randomly.
+
+        The simplest mode, aligned on patch boundaries. Behaves similarly to speckle or 'sprinkles'
+        noise augmentation at patch size.
+        """
+        if random.random() > self.erase_prob:
+            return
+
+        # Get indices of valid patches
+        valid_indices = torch.nonzero(patch_valid, as_tuple=True)[0].tolist()
+        if not valid_indices:
+            # Skip if no valid patches
+            return
+
+        num_valid = len(valid_indices)
+        count = random.randint(self.min_count, self.max_count)
+        # Determine how many valid patches to erase from RE min/max count and area args
+        max_erase = max(1, int(num_valid * count * self.max_area))
+        min_erase = max(1, int(num_valid * count * self.min_area))
+        num_erase = random.randint(min_erase, max_erase)
+
+        # Randomly select valid patches to erase
+        indices_to_erase = random.sample(valid_indices, min(num_erase, num_valid))
+
+        random_value = None
+        if self.erase_mode == 'rand':
+            random_value = torch.empty(patch_shape[-1], dtype=dtype, device=self.device).normal_()
+
+        for idx in indices_to_erase:
+            patches[idx].copy_(self._get_values(patch_shape, dtype=dtype, value=random_value))
+
+    def _erase_region(
+            self,
+            patches: torch.Tensor,
+            patch_coord: torch.Tensor,
+            patch_valid: torch.Tensor,
+            patch_shape: torch.Size,
+            dtype: torch.dtype = torch.float32,
+    ):
+        """Apply erasing by selecting rectangular regions of patches randomly
+
+        Closer to the original RandomErasing implementation. Erases
+        spatially contiguous rectangular regions of patches (aligned with patches).
+        """
+        if random.random() > self.erase_prob:
+            return
+
+        # Determine grid dimensions from coordinates
+        if patch_valid is not None:
+            valid_coord = patch_coord[patch_valid]
+            if len(valid_coord) == 0:
+                return  # No valid patches
+            max_y = valid_coord[:, 0].max().item() + 1
+            max_x = valid_coord[:, 1].max().item() + 1
+        else:
+            max_y = patch_coord[:, 0].max().item() + 1
+            max_x = patch_coord[:, 1].max().item() + 1
+
+        grid_h, grid_w = max_y, max_x
+
+        # Calculate total area
+        total_area = grid_h * grid_w
+
+        count = random.randint(self.min_count, self.max_count)
+        for _ in range(count):
+            # Try to select a valid region to erase (multiple attempts)
+            for attempt in range(10):
+                # Sample random area and aspect ratio
+                target_area = random.uniform(self.min_area, self.max_area) * total_area
+                aspect_ratio = math.exp(random.uniform(*self.log_aspect_ratio))
+
+                # Calculate region height and width
+                h = int(round(math.sqrt(target_area * aspect_ratio)))
+                w = int(round(math.sqrt(target_area / aspect_ratio)))
+
+                # Ensure region fits within grid
+                if w <= grid_w and h <= grid_h:
+                    # Select random top-left corner
+                    top = random.randint(0, grid_h - h)
+                    left = random.randint(0, grid_w - w)
+
+                    # Define region bounds
+                    bottom = top + h
+                    right = left + w
+
+                    # Create a single random value for all affected patches if using 'rand' mode
+                    if self.erase_mode == 'rand':
+                        random_value = torch.empty(patch_shape[-1], dtype=dtype, device=self.device).normal_()
+                    else:
+                        random_value = None
+
+                    # Find and erase all patches that fall within the region
+                    for i in range(len(patches)):
+                        if patch_valid is None or patch_valid[i]:
+                            y, x = patch_coord[i]
+                            if top <= y < bottom and left <= x < right:
+                                patches[i] = self._get_values(patch_shape, dtype=dtype, value=random_value)
+
+                    # Successfully applied erasing, exit the loop
+                    break
+
+    def _erase_subregion(
+            self,
+            patches: torch.Tensor,
+            patch_coord: torch.Tensor,
+            patch_valid: torch.Tensor,
+            patch_shape: torch.Size,
+            patch_size: Tuple[int, int],
+            dtype: torch.dtype = torch.float32,
+    ):
+        """Apply erasing by selecting rectangular regions ignoring patch boundaries.
+
+        Matches or original RandomErasing implementation. Erases spatially contiguous rectangular
+        regions that are not aligned to patches (erase regions boundaries cut within patches).
+
+        FIXME complexity probably not worth it, may remove.
+        """
+        if random.random() > self.erase_prob:
+            return
+
+        # Get patch dimensions
+        patch_h, patch_w = patch_size
+        channels = patch_shape[-1]
+
+        # Determine grid dimensions in patch coordinates
+        if patch_valid is not None:
+            valid_coord = patch_coord[patch_valid]
+            if len(valid_coord) == 0:
+                return  # No valid patches
+            max_y = valid_coord[:, 0].max().item() + 1
+            max_x = valid_coord[:, 1].max().item() + 1
+        else:
+            max_y = patch_coord[:, 0].max().item() + 1
+            max_x = patch_coord[:, 1].max().item() + 1
+
+        grid_h, grid_w = max_y, max_x
+
+        # Calculate total area in pixel space
+        total_area = (grid_h * patch_h) * (grid_w * patch_w)
+
+        count = random.randint(self.min_count, self.max_count)
+        for _ in range(count):
+            # Try to select a valid region to erase (multiple attempts)
+            for attempt in range(10):
+                # Sample random area and aspect ratio
+                target_area = random.uniform(self.min_area, self.max_area) * total_area
+                aspect_ratio = math.exp(random.uniform(*self.log_aspect_ratio))
+
+                # Calculate region height and width in pixel space
+                pixel_h = int(round(math.sqrt(target_area * aspect_ratio)))
+                pixel_w = int(round(math.sqrt(target_area / aspect_ratio)))
+
+                # Ensure region fits within total pixel grid
+                if pixel_w <= grid_w * patch_w and pixel_h <= grid_h * patch_h:
+                    # Select random top-left corner in pixel space
+                    pixel_top = random.randint(0, grid_h * patch_h - pixel_h)
+                    pixel_left = random.randint(0, grid_w * patch_w - pixel_w)
+
+                    # Define region bounds in pixel space
+                    pixel_bottom = pixel_top + pixel_h
+                    pixel_right = pixel_left + pixel_w
+
+                    # Create a single random value for the entire region if using 'rand' mode
+                    rand_value = None
+                    if self.erase_mode == 'rand':
+                        rand_value = torch.empty(patch_shape[-1], dtype=dtype, device=self.device).normal_()
+
+                    # For each valid patch, determine if and how it overlaps with the erase region
+                    for i in range(len(patches)):
+                        if patch_valid is None or patch_valid[i]:
+                            # Convert patch coordinates to pixel space (top-left corner)
+                            y, x = patch_coord[i]
+                            patch_pixel_top = y * patch_h
+                            patch_pixel_left = x * patch_w
+                            patch_pixel_bottom = patch_pixel_top + patch_h
+                            patch_pixel_right = patch_pixel_left + patch_w
+
+                            # Check if this patch overlaps with the erase region
+                            if not (patch_pixel_right <= pixel_left or patch_pixel_left >= pixel_right or
+                                    patch_pixel_bottom <= pixel_top or patch_pixel_top >= pixel_bottom):
+
+                                # Calculate the overlap region in patch-local coordinates
+                                local_top = max(0, pixel_top - patch_pixel_top)
+                                local_left = max(0, pixel_left - patch_pixel_left)
+                                local_bottom = min(patch_h, pixel_bottom - patch_pixel_top)
+                                local_right = min(patch_w, pixel_right - patch_pixel_left)
+
+                                # Reshape the patch to [patch_h, patch_w, chans]
+                                patch_data = patches[i].reshape(patch_h, patch_w, channels)
+
+                                erase_shape = (local_bottom - local_top, local_right - local_left, channels)
+                                erase_value = self._get_values(erase_shape, dtype=dtype, value=rand_value)
+                                patch_data[local_top:local_bottom, local_left:local_right, :] = erase_value
+
+                                # Flatten the patch back to [patch_h*patch_w, chans]
+                                if len(patch_shape) == 2:
+                                    patch_data = patch_data.reshape(-1, channels)
+                                patches[i] = patch_data
+
+                    # Successfully applied erasing, exit the loop
+                    break
+
+    def __call__(
+            self,
+            patches: torch.Tensor,
+            patch_coord: torch.Tensor,
+            patch_valid: Optional[torch.Tensor] = None,
+    ):
+        """
+        Apply random patch erasing.
+
+        Args:
+            patches: Tensor of shape [B, N, P*P, C]
+            patch_coord: Tensor of shape [B, N, 2] with (y, x) coordinates
+            patch_valid: Boolean tensor of shape [B, N] indicating which patches are valid
+                        If None, all patches are considered valid
+
+        Returns:
+            Erased patches tensor of same shape
+        """
+        if patches.ndim == 4:
+            batch_size, num_patches, patch_dim, channels = patches.shape
+            if self.patch_size is not None:
+                patch_size = self.patch_size
+            else:
+                patch_size = None
+        elif patches.ndim == 5:
+            batch_size, num_patches, patch_h, patch_w, channels = patches.shape
+            patch_size = (patch_h, patch_w)
+        else:
+            assert False
+        patch_shape = patches.shape[2:]
+        # patch_shape ==> shape of patches to fill (h, w, c) or (h * w, c)
+        # patch_size ==> patch h, w (if available, must be avail for subregion mode)
+
+        # Create default valid mask if not provided
+        if patch_valid is None:
+            patch_valid = torch.ones((batch_size, num_patches), dtype=torch.bool, device=patches.device)
+
+        # Skip the first part of the batch if num_splits is set
+        batch_start = batch_size // self.num_splits if self.num_splits > 1 else 0
+
+        # Apply erasing to each batch element
+        for i in range(batch_start, batch_size):
+            if self.patch_drop_prob:
+                assert False, "WIP, not completed"
+                self._drop_patches(
+                    patches[i],
+                    patch_coord[i],
+                    patch_valid[i],
+                )
+            elif self.spatial_mode == 'patch':
+                self._erase_patches(
+                    patches[i],
+                    patch_coord[i],
+                    patch_valid[i],
+                    patch_shape,
+                    patches.dtype
+                )
+            elif self.spatial_mode == 'region':
+                self._erase_region(
+                    patches[i],
+                    patch_coord[i],
+                    patch_valid[i],
+                    patch_shape,
+                    patches.dtype
+                )
+            elif self.spatial_mode == 'subregion':
+                self._erase_subregion(
+                    patches[i],
+                    patch_coord[i],
+                    patch_valid[i],
+                    patch_shape,
+                    patch_size,
+                    patches.dtype
+                )
+
+        return patches
+
+    def __repr__(self):
+        fs = self.__class__.__name__ + f'(p={self.erase_prob}, mode={self.erase_mode}'
+        fs += f', spatial={self.spatial_mode}, area=({self.min_area}, {self.max_area}))'
+        fs += f', count=({self.min_count}, {self.max_count}))'
+        return fs

--- a/timm/data/naflex_random_erasing.py
+++ b/timm/data/naflex_random_erasing.py
@@ -1,3 +1,16 @@
+"""Patch-level random erasing augmentation for NaFlex Vision Transformers.
+
+This module implements random erasing specifically designed for patchified images,
+operating at the patch granularity rather than pixel level. It supports two modes:
+- 'patch': Randomly erases individual patches (speckle-like noise)
+- 'region': Erases contiguous rectangular regions of patches (similar to original RandomErasing)
+
+The implementation is coordinate-aware, respecting valid patch boundaries and supporting
+variable patch sizes in NaFlex training.
+
+Hacked together by / Copyright 2025, Ross Wightman, Hugging Face
+"""
+
 import random
 import math
 from typing import Optional, Union, Tuple

--- a/timm/data/naflex_random_erasing.py
+++ b/timm/data/naflex_random_erasing.py
@@ -11,17 +11,15 @@ class PatchRandomErasing:
 
     Supports three modes:
     1. 'patch': Simple mode that erases randomly selected valid patches
-    2. 'region': Erases spatial regions at patch granularity
-    3. 'subregion': Most sophisticated mode that erases spatial regions at sub-patch granularity,
-       partially erasing patches that are on the boundary of the erased region
+    2. 'region': Erases rectangular regions at patch granularity
 
     Args:
         erase_prob: Probability that the Random Erasing operation will be performed.
         patch_drop_prob: Patch dropout probability. Remove random patches instead of erasing.
         min_area: Minimum percentage of valid patches/area to erase.
         max_area: Maximum percentage of valid patches/area to erase.
-        min_aspect: Minimum aspect ratio of erased area (only used in 'region'/'subregion' mode).
-        max_aspect: Maximum aspect ratio of erased area (only used in 'region'/'subregion' mode).
+        min_aspect: Minimum aspect ratio of erased area (only used in 'region' mode).
+        max_aspect: Maximum aspect ratio of erased area (only used in 'region' mode).
         mode: Patch content mode, one of 'const', 'rand', or 'pixel'
             'const' - erase patch is constant color of 0 for all channels
             'rand'  - erase patch has same random (normal) value across all elements
@@ -45,7 +43,6 @@ class PatchRandomErasing:
             mode: str = 'const',
             value: float = 0.,
             spatial_mode: str = 'region',
-            patch_size: Optional[Union[int, Tuple[int, int]]] = 16,
             num_splits: int = 0,
             device: Union[str, torch.device] = 'cuda',
     ):
@@ -66,14 +63,13 @@ class PatchRandomErasing:
 
         # Strategy mode
         self.spatial_mode = spatial_mode
-
-        # Patch size (needed for subregion mode)
-        self.patch_size = patch_size if isinstance(patch_size, tuple) else (patch_size, patch_size)
+        assert self.spatial_mode in ('patch', 'region')
 
         # Value generation mode flags
         self.erase_mode = mode.lower()
         assert self.erase_mode in ('rand', 'pixel', 'const')
         self.const_value = value
+        self.unique_noise_per_patch = True
 
     def _get_values(
             self,
@@ -156,27 +152,27 @@ class PatchRandomErasing:
             return
 
         # Get indices of valid patches
-        valid_indices = torch.nonzero(patch_valid, as_tuple=True)[0].tolist()
-        if not valid_indices:
-            # Skip if no valid patches
+        valid_indices = torch.nonzero(patch_valid, as_tuple=True)[0]
+        num_valid = len(valid_indices)
+        if num_valid == 0:
             return
 
-        num_valid = len(valid_indices)
         count = random.randint(self.min_count, self.max_count)
         # Determine how many valid patches to erase from RE min/max count and area args
-        max_erase = max(1, int(num_valid * count * self.max_area))
+        max_erase = min(num_valid, max(1, int(num_valid * count * self.max_area)))
         min_erase = max(1, int(num_valid * count * self.min_area))
         num_erase = random.randint(min_erase, max_erase)
 
         # Randomly select valid patches to erase
-        indices_to_erase = random.sample(valid_indices, min(num_erase, num_valid))
+        erase_idx = valid_indices[torch.randperm(num_valid, device=patches.device)[:num_erase]]
 
-        random_value = None
-        if self.erase_mode == 'rand':
-            random_value = torch.empty(patch_shape[-1], dtype=dtype, device=self.device).normal_()
+        if self.unique_noise_per_patch and self.erase_mode == 'pixel':
+            # generate unique noise for the whole selection of patches
+            fill_shape = (num_erase,) + patch_shape
+        else:
+            fill_shape = patch_shape
 
-        for idx in indices_to_erase:
-            patches[idx].copy_(self._get_values(patch_shape, dtype=dtype, value=random_value))
+        patches[erase_idx] = self._get_values(fill_shape, dtype=dtype)
 
     def _erase_region(
             self,
@@ -195,20 +191,14 @@ class PatchRandomErasing:
             return
 
         # Determine grid dimensions from coordinates
-        if patch_valid is not None:
-            valid_coord = patch_coord[patch_valid]
-            if len(valid_coord) == 0:
-                return  # No valid patches
-            max_y = valid_coord[:, 0].max().item() + 1
-            max_x = valid_coord[:, 1].max().item() + 1
-        else:
-            max_y = patch_coord[:, 0].max().item() + 1
-            max_x = patch_coord[:, 1].max().item() + 1
-
+        valid_coord = patch_coord[patch_valid]
+        if len(valid_coord) == 0:
+            return  # No valid patches
+        max_y = valid_coord[:, 0].max().item() + 1
+        max_x = valid_coord[:, 1].max().item() + 1
         grid_h, grid_w = max_y, max_x
-
-        # Calculate total area
         total_area = grid_h * grid_w
+        ys, xs = patch_coord[:, 0], patch_coord[:, 1]
 
         count = random.randint(self.min_count, self.max_count)
         for _ in range(count):
@@ -222,132 +212,33 @@ class PatchRandomErasing:
                 h = int(round(math.sqrt(target_area * aspect_ratio)))
                 w = int(round(math.sqrt(target_area / aspect_ratio)))
 
-                # Ensure region fits within grid
-                if w <= grid_w and h <= grid_h:
-                    # Select random top-left corner
-                    top = random.randint(0, grid_h - h)
-                    left = random.randint(0, grid_w - w)
+                if h > grid_h or w > grid_w:
+                    continue  # try again
 
-                    # Define region bounds
-                    bottom = top + h
-                    right = left + w
+                # Calculate region patch bounds
+                top = random.randint(0, grid_h - h)
+                left = random.randint(0, grid_w - w)
+                bottom, right = top + h, left + w
 
-                    # Create a single random value for all affected patches if using 'rand' mode
-                    if self.erase_mode == 'rand':
-                        random_value = torch.empty(patch_shape[-1], dtype=dtype, device=self.device).normal_()
-                    else:
-                        random_value = None
+                # Region test
+                region_mask = (
+                        (ys >= top) & (ys < bottom) &
+                        (xs >= left) & (xs < right) &
+                        patch_valid
+                )
+                num_selected = int(region_mask.sum().item())
+                if not num_selected:
+                    continue  # no patch actually falls inside – try again
 
-                    # Find and erase all patches that fall within the region
-                    for i in range(len(patches)):
-                        if patch_valid is None or patch_valid[i]:
-                            y, x = patch_coord[i]
-                            if top <= y < bottom and left <= x < right:
-                                patches[i] = self._get_values(patch_shape, dtype=dtype, value=random_value)
+                if self.unique_noise_per_patch and self.erase_mode == 'pixel':
+                    # generate unique noise for the whole region
+                    fill_shape = (num_selected,) + patch_shape
+                else:
+                    fill_shape = patch_shape
 
-                    # Successfully applied erasing, exit the loop
-                    break
-
-    def _erase_subregion(
-            self,
-            patches: torch.Tensor,
-            patch_coord: torch.Tensor,
-            patch_valid: torch.Tensor,
-            patch_shape: torch.Size,
-            patch_size: Tuple[int, int],
-            dtype: torch.dtype = torch.float32,
-    ):
-        """Apply erasing by selecting rectangular regions ignoring patch boundaries.
-
-        Matches or original RandomErasing implementation. Erases spatially contiguous rectangular
-        regions that are not aligned to patches (erase regions boundaries cut within patches).
-
-        FIXME complexity probably not worth it, may remove.
-        """
-        if random.random() > self.erase_prob:
-            return
-
-        # Get patch dimensions
-        patch_h, patch_w = patch_size
-        channels = patch_shape[-1]
-
-        # Determine grid dimensions in patch coordinates
-        if patch_valid is not None:
-            valid_coord = patch_coord[patch_valid]
-            if len(valid_coord) == 0:
-                return  # No valid patches
-            max_y = valid_coord[:, 0].max().item() + 1
-            max_x = valid_coord[:, 1].max().item() + 1
-        else:
-            max_y = patch_coord[:, 0].max().item() + 1
-            max_x = patch_coord[:, 1].max().item() + 1
-
-        grid_h, grid_w = max_y, max_x
-
-        # Calculate total area in pixel space
-        total_area = (grid_h * patch_h) * (grid_w * patch_w)
-
-        count = random.randint(self.min_count, self.max_count)
-        for _ in range(count):
-            # Try to select a valid region to erase (multiple attempts)
-            for attempt in range(10):
-                # Sample random area and aspect ratio
-                target_area = random.uniform(self.min_area, self.max_area) * total_area
-                aspect_ratio = math.exp(random.uniform(*self.log_aspect_ratio))
-
-                # Calculate region height and width in pixel space
-                pixel_h = int(round(math.sqrt(target_area * aspect_ratio)))
-                pixel_w = int(round(math.sqrt(target_area / aspect_ratio)))
-
-                # Ensure region fits within total pixel grid
-                if pixel_w <= grid_w * patch_w and pixel_h <= grid_h * patch_h:
-                    # Select random top-left corner in pixel space
-                    pixel_top = random.randint(0, grid_h * patch_h - pixel_h)
-                    pixel_left = random.randint(0, grid_w * patch_w - pixel_w)
-
-                    # Define region bounds in pixel space
-                    pixel_bottom = pixel_top + pixel_h
-                    pixel_right = pixel_left + pixel_w
-
-                    # Create a single random value for the entire region if using 'rand' mode
-                    rand_value = None
-                    if self.erase_mode == 'rand':
-                        rand_value = torch.empty(patch_shape[-1], dtype=dtype, device=self.device).normal_()
-
-                    # For each valid patch, determine if and how it overlaps with the erase region
-                    for i in range(len(patches)):
-                        if patch_valid is None or patch_valid[i]:
-                            # Convert patch coordinates to pixel space (top-left corner)
-                            y, x = patch_coord[i]
-                            patch_pixel_top = y * patch_h
-                            patch_pixel_left = x * patch_w
-                            patch_pixel_bottom = patch_pixel_top + patch_h
-                            patch_pixel_right = patch_pixel_left + patch_w
-
-                            # Check if this patch overlaps with the erase region
-                            if not (patch_pixel_right <= pixel_left or patch_pixel_left >= pixel_right or
-                                    patch_pixel_bottom <= pixel_top or patch_pixel_top >= pixel_bottom):
-
-                                # Calculate the overlap region in patch-local coordinates
-                                local_top = max(0, pixel_top - patch_pixel_top)
-                                local_left = max(0, pixel_left - patch_pixel_left)
-                                local_bottom = min(patch_h, pixel_bottom - patch_pixel_top)
-                                local_right = min(patch_w, pixel_right - patch_pixel_left)
-
-                                # Reshape the patch to [patch_h, patch_w, chans]
-                                patch_data = patches[i].reshape(patch_h, patch_w, channels)
-
-                                erase_shape = (local_bottom - local_top, local_right - local_left, channels)
-                                erase_value = self._get_values(erase_shape, dtype=dtype, value=rand_value)
-                                patch_data[local_top:local_bottom, local_left:local_right, :] = erase_value
-
-                                # Flatten the patch back to [patch_h*patch_w, chans]
-                                if len(patch_shape) == 2:
-                                    patch_data = patch_data.reshape(-1, channels)
-                                patches[i] = patch_data
-
-                    # Successfully applied erasing, exit the loop
-                    break
+                patches[region_mask] = self._get_values(fill_shape, dtype=dtype)
+                # Successfully applied erasing, exit the loop
+                break
 
     def __call__(
             self,
@@ -369,18 +260,12 @@ class PatchRandomErasing:
         """
         if patches.ndim == 4:
             batch_size, num_patches, patch_dim, channels = patches.shape
-            if self.patch_size is not None:
-                patch_size = self.patch_size
-            else:
-                patch_size = None
         elif patches.ndim == 5:
             batch_size, num_patches, patch_h, patch_w, channels = patches.shape
-            patch_size = (patch_h, patch_w)
         else:
             assert False
         patch_shape = patches.shape[2:]
         # patch_shape ==> shape of patches to fill (h, w, c) or (h * w, c)
-        # patch_size ==> patch h, w (if available, must be avail for subregion mode)
 
         # Create default valid mask if not provided
         if patch_valid is None:
@@ -399,6 +284,7 @@ class PatchRandomErasing:
                     patch_valid[i],
                 )
             elif self.spatial_mode == 'patch':
+                # FIXME we could vectorize patch mode across batch, worth the effort?
                 self._erase_patches(
                     patches[i],
                     patch_coord[i],
@@ -414,15 +300,8 @@ class PatchRandomErasing:
                     patch_shape,
                     patches.dtype
                 )
-            elif self.spatial_mode == 'subregion':
-                self._erase_subregion(
-                    patches[i],
-                    patch_coord[i],
-                    patch_valid[i],
-                    patch_shape,
-                    patch_size,
-                    patches.dtype
-                )
+            else:
+                assert False
 
         return patches
 

--- a/timm/data/naflex_transforms.py
+++ b/timm/data/naflex_transforms.py
@@ -738,7 +738,7 @@ class RandomResizedCropToSequence(torch.nn.Module):
         return format_string
 
 
-def patchify(
+def patchify_image(
         img: torch.Tensor,
         patch_size: Tuple[int, int],
         pad: bool = True,
@@ -794,7 +794,7 @@ class Patchify(torch.nn.Module):
             # Convert PIL Image to tensor [C, H, W]
             img = transforms.functional.to_tensor(img)
 
-        patches, coord, valid = patchify(img, self.patch_size)
+        patches, coord, valid = patchify_image(img, self.patch_size)
 
         return {
             'patches': patches,

--- a/timm/data/naflex_transforms.py
+++ b/timm/data/naflex_transforms.py
@@ -5,6 +5,8 @@ Implements PyTorch versions of the transforms described in the NaViT and FlexiVi
 - FlexiViT: https://arxiv.org/abs/2212.08013
 
 Enables variable resolution/aspect ratio image handling with efficient patching.
+
+Hacked together by / Copyright 2025, Ross Wightman, Hugging Face
 """
 
 import math

--- a/timm/data/naflex_transforms.py
+++ b/timm/data/naflex_transforms.py
@@ -749,11 +749,9 @@ def patchify_image(
 
     # Ensure the image is divisible by patch size
     if pad and (h % ph != 0 or w % pw != 0):
-        new_h = math.ceil(h / ph) * ph
-        new_w = math.ceil(w / pw) * pw
-        padded_img = torch.zeros(c, new_h, new_w, dtype=img.dtype)
-        padded_img[:, :h, :w] = img
-        img = padded_img
+        pad_h = (ph - h % ph) % ph  # amount to add on bottom
+        pad_w = (pw - w % pw) % pw  # amount to add on right
+        img = torch.nn.functional.pad(img, (0, pad_w, 0, pad_h))
         c, h, w = img.shape
 
     # Calculate number of patches in each dimension

--- a/timm/data/naflex_transforms.py
+++ b/timm/data/naflex_transforms.py
@@ -760,7 +760,6 @@ def patchify(
     nh, nw = h // ph, w // pw
     # Reshape image to patches [nh, nw, ph, pw, c]
     patches = img.view(c, nh, ph, nw, pw).permute(1, 3, 2, 4, 0).reshape(nh * nw, ph * pw * c)
-
     if include_info:
         # Create coordinate indices
         y_idx, x_idx = torch.meshgrid(torch.arange(nh), torch.arange(nw), indexing='ij')

--- a/timm/data/naflex_transforms.py
+++ b/timm/data/naflex_transforms.py
@@ -1,0 +1,804 @@
+""" NaFlex (NaViT + FlexiViT) Transforms and Collation
+
+Implements PyTorch versions of the transforms described in the NaViT and FlexiViT papers:
+- NaViT: https://arxiv.org/abs/2307.14995
+- FlexiViT: https://arxiv.org/abs/2212.08013
+
+Enables variable resolution/aspect ratio image handling with efficient patching.
+"""
+
+import math
+import random
+import warnings
+from typing import List, Optional, Sequence, Tuple, Union
+
+import torch
+from PIL import Image
+from torchvision import transforms
+from torchvision.transforms import functional as F
+from torchvision.transforms.functional import InterpolationMode
+
+from .transforms import str_to_interp_mode, crop_or_pad, center_crop_or_pad
+
+
+def get_image_size_for_seq(
+        image_hw,
+        patch_size=16,
+        max_seq_len=1024,
+        divisible_by_patch=True,
+        max_ratio=None,
+        eps = 1e-5,
+):
+    """
+    Determine scaling ratio and image size so that when `image_hw` is scaled
+    by 'ratio', the total number of resulting patches does not exceed
+    'max_seq_len'.
+
+    - Patch size can be an integer (square patch) or a tuple (patch_h, patch_w).
+    - Optionally cap the ratio at `max_ratio` to prevent upsampling beyond
+      a certain multiple of the original size.
+
+    Args:
+        image_hw (tuple or list of int): (height, width) of the original image.
+        patch_size (int or tuple[int, int]): If int, patch is square. If tuple,
+            patch is rectangular (patch_h, patch_w).
+        max_seq_len (int): Maximum allowed sequence length for the resulting image.
+        divisible_by_patch (bool): If True, the resulting image height and width
+            must be multiples of patch_size.
+        eps (float): Small number for binary search convergence.
+        max_ratio (float or None): If provided, the scaling ratio found by the
+            binary search will be clamped to min(found_ratio, max_ratio). Set
+            max_ratio=1.0 to ensure no upsampling beyond original size.
+
+    Returns:
+        ratio (float): Found scaling ratio (capped by `max_ratio` if provided).
+        target_hw (tuple of int): Target (height, width) after scaling.
+    """
+
+    # Handle patch size input, extract patch_h, patch_w
+    if isinstance(patch_size, int):
+        patch_h, patch_w = patch_size, patch_size
+    else:
+        # Assume it's a tuple/list: (patch_h, patch_w)
+        if len(patch_size) != 2:
+            raise ValueError("patch_size tuple must have exactly two elements (patch_h, patch_w).")
+        patch_h, patch_w = patch_size
+
+    # Safety checks
+    if patch_h <= 0 or patch_w <= 0:
+        raise ValueError("patch_size dimensions must be positive.")
+
+    def prepare_target_hw(ratio):
+        """Scale image_hw by ratio and optionally round dimensions to multiples of patch_h, patch_w."""
+        scaled_h = image_hw[0] * ratio
+        scaled_w = image_hw[1] * ratio
+
+        # If we need the result to be divisible by patch_size
+        if divisible_by_patch:
+            scaled_h = patch_h * math.ceil(scaled_h / patch_h)
+            scaled_w = patch_w * math.ceil(scaled_w / patch_w)
+
+        # Ensure at least one patch in each dimension
+        scaled_h = int(max(scaled_h, patch_h))
+        scaled_w = int(max(scaled_w, patch_w))
+
+        return scaled_h, scaled_w
+
+    def is_feasible(ratio):
+        """Check if scaling by 'ratio' keeps patch count within max_seq_len."""
+        t_h, t_w = prepare_target_hw(ratio)
+
+        # Each dimension is already a multiple of patch_h, patch_w if divisible_by_patch=True.
+        # Use integer division to count patches.
+        num_patches_h = t_h // patch_h
+        num_patches_w = t_w // patch_w
+        seq_len = num_patches_h * num_patches_w
+
+        return seq_len <= max_seq_len
+
+    # Binary search boundaries
+    lb = eps / 10.0
+    rb = 100.0
+
+    # Standard binary search loop
+    while (rb - lb) >= eps:
+        mid = (lb + rb) / 2.0
+        if is_feasible(mid):
+            lb = mid
+        else:
+            rb = mid
+
+    # The final ratio from the binary search
+    ratio = lb
+
+    # If max_ratio is provided, clamp it to prevent upsampling beyond that threshold
+    if max_ratio is not None:
+        ratio = min(ratio, max_ratio)
+
+    # Final checks
+    if ratio <= eps:
+        raise ValueError("Binary search failed - image might be too large?")
+    if ratio >= 100.0:
+        raise ValueError("Binary search failed - image might be too small?")
+
+    # Prepare the final target dimensions with the possibly clamped ratio
+    target_hw = prepare_target_hw(ratio)
+    return ratio, target_hw
+
+
+_RANDOM_INTERPOLATION = (str_to_interp_mode('bilinear'), str_to_interp_mode('bicubic'))
+
+
+class ResizeToSequence(torch.nn.Module):
+    """Resize image to fit within a maximum sequence length constraint when patchified.
+    
+    This maintains aspect ratio while ensuring the resulting image, when divided into patches,
+    will not exceed the specified maximum sequence length.
+    """
+    def __init__(
+            self, 
+            patch_size: int, 
+            max_seq_len: int = 1024,
+            divisible_by_patch: bool = True,
+            max_ratio: Optional[float] = None,
+            interpolation='bicubic',
+        ):
+        super().__init__()
+        self.patch_size = patch_size
+        self.max_seq_len = max_seq_len
+        self.divisible_by_patch = divisible_by_patch
+        self.max_ratio = max_ratio
+        if isinstance(interpolation, str):
+            if interpolation == 'random':
+                self.interpolation = _RANDOM_INTERPOLATION
+            else:
+                self.interpolation = str_to_interp_mode(interpolation)
+        else:
+            self.interpolation = interpolation
+        
+
+    def forward(self, img):
+        """Resize image to maintain aspect ratio and fit sequence constraint."""
+        _, h, w = transforms.functional.get_dimensions(img)
+
+        _, target_hw = get_image_size_for_seq(
+            (h, w), 
+            self.patch_size, 
+            self.max_seq_len,
+            divisible_by_patch=self.divisible_by_patch,
+            max_ratio=self.max_ratio,
+        )
+        
+        if isinstance(self.interpolation, (tuple, list)):
+            interpolation = random.choice(self.interpolation)
+        else:
+            interpolation = self.interpolation
+
+        resized_img = transforms.functional.resize(img, target_hw, interpolation=interpolation, antialias=True)
+
+        return resized_img
+
+
+class ResizeKeepRatioToSequence(torch.nn.Module):
+    """
+    Resize and Keep Aspect Ratio, adapted to fit sequence length constraints.
+    """
+
+    def __init__(
+            self,
+            patch_size=16,
+            max_sequence_len=1024,
+            divisible_by_patch=True,
+            longest=0.,
+            interpolation='bilinear',
+            random_scale_prob=0.,
+            random_scale_range=(0.85, 1.05),
+            random_scale_area=False,
+            random_aspect_prob=0.,
+            random_aspect_range=(0.9, 1.11),
+            max_ratio=None,
+    ):
+        """
+        Args:
+            patch_size: Size of patches (int or tuple of (patch_h, patch_w))
+            max_sequence_len: Maximum allowed sequence length for the resulting image
+            divisible_by_patch: If True, ensure dimensions are divisible by patch_size
+            longest: Float between 0-1 where 0=shortest side, 1=longest side determines scale
+            interpolation: Interpolation method for resizing
+            random_scale_prob: Probability of applying random scaling
+            random_scale_range: Range for random scaling factor (min, max)
+            random_scale_area: If True, scale factors affect area (√ factor)
+            random_aspect_prob: Probability of applying random aspect ratio jittering
+            random_aspect_range: Range for random aspect ratio (min, max)
+            max_ratio: Maximum allowed scaling ratio
+        """
+        super().__init__()
+        self.patch_size = patch_size
+        self.max_sequence_len = max_sequence_len
+        self.divisible_by_patch = divisible_by_patch
+        self.longest = float(longest)
+
+        if interpolation == 'random':
+            self.interpolation = _RANDOM_INTERPOLATION
+        else:
+            self.interpolation = str_to_interp_mode(interpolation)
+
+        self.random_scale_prob = random_scale_prob
+        self.random_scale_range = random_scale_range
+        self.random_scale_area = random_scale_area
+        self.random_aspect_prob = random_aspect_prob
+        self.random_aspect_range = random_aspect_range
+        self.max_ratio = max_ratio
+
+    @staticmethod
+    def get_params(
+            img,
+            patch_size,
+            max_sequence_len,
+            divisible_by_patch,
+            longest,
+            random_scale_prob=0.,
+            random_scale_range=(1.0, 1.33),
+            random_scale_area=False,
+            random_aspect_prob=0.,
+            random_aspect_range=(0.9, 1.11),
+            max_ratio=None,
+    ):
+        """Get parameters for resizing."""
+        # Get image dimensions
+        img_h, img_w = F.get_dimensions(img)[1:]
+
+        # Step 1: Get the maximum allowed dimensions from sequence length constraint
+        _, target_hw = get_image_size_for_seq(
+            (img_h, img_w),
+            patch_size,
+            max_sequence_len,
+            divisible_by_patch,
+            max_ratio,
+        )
+        target_h, target_w = target_hw
+
+        # Calculate ratio based on sequence constraint
+        ratio_h = target_h / img_h
+        ratio_w = target_w / img_w
+        # Apply longest blending
+        ratio = max(ratio_h, ratio_w) * longest + min(ratio_h, ratio_w) * (1. - longest)
+
+        # Apply random scaling
+        if random_scale_prob > 0 and random.random() < random_scale_prob:
+            ratio_factor = random.uniform(random_scale_range[0], random_scale_range[1])
+            if random_scale_area:
+                # Make ratio factor equivalent to area change
+                ratio_factor = 1. / math.sqrt(ratio_factor)
+            ratio_factor = (ratio_factor, ratio_factor)
+        else:
+            ratio_factor = (1., 1.)
+
+        # Apply random aspect
+        if random_aspect_prob > 0 and random.random() < random_aspect_prob:
+            log_aspect = (math.log(random_aspect_range[0]), math.log(random_aspect_range[1]))
+            aspect_factor = math.exp(random.uniform(*log_aspect))
+            aspect_factor = math.sqrt(aspect_factor)
+            # Apply aspect ratio jittering
+            ratio_factor = (ratio_factor[0] / aspect_factor, ratio_factor[1] * aspect_factor)
+
+        # Calculate final dimensions
+        size = [round(dim * ratio * f) for dim, f in zip((img_h, img_w), ratio_factor)]
+
+        # Ensure dimensions satisfy sequence constraint and are divisible by patch size
+        if isinstance(patch_size, int):
+            ph, pw = patch_size, patch_size
+        else:
+            ph, pw = patch_size
+
+        # Ensure dimensions are at least one patch
+        size[0] = max(size[0], ph)
+        size[1] = max(size[1], pw)
+
+        # Make divisible by patch size if needed
+        if divisible_by_patch:
+            size[0] = ph * math.ceil(size[0] / ph)
+            size[1] = pw * math.ceil(size[1] / pw)
+
+        # Verify we haven't exceeded sequence length
+        num_patches_h = size[0] // ph
+        num_patches_w = size[1] // pw
+        seq_len = num_patches_h * num_patches_w
+
+        if seq_len > max_sequence_len:
+            # Scale back down to fit sequence constraint
+            scale_back = math.sqrt(max_sequence_len / seq_len)
+            size[0] = int(size[0] * scale_back)
+            size[1] = int(size[1] * scale_back)
+
+            # Ensure divisible by patch size after scaling back
+            if divisible_by_patch:
+                size[0] = ph * math.ceil(size[0] / ph)
+                size[1] = pw * math.ceil(size[1] / pw)
+
+        return size
+
+    def forward(self, img):
+        """
+        Resize the image with aspect ratio preservation and sequence length constraints.
+        """
+        size = self.get_params(
+            img,
+            self.patch_size,
+            self.max_sequence_len,
+            self.divisible_by_patch,
+            self.longest,
+            self.random_scale_prob,
+            self.random_scale_range,
+            self.random_scale_area,
+            self.random_aspect_prob,
+            self.random_aspect_range,
+            self.max_ratio,
+        )
+
+        if isinstance(self.interpolation, (tuple, list)):
+            interpolation = random.choice(self.interpolation)
+        else:
+            interpolation = self.interpolation
+
+        return F.resize(img, size, interpolation)
+
+    def __repr__(self):
+        interpolate_str = "random" if isinstance(self.interpolation, (tuple, list)) else str(self.interpolation)
+        return (f"{self.__class__.__name__}(patch_size={self.patch_size}, "
+                f"max_sequence_len={self.max_sequence_len}, "
+                f"longest={self.longest:.3f}, "
+                f"random_scale_prob={self.random_scale_prob:.3f}, "
+                f"random_aspect_prob={self.random_aspect_prob:.3f})")
+
+
+class CenterCropToSequence(torch.nn.Module):
+    """Center crop the image such that the resulting patch sequence length meets constraints."""
+    def __init__(
+            self, 
+            patch_size: int, 
+            max_seq_len: int,
+            divisible_by_patch: bool = True,
+            fill: Union[int, Tuple[int, int, int]] = 0,
+            padding_mode: str = 'constant'
+        ):
+        super().__init__()
+        self.patch_size = patch_size
+        self.max_seq_len = max_seq_len
+        self.divisible_by_patch = divisible_by_patch
+        self.fill = fill
+        self.padding_mode = padding_mode
+
+
+    def forward(self, img):
+        """Center crop the image to maintain aspect ratio and fit sequence constraint."""
+        _, h, w = transforms.functional.get_dimensions(img)
+        _, target_hw = get_image_size_for_seq(
+            (h, w), 
+            self.patch_size, 
+            self.max_seq_len,
+            self.divisible_by_patch
+        )
+        
+        # Use center crop
+        return center_crop_or_pad(img, target_hw, fill=self.fill, padding_mode=self.padding_mode)
+
+
+class RandomCropToSequence(torch.nn.Module):
+    """Randomly crop and/or pad the image to fit sequence length constraints.
+
+    This maintains aspect ratio while ensuring the resulting image, when divided into patches,
+    will not exceed the specified maximum sequence length. Similar to CentralCropToSequence
+    but with randomized positioning.
+    """
+
+    def __init__(
+            self,
+            patch_size: int,
+            max_sequence_len: int,
+            divisible_by_patch: bool = True,
+            fill: Union[int, Tuple[int, int, int]] = 0,
+            padding_mode: str = 'constant'
+    ):
+        """
+        Args:
+            patch_size: Size of patches (int or tuple of (patch_h, patch_w))
+            max_sequence_len: Maximum allowed sequence length for the resulting image
+            divisible_by_patch: If True, resulting image dimensions will be multiples of patch_size
+            fill: Fill value for padding
+            padding_mode: Padding mode ('constant', 'edge', 'reflect', 'symmetric')
+        """
+        super().__init__()
+        self.patch_size = patch_size
+        self.max_sequence_len = max_sequence_len
+        self.divisible_by_patch = divisible_by_patch
+        self.fill = fill
+        self.padding_mode = padding_mode
+
+    @staticmethod
+    def get_params(img, target_size):
+        """Get random position for crop/pad."""
+        _, image_height, image_width = transforms.functional.get_dimensions(img)
+        delta_height = image_height - target_size[0]
+        delta_width = image_width - target_size[1]
+
+        # Handle both positive (crop) and negative (pad) deltas
+        if delta_height == 0:
+            top = 0
+        else:
+            top = int(math.copysign(random.randint(0, abs(delta_height)), delta_height))
+
+        if delta_width == 0:
+            left = 0
+        else:
+            left = int(math.copysign(random.randint(0, abs(delta_width)), delta_width))
+
+        return top, left
+
+    def forward(self, img):
+        """Randomly crop or pad the image to maintain aspect ratio and fit sequence constraint."""
+        # Get current dimensions
+        _, img_h, img_w = transforms.functional.get_dimensions(img)
+
+        # Calculate target dimensions that satisfy sequence length
+        # We use max_ratio=1.0 to prevent upscaling - we only want to crop or maintain current size
+        _, target_hw = get_image_size_for_seq(
+            (img_h, img_w),
+            self.patch_size,
+            self.max_sequence_len,
+            self.divisible_by_patch,
+            max_ratio=1.0  # Prevent upscaling
+        )
+
+        # Get random position for crop/pad
+        top, left = self.get_params(img, target_hw)
+
+        # Apply crop or pad
+        return crop_or_pad(
+            img,
+            top=top,
+            left=left,
+            height=target_hw[0],
+            width=target_hw[1],
+            fill=self.fill,
+            padding_mode=self.padding_mode,
+        )
+
+    def __repr__(self) -> str:
+        return (f"{self.__class__.__name__}(patch_size={self.patch_size}, "
+                f"max_sequence_len={self.max_sequence_len}, "
+                f"divisible_by_patch={self.divisible_by_patch})")
+
+
+def _validate_range(value, name, length=2):
+    # Validate type and length
+    if not isinstance(value, Sequence) or len(value) != length:
+        raise ValueError(f"{name} should be a sequence of length {length}.")
+
+    # Validate order
+    if value[0] > value[1]:
+        warnings.warn(f"{name.capitalize()} range reversed. Swapping.")
+        return value[1], value[0]
+
+    return value
+
+
+class RandomResizedCropToSequence(torch.nn.Module):
+    """
+    Randomly crop the input image to a subregion with varying area and aspect ratio
+    (relative to the original), then resize that crop to a target size. The target size
+    is determined such that patchifying the resized image (with `patch_size`)
+    does not exceed `max_seq_len` patches, while maintaining the aspect ratio of the crop.
+
+    This combines aspects of torchvision's RandomResizedCrop with sequence length constraints.
+
+    Args:
+        patch_size (int or tuple[int, int]):
+            Patch dimensions (patch_h, patch_w) for sequence length calculation.
+        max_seq_len (int):
+            Maximum number of patches allowed in the final image.
+        scale (tuple[float, float]):
+            Range (min, max) of area fraction of the original image to crop.
+        ratio (tuple[float, float]):
+            Range (min, max) of aspect ratio *multipliers* for the crop, relative
+            to the original image's aspect ratio. E.g., (0.75, 1.333) means the
+            crop's aspect ratio will be sampled between 0.75*orig_ar and 1.333*orig_ar.
+            Uses log-uniform sampling.
+        interpolation (str or InterpolationMode):
+            Interpolation mode for resizing. Can be 'bilinear', 'bicubic', 'nearest',
+            or 'random' (chooses between bilinear and bicubic).
+            Defaults to 'bicubic'.
+        divisible_by_patch (bool):
+            If True, the final image height and width will be multiples of the
+            respective patch dimensions. Defaults to True.
+        max_ratio (float, optional):
+            An optional upper limit on the scaling ratio applied during resizing.
+            Prevents excessive upsampling of the initial crop. `max_ratio=1.0`
+            prevents any upsampling beyond the cropped size. Defaults to None (no limit).
+        final_scale_range (tuple[float, float], optional):
+            If provided, applies an *additional* random scaling factor to the
+            final target size. The factor is sampled uniformly from this range,
+            and multiplied by the size determined by `get_image_size_for_seq`.
+            E.g., (0.8, 1.0) means the final size will be between 80% and 100%
+            of the maximum feasible size. Defaults to None (use maximum feasible size).
+        attempts (int):
+            Number of attempts to sample a valid crop geometry before falling back
+            to a center crop strategy. Defaults to 10.
+    """
+
+    def __init__(
+        self,
+        patch_size: Union[int, Tuple[int, int]] = 16,
+        max_seq_len: int = 1024,
+        scale: Tuple[float, float] = (0.08, 1.0),
+        ratio: Tuple[float, float] = (.8, 1.25),
+        interpolation: Union[str, InterpolationMode] = 'bicubic',
+        divisible_by_patch: bool = True,
+        max_ratio: Optional[float] = None,
+        final_scale_range: Optional[Tuple[float, float]] = None,
+        attempts: int = 10,
+    ):
+        super().__init__()
+        if isinstance(patch_size, int):
+            self.patch_h, self.patch_w = patch_size, patch_size
+        else:
+            # Assume it's a tuple/list: (patch_h, patch_w)
+            if len(patch_size) != 2:
+                raise ValueError("patch_size tuple must have exactly two elements (patch_h, patch_w).")
+            self.patch_h, self.patch_w = patch_size
+        self.max_seq_len = max_seq_len
+        self.scale = scale
+        self.ratio = ratio
+        self.divisible_by_patch = divisible_by_patch
+        self.max_ratio = max_ratio
+        self.final_scale_range = final_scale_range
+        self.attempts = attempts
+        if isinstance(interpolation, str):
+            if interpolation == 'random':
+                self.interpolation = _RANDOM_INTERPOLATION
+            else:
+                self.interpolation = str_to_interp_mode(interpolation)
+        else:
+            self.interpolation = interpolation
+
+        # Validate scale and ratio
+        self.scale = _validate_range(self.scale, "scale")
+        self.ratio = _validate_range(self.ratio, "ratio")
+
+        # Validate final_scale_range if provided
+        if self.final_scale_range is not None:
+            self.final_scale_range = _validate_range(self.final_scale_range, "final_scale_range")
+
+            # Additional validation for final_scale_range values
+            if not (0.0 <= self.final_scale_range[0] <= self.final_scale_range[1] <= 1.0):
+                warnings.warn("final_scale_range values should ideally be between 0.0 and 1.0.")
+
+    @staticmethod
+    def get_params(
+            img: Union[torch.Tensor, Image],
+            scale: Tuple[float, float],
+            ratio: Tuple[float, float],
+            crop_attempts: int = 10,
+            patch_h: int = 16,
+            patch_w: int = 16,
+            max_seq_len: int = 1024,
+            divisible_by_patch: bool = True,
+            max_ratio: Optional[float] = None,
+            final_scale_range: Optional[Tuple[float, float]] = None,
+            interpolation: Union[List[InterpolationMode], InterpolationMode] = _RANDOM_INTERPOLATION,
+    ) -> Tuple[Tuple[int, int, int, int], Tuple[int, int], InterpolationMode]:
+        """ Get parameters for a random sized crop relative to image aspect ratio.
+        """
+        _, height, width = F.get_dimensions(img)
+        if height <= 0 or width <= 0:
+             raise ValueError(f"Input image must have positive dimensions, got H={height}, W={width}")
+
+        area = height * width
+        orig_aspect = width / height
+        log_ratio = (math.log(ratio[0]), math.log(ratio[1]))
+
+        for _ in range(crop_attempts):
+            target_area = area * random.uniform(scale[0], scale[1])
+            aspect_ratio_factor = math.exp(random.uniform(log_ratio[0], log_ratio[1]))
+            aspect_ratio = orig_aspect * aspect_ratio_factor
+
+            # Calculate target dimensions for the crop
+            # target_area = crop_w * crop_h, aspect_ratio = crop_w / crop_h
+            # => crop_h = sqrt(target_area / aspect_ratio)
+            # => crop_w = sqrt(target_area * aspect_ratio)
+            crop_h = int(round(math.sqrt(target_area / aspect_ratio)))
+            crop_w = int(round(math.sqrt(target_area * aspect_ratio)))
+
+            if 0 < crop_w <= width and 0 < crop_h <= height:
+                top = random.randint(0, height - crop_h)
+                left = random.randint(0, width - crop_w)
+                break
+        else:
+            # Fallback strategy, use center crop trying to respect ratio range
+            min_aspect_ratio = orig_aspect * ratio[0]
+            max_aspect_ratio = orig_aspect * ratio[1]
+
+            if orig_aspect < min_aspect_ratio:
+                # Original is narrower than target min, clamp width
+                crop_w = width
+                crop_h = min(int(round(crop_w / min_aspect_ratio)), height)
+            elif orig_aspect > max_aspect_ratio:
+                # Original is wider than target max, clamp height
+                crop_h = height
+                crop_w = min(int(round(crop_h * max_aspect_ratio)), width)
+            else:
+                # Aspect ratio is within range, take the largest possible crop (full image)
+                crop_w = width
+                crop_h = height
+
+            # Ensure valid dimensions after fallback calculation
+            crop_h = max(1, crop_h)
+            crop_w = max(1, crop_w)
+
+            top = (height - crop_h) // 2
+            left = (width - crop_w) // 2
+
+        # Determine max feasible size for scaling of the *cropped* region
+        feasible_ratio, feasible_size = get_image_size_for_seq(
+            (crop_h, crop_w),
+            patch_size=(patch_h, patch_w), # Pass as tuple
+            max_seq_len=max_seq_len,
+            divisible_by_patch=divisible_by_patch,
+            max_ratio=max_ratio,
+        )
+
+        # Optionally apply final scale randomization
+        final_size = feasible_size
+        if final_scale_range is not None:
+            min_sc, max_sc = final_scale_range
+            scale_factor = random.uniform(min_sc, max_sc)
+            scale_factor = min(max(scale_factor, 0.0), 1.0) # Clamp factor just in case
+
+            # Calculate raw scaled size
+            # Note: feasible_ratio already accounts for max_ratio clamp if any
+            raw_h = crop_h * feasible_ratio * scale_factor
+            raw_w = crop_w * feasible_ratio * scale_factor
+
+            # Re-apply divisibility constraint if needed
+            if divisible_by_patch:
+                # Use ceil to avoid going under minimum patch size
+                target_h = patch_h * math.ceil(raw_h / patch_h)
+                target_w = patch_w * math.ceil(raw_w / patch_w)
+            else:
+                target_h = int(round(raw_h))
+                target_w = int(round(raw_w))
+
+            # Ensure final size is at least one patch dimension
+            target_h = max(target_h, patch_h)
+            target_w = max(target_w, patch_w)
+            final_size = (target_h, target_w)
+
+             # Final check: Ensure this randomized size still fits max_seq_len
+             # (It should, as we scaled down, but rounding might theoretically push it over)
+            num_patches_h = final_size[0] // patch_h
+            num_patches_w = final_size[1] // patch_w
+            if (num_patches_h * num_patches_w) > max_seq_len:
+                 # If it exceeds, revert to the original feasible_size (safest)
+                 final_size = feasible_size
+                 warnings.warn(f"Final scale randomization ({scale_factor:.2f}) resulted in size {final_size} exceeding max_seq_len={max_seq_len} after rounding. Reverting to feasible size {feasible_size}.")
+
+        # Select interpolation mode
+        if isinstance(interpolation, (tuple, list)):
+            interpolation = random.choice(interpolation)
+        else:
+            interpolation = interpolation
+
+        return (top, left, crop_h, crop_w), final_size, interpolation
+
+    def forward(self, img: Union[torch.Tensor, Image]) -> torch.Tensor:
+        # Sample crop, resize, and interpolation parameters
+        crop_params, final_size, interpolation = self.get_params(
+            img,
+            scale=self.scale,
+            ratio=self.ratio,
+            crop_attempts=self.attempts,
+            patch_h=self.patch_h,
+            patch_w=self.patch_w,
+            divisible_by_patch=self.divisible_by_patch,
+            max_seq_len=self.max_seq_len,
+            final_scale_range=self.final_scale_range,
+            interpolation=self.interpolation,
+        )
+        top, left, crop_h, crop_w = crop_params
+
+        output = F.resized_crop(
+            img,
+            top=top,
+            left=left,
+            height=crop_h,
+            width=crop_w,
+            size=final_size,
+            interpolation=interpolation,
+            antialias=True,
+        )
+
+        return output
+
+    def __repr__(self) -> str:
+        if isinstance(self.interpolation, (tuple, list)):
+            interpolate_str = ', '.join(str(m).split('.')[-1] for m in self.interpolation)
+        else:
+            interpolate_str = str(self.interpolation)
+        format_string = self.__class__.__name__ + '('
+        format_string += f"patch_size=({self.patch_h}, {self.patch_w})"
+        format_string += f", max_seq_len={self.max_seq_len}"
+        format_string += f", scale={self.scale}"
+        format_string += f", ratio={self.ratio}"
+        format_string += f", interpolation=[{interpolate_str}]"
+        format_string += f", divisible_by_patch={self.divisible_by_patch}"
+        format_string += f", max_ratio={self.max_ratio}"
+        format_string += f", final_scale_range={self.final_scale_range}"
+        format_string += f", attempts={self.attempts}"
+        format_string += ')'
+        return format_string
+
+
+def patchify(
+        img: torch.Tensor,
+        patch_size: Tuple[int, int],
+        pad: bool = True,
+        include_info: bool = True,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+    c, h, w = img.shape
+    ph, pw = patch_size
+
+    # Ensure the image is divisible by patch size
+    if pad and (h % ph != 0 or w % pw != 0):
+        new_h = math.ceil(h / ph) * ph
+        new_w = math.ceil(w / pw) * pw
+        padded_img = torch.zeros(c, new_h, new_w, dtype=img.dtype)
+        padded_img[:, :h, :w] = img
+        img = padded_img
+        c, h, w = img.shape
+
+    # Calculate number of patches in each dimension
+    nh, nw = h // ph, w // pw
+    # Reshape image to patches [nh, nw, ph, pw, c]
+    patches = img.view(c, nh, ph, nw, pw).permute(1, 3, 2, 4, 0).reshape(nh * nw, ph * pw * c)
+
+    if include_info:
+        # Create coordinate indices
+        y_idx, x_idx = torch.meshgrid(torch.arange(nh), torch.arange(nw), indexing='ij')
+        # Stack into a single coords tensor [N, 2] with (y, x) order
+        coord = torch.stack([y_idx.reshape(-1), x_idx.reshape(-1)], dim=1)
+        # Create type indicators (all 1s for regular patches)
+        valid = torch.ones(nh * nw, dtype=torch.bool)
+        return patches, coord, valid
+
+    return patches
+
+
+class Patchify(torch.nn.Module):
+    """Transform an image into patches with corresponding coordinates and type indicators."""
+    
+    def __init__(self, patch_size):
+        super().__init__()
+        self.patch_size = patch_size if isinstance(patch_size, tuple) else (patch_size, patch_size)
+        
+    def forward(self, img):
+        """
+        Args:
+            img: A PIL Image or tensor of shape [C, H, W]
+            
+        Returns:
+            A dictionary containing:
+                - patches: Tensor of shape [N, P*P*C] where N is the number of patches
+                - patch_coord: Tensor of shape [N, 2] with (y, x) coordinates
+                - patch_valid: Valid indicator (all 1s for non-padding patches)
+        """
+        if isinstance(img, Image.Image):
+            # Convert PIL Image to tensor [C, H, W]
+            img = transforms.functional.to_tensor(img)
+
+        patches, coord, valid = patchify(img, self.patch_size)
+
+        return {
+            'patches': patches,
+            'patch_coord': coord,
+            'patch_valid': valid,
+        }

--- a/timm/data/naflex_transforms.py
+++ b/timm/data/naflex_transforms.py
@@ -575,7 +575,7 @@ class RandomResizedCropToSequence(torch.nn.Module):
 
     @staticmethod
     def get_params(
-            img: Union[torch.Tensor, Image],
+            img: torch.Tensor,
             scale: Tuple[float, float],
             ratio: Tuple[float, float],
             crop_attempts: int = 10,
@@ -690,7 +690,7 @@ class RandomResizedCropToSequence(torch.nn.Module):
 
         return (top, left, crop_h, crop_w), final_size, interpolation
 
-    def forward(self, img: Union[torch.Tensor, Image]) -> torch.Tensor:
+    def forward(self, img: torch.Tensor) -> torch.Tensor:
         # Sample crop, resize, and interpolation parameters
         crop_params, final_size, interpolation = self.get_params(
             img,

--- a/timm/data/transforms_factory.py
+++ b/timm/data/transforms_factory.py
@@ -132,9 +132,13 @@ def transforms_imagenet_train(
 
     primary_tfl = []
     if naflex:
+        scale = tuple(scale or (0.08, 1.0))  # default imagenet scale range
+        ratio = tuple(ratio or (3. / 4., 4. / 3.))  # default imagenet ratio range
         primary_tfl += [RandomResizedCropToSequence(
             patch_size=patch_size,
             max_seq_len=max_seq_len,
+            scale=scale,
+            ratio=ratio,
             interpolation=interpolation
         )]
     else:

--- a/timm/data/transforms_factory.py
+++ b/timm/data/transforms_factory.py
@@ -318,7 +318,7 @@ def transforms_imagenet_eval(
         tfl += [ResizeToSequence(
             patch_size=patch_size,
             max_seq_len=max_seq_len,
-            interpolation=interpolation
+            interpolation=interpolation,
         )]
     else:
         if crop_mode == 'squash':

--- a/timm/layers/__init__.py
+++ b/timm/layers/__init__.py
@@ -41,8 +41,7 @@ from .norm_act import BatchNormAct2d, GroupNormAct, GroupNorm1Act, LayerNormAct,
     SyncBatchNormAct, convert_sync_batchnorm, FrozenBatchNormAct2d, freeze_batch_norm_2d, unfreeze_batch_norm_2d
 from .padding import get_padding, get_same_padding, pad_same
 from .patch_dropout import PatchDropout
-from .patch_embed import PatchEmbed, PatchEmbedWithSize, resample_patch_embed
-from .patch_embed_interpolator import PatchEmbedInterpolator
+from .patch_embed import PatchEmbed, PatchEmbedWithSize, PatchEmbedInterpolator, resample_patch_embed
 from .pool1d import global_pool_nlc
 from .pool2d_same import AvgPool2dSame, create_pool2d
 from .pos_embed import resample_abs_pos_embed, resample_abs_pos_embed_nhwc

--- a/timm/layers/__init__.py
+++ b/timm/layers/__init__.py
@@ -42,6 +42,7 @@ from .norm_act import BatchNormAct2d, GroupNormAct, GroupNorm1Act, LayerNormAct,
 from .padding import get_padding, get_same_padding, pad_same
 from .patch_dropout import PatchDropout
 from .patch_embed import PatchEmbed, PatchEmbedWithSize, resample_patch_embed
+from .patch_embed_interpolator import PatchEmbedInterpolator
 from .pool1d import global_pool_nlc
 from .pool2d_same import AvgPool2dSame, create_pool2d
 from .pos_embed import resample_abs_pos_embed, resample_abs_pos_embed_nhwc

--- a/timm/layers/__init__.py
+++ b/timm/layers/__init__.py
@@ -1,7 +1,7 @@
 from .activations import *
 from .adaptive_avgmax_pool import \
     adaptive_avgmax_pool2d, select_adaptive_pool2d, AdaptiveAvgMaxPool2d, SelectAdaptivePool2d
-from .attention import Attention, AttentionRope
+from .attention import Attention, AttentionRope, maybe_add_mask
 from .attention2d import MultiQueryAttention2d, Attention2d, MultiQueryAttentionV2
 from .attention_pool import AttentionPoolLatent
 from .attention_pool2d import AttentionPool2d, RotAttentionPool2d, RotaryEmbedding

--- a/timm/layers/__init__.py
+++ b/timm/layers/__init__.py
@@ -1,6 +1,7 @@
 from .activations import *
 from .adaptive_avgmax_pool import \
     adaptive_avgmax_pool2d, select_adaptive_pool2d, AdaptiveAvgMaxPool2d, SelectAdaptivePool2d
+from .attention import Attention
 from .attention2d import MultiQueryAttention2d, Attention2d, MultiQueryAttentionV2
 from .attention_pool import AttentionPoolLatent
 from .attention_pool2d import AttentionPool2d, RotAttentionPool2d, RotaryEmbedding

--- a/timm/layers/attention.py
+++ b/timm/layers/attention.py
@@ -1,0 +1,66 @@
+from typing import Final, Type, Optional
+
+import torch
+from torch import nn as nn
+from torch.nn import functional as F
+
+from .config import use_fused_attn
+
+
+class Attention(nn.Module):
+    fused_attn: Final[bool]
+
+    def __init__(
+            self,
+            dim: int,
+            num_heads: int = 8,
+            qkv_bias: bool = False,
+            qk_norm: bool = False,
+            proj_bias: bool = True,
+            attn_drop: float = 0.,
+            proj_drop: float = 0.,
+            norm_layer: Type[nn.Module] = nn.LayerNorm,
+    ) -> None:
+        super().__init__()
+        assert dim % num_heads == 0, 'dim should be divisible by num_heads'
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.scale = self.head_dim ** -0.5
+        self.fused_attn = use_fused_attn()
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.q_norm = norm_layer(self.head_dim) if qk_norm else nn.Identity()
+        self.k_norm = norm_layer(self.head_dim) if qk_norm else nn.Identity()
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim, bias=proj_bias)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def forward(
+            self,
+            x: torch.Tensor,
+            attn_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        B, N, C = x.shape
+        qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, self.head_dim).permute(2, 0, 3, 1, 4)
+        q, k, v = qkv.unbind(0)
+        q, k = self.q_norm(q), self.k_norm(k)
+
+        if self.fused_attn:
+            x = F.scaled_dot_product_attention(
+                q, k, v,
+                attn_mask=attn_mask,
+                dropout_p=self.attn_drop.p if self.training else 0.,
+            )
+        else:
+            q = q * self.scale
+            attn = q @ k.transpose(-2, -1)
+            if attn_mask is not None:
+                attn = attn + attn_mask
+            attn = attn.softmax(dim=-1)
+            attn = self.attn_drop(attn)
+            x = attn @ v
+
+        x = x.transpose(1, 2).reshape(B, N, C)
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x

--- a/timm/layers/attention.py
+++ b/timm/layers/attention.py
@@ -8,7 +8,6 @@ from .config import use_fused_attn
 from .pos_embed_sincos import apply_rot_embed_cat
 
 
-@torch.fx.wrap
 def maybe_add_mask(scores: torch.Tensor, attn_mask: Optional[torch.Tensor] = None):
     return scores if attn_mask is None else scores + attn_mask
 

--- a/timm/layers/attention_pool.py
+++ b/timm/layers/attention_pool.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from .attention import maybe_add_mask
 from .config import use_fused_attn
 from .mlp import Mlp
 from .weight_init import trunc_normal_tf_
@@ -95,8 +96,7 @@ class AttentionPoolLatent(nn.Module):
         else:
             q = q * self.scale
             attn = q @ k.transpose(-2, -1)
-            if attn_mask is not None:
-                attn = attn + attn_mask
+            attn = maybe_add_mask(attn, attn_mask)
             attn = attn.softmax(dim=-1)
             x = attn @ v
         x = x.transpose(1, 2).reshape(B, self.latent_len, C)

--- a/timm/layers/attention_pool.py
+++ b/timm/layers/attention_pool.py
@@ -75,7 +75,7 @@ class AttentionPoolLatent(nn.Module):
             trunc_normal_tf_(self.pos_embed, std=self.pos_embed.shape[1] ** -0.5)
         trunc_normal_tf_(self.latent, std=self.latent_dim ** -0.5)
 
-    def forward(self, x):
+    def forward(self, x, attn_mask: Optional[torch.Tensor] = None):
         B, N, C = x.shape
 
         if self.pos_embed is not None:
@@ -91,10 +91,12 @@ class AttentionPoolLatent(nn.Module):
         q, k = self.q_norm(q), self.k_norm(k)
 
         if self.fused_attn:
-            x = F.scaled_dot_product_attention(q, k, v)
+            x = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
         else:
             q = q * self.scale
             attn = q @ k.transpose(-2, -1)
+            if attn_mask is not None:
+                attn = attn + attn_mask
             attn = attn.softmax(dim=-1)
             x = attn @ v
         x = x.transpose(1, 2).reshape(B, self.latent_len, C)

--- a/timm/layers/patch_embed.py
+++ b/timm/layers/patch_embed.py
@@ -321,7 +321,7 @@ def resample_patch_embed(
         verbose: bool = False,
 ):
     """ Standalone function (computes matrix on each call). """
-    assert len(patch_embed.shape) == 4, "Input tensor should be 4D (out_c, in_c, h, w)"
+    assert len(patch_embed.shape) == 4, "Input tensor should be 4D (out_ch, in_ch, h, w)"
     assert len(new_size) == 2, "New shape should only be hw (height, width)"
 
     old_size_tuple: Tuple[int, int] = tuple(patch_embed.shape[-2:])

--- a/timm/models/__init__.py
+++ b/timm/models/__init__.py
@@ -41,6 +41,7 @@ from .mlp_mixer import *
 from .mobilenetv3 import *
 from .mobilevit import *
 from .mvitv2 import *
+from .naflexvit import *
 from .nasnet import *
 from .nest import *
 from .nextvit import *
@@ -72,7 +73,6 @@ from .vgg import *
 from .visformer import *
 from .vision_transformer import *
 from .vision_transformer_hybrid import *
-from .vision_transformer_flex import *
 from .vision_transformer_relpos import *
 from .vision_transformer_sam import *
 from .vitamin import *

--- a/timm/models/__init__.py
+++ b/timm/models/__init__.py
@@ -72,6 +72,7 @@ from .vgg import *
 from .visformer import *
 from .vision_transformer import *
 from .vision_transformer_hybrid import *
+from .vision_transformer_flex import *
 from .vision_transformer_relpos import *
 from .vision_transformer_sam import *
 from .vitamin import *

--- a/timm/models/_features_fx.py
+++ b/timm/models/_features_fx.py
@@ -18,7 +18,7 @@ except ImportError:
 
 # Layers we went to treat as leaf modules
 from timm.layers import Conv2dSame, ScaledStdConv2dSame, CondConv2d, StdConv2dSame, Format
-from timm.layers import resample_abs_pos_embed, resample_abs_pos_embed_nhwc
+from timm.layers import resample_abs_pos_embed, resample_abs_pos_embed_nhwc, maybe_add_mask
 from timm.layers.non_local_attn import BilinearAttnTransform
 from timm.layers.pool2d_same import MaxPool2dSame, AvgPool2dSame
 from timm.layers.norm_act import (
@@ -79,6 +79,7 @@ def get_notrace_modules():
 _autowrap_functions = {
     resample_abs_pos_embed,
     resample_abs_pos_embed_nhwc,
+    maybe_add_mask,
 }
 
 

--- a/timm/models/naflexvit.py
+++ b/timm/models/naflexvit.py
@@ -1007,8 +1007,11 @@ class NaFlexVit(nn.Module):
             patch_coord = x['patch_coord']
             patch_valid = x['patch_valid']
             patches = x['patches']
+            assert False, 'WIP, patch mode needs more work'
         else:
             patches = x
+            height, width = x.shape[-2:]
+            H, W = self.embeds.dynamic_feat_size((height, width))
 
         # Create attention mask if patch_type is provided and mask is not
         if mask is None and patch_valid is not None:
@@ -1040,12 +1043,6 @@ class NaFlexVit(nn.Module):
 
         if reshape:
             # reshape to BCHW output format
-            grid_size = self.embeds.pos_embed_grid_size
-            if hasattr(self.embeds, 'dynamic_feat_size') and len(x.shape) >= 4:
-                _, height, width, _ = x.shape if len(x.shape) == 4 else (None, *x.shape[-3:-1], None)
-                H, W = self.embeds.dynamic_feat_size((height, width))
-            else:
-                H, W = grid_size
             intermediates = [
                 y.reshape(y.shape[0], H, W, -1).permute(0, 3, 1, 2).contiguous()
                 for y in intermediates

--- a/timm/models/naflexvit.py
+++ b/timm/models/naflexvit.py
@@ -1,16 +1,19 @@
-""" Vision Transformer (New)
+""" NaFlex Vision Transformer
 
 An improved version of the Vision Transformer with:
 1. Encapsulated embedding and position encoding in a single module
 2. Support for linear patch embedding on pre-patchified inputs
-3. Support for NaFlex functionality (NaViT + FlexiViT)
+3. Support for NaFlex variable aspect, variable resolution
+4. Support for FlexiViT variable patch size
+5. Support for NaViT fractional/factorized position embedding
 
-Based on:
+Based on ideas from:
 - Original Vision Transformer: https://arxiv.org/abs/2010.11929
 - FlexiViT: https://arxiv.org/abs/2212.08013
 - NaViT: https://arxiv.org/abs/2307.06304
+- NaFlex (SigLip-2): https://arxiv.org/abs/2502.14786
 
-Copyright 2025
+Hacked together by / Copyright 2025, Ross Wightman, Hugging Face
 """
 
 import logging

--- a/timm/models/naflexvit.py
+++ b/timm/models/naflexvit.py
@@ -15,7 +15,7 @@ Copyright 2025
 
 import logging
 import math
-from collections import OrderedDict
+from dataclasses import dataclass, fields, replace
 from functools import partial
 from typing import Callable, Dict, List, Optional, Set, Tuple, Type, Union, Final, Any, Literal
 
@@ -42,7 +42,87 @@ from timm.models._manipulate import checkpoint_seq, named_apply
 
 from .vision_transformer import Block, global_pool_nlc
 
+__all__ = ['NaFlexVitCfg', 'NaFlexVit']
+
+
 _logger = logging.getLogger(__name__)
+
+
+@dataclass
+class NaFlexVitCfg:
+    """Configuration for FlexVit model.
+
+    This dataclass contains the bulk of model configuration parameters,
+    with core parameters (img_size, in_chans, num_classes, etc.) remaining
+    as direct constructor arguments for API compatibility.
+    """
+    # Architecture parameters
+    patch_size: Union[int, Tuple[int, int]] = 16
+    embed_dim: int = 768
+    depth: int = 12
+    num_heads: int = 12
+    mlp_ratio: float = 4.0
+
+    # Attention parameters
+    qkv_bias: bool = True
+    qk_norm: bool = False
+    proj_bias: bool = True
+    attn_drop_rate: float = 0.0
+
+    # Regularization
+    init_values: Optional[float] = None  # Layer-scale init values (layer-scale enabled if not None)
+    drop_rate: float = 0.0  # Dropout rate for classifier
+    pos_drop_rate: float = 0.0  # Dropout rate for position embeddings
+    patch_drop_rate: float = 0.0  # Dropout rate for patch tokens
+    proj_drop_rate: float = 0.0  # Dropout rate for linear projections
+    drop_path_rate: float = 0.0  # Stochastic depth drop rate
+
+    # Prefix token configuration
+    class_token: bool = False  # Use class token
+    reg_tokens: int = 0  # Number of register tokens
+
+    # Position embedding configuration
+    pos_embed: str = 'learned'  # Type of position embedding ('learned', 'factorized', 'rope', 'none')
+    pos_embed_grid_size: Optional[Tuple[int, int]] = (16, 16)  # Grid size for position embedding initialization
+    pos_embed_interp_mode: str = 'bicubic'  # Interpolation mode for position embedding resizing
+    pos_embed_ar_preserving: bool = False  # Whether to preserve aspect ratio during position embedding interpolation
+
+    # Image processing
+    dynamic_img_pad: bool = False  # Whether to enable dynamic padding for variable resolution
+
+    # Architecture choices
+    pre_norm: bool = False  # Whether to apply normalization before attention/MLP layers (start of blocks)
+    final_norm: bool = True  # Whether to apply final normalization before pooling and classifier (end of blocks)
+    fc_norm: Optional[bool] = None  # Whether to normalize features before final classifier (after pooling)
+    global_pool: str = 'map'  # Type of global pooling for final sequence
+    pool_include_prefix: bool = False  # Whether to include class/register prefix tokens in global pooling
+
+    # Weight initialization
+    weight_init: str = ''  # Weight initialization scheme
+    fix_init: bool = True  # Apply weight initialization fix (scaling w/ layer index)
+
+    # Embedding configuration
+    embed_proj_type: str = 'linear'  # Type of embedding layer ('conv' or 'linear')
+    input_norm_layer: Optional[str] = None  # Normalization layer for embeddings input (before input projection)
+    embed_norm_layer: Optional[str] = None  # Normalization layer for embeddings (after input projection)
+
+    # Layer implementations
+    norm_layer: Optional[str] = None  # Normalization layer for transformer blocks
+    act_layer: Optional[str] = None  # Activation layer for MLP blocks
+    block_fn: Optional[str] = None  # Transformer block implementation class name
+    mlp_layer: Optional[str] = None  # MLP implementation class name
+
+
+def _overlay_kwargs(cfg: NaFlexVitCfg, **kwargs) -> NaFlexVitCfg:
+    """Overlay kwargs onto config, replacing config values with provided kwargs."""
+    # Only update fields that exist in the config
+    config_fields = set(cfg.__dataclass_fields__.keys())
+    config_kwargs = {k: v for k, v in kwargs.items() if k in config_fields}
+
+    if config_kwargs:
+        cfg = replace(cfg, **config_kwargs)
+
+    return cfg
 
 
 def batch_patchify(
@@ -67,7 +147,7 @@ def batch_patchify(
 
 
 @register_notrace_module
-class FlexEmbeds(nn.Module):
+class NaFlexEmbeds(nn.Module):
     """NaFlex Embedding module for Vision Transformers.
 
     This module encapsulates the complete embedding process for Vision Transformers,
@@ -93,10 +173,9 @@ class FlexEmbeds(nn.Module):
         patch_size: Size of patches for patch embedding
         in_chans: Number of input image channels
         embed_dim: Dimensionality of patch embedding
-        embed_layer: Type of embedding layer ('conv' or 'linear')
+        proj_type: Type of embedding projection layer ('conv' or 'linear')
         input_norm_layer: Normalization layer applied to input (linear mode only)
         proj_norm_layer: Normalization layer applied after projection
-        final_norm_layer: Final normalization layer before output
         pos_embed: Type of position embedding ('learned', 'factorized', 'rope', 'none')
         pos_drop_rate: Dropout rate for position embeddings
         patch_drop_rate: Dropout rate for patch tokens
@@ -115,21 +194,21 @@ class FlexEmbeds(nn.Module):
             patch_size: Union[int, Tuple[int, int]] = 16,
             in_chans: int = 3,
             embed_dim: int = 768,
-            embed_layer: Optional[str] = None,  # 'conv' or 'linear', default is 'linear'
-            input_norm_layer: Optional[Type[nn.Module]] = None,
-            proj_norm_layer: Optional[Type[nn.Module]] = None,
-            final_norm_layer: Optional[Type[nn.Module]] = None,
-            pos_embed: str = 'learned',
-            pos_drop_rate: float = 0.,
-            patch_drop_rate: float = 0.,
+            proj_type: Optional[str] = None,  # 'conv' or 'linear', default is 'linear'
+            proj_bias: bool = True,
             class_token: bool = True,
             reg_tokens: int = 0,
-            bias: bool = True,
             dynamic_img_pad: bool = False,
+            default_img_size: Union[int, Tuple[int, int]] = None,
+            pos_embed: str = 'learned',
             pos_embed_grid_size: Optional[Tuple[int, int]] = (14, 14),
             pos_embed_interp_mode: str = 'bicubic',
             pos_embed_ar_preserving: bool = False,
-            default_img_size: Union[int, Tuple[int, int]] = None,
+            input_norm_layer: Optional[Type[nn.Module]] = None,
+            proj_norm_layer: Union[bool, Optional[Type[nn.Module]]] = None,
+            norm_layer: Optional[Type[nn.Module]] = None,
+            pos_drop_rate: float = 0.,
+            patch_drop_rate: float = 0.,
     ):
         super().__init__()
         self.has_class_token = class_token
@@ -151,36 +230,42 @@ class FlexEmbeds(nn.Module):
 
         # Calculate grid size and number of patches
         self.default_img_size: Optional[Tuple[int, int]] = None
-        self.pos_embed_grid_size: Optional[
-            Tuple[int, int]] = None  # Stores the grid size used for learned pos embed init
-        if pos_embed_grid_size is None and default_img_size is not None:
+        self.pos_embed_grid_size: Optional[Tuple[int, int]] = None  # Grid size used for learned pos embed init
+        if pos_embed_grid_size is not None:
+            # Highest priority, use provided pos_embed_grid_size
+            self.pos_embed_grid_size = pos_embed_grid_size
+        elif default_img_size is not None:
+            # Fallback to calculating grid size from img_size + patch_size if img size provided.
             self.default_img_size = to_2tuple(default_img_size)
             self.pos_embed_grid_size = tuple([s // p for s, p in zip(self.default_img_size, self.patch_size)])
-        elif pos_embed_grid_size is not None:
-            # Use provided pos_embed_grid_size for NaFlex mode
-            self.pos_embed_grid_size = pos_embed_grid_size
 
         # Determine patch embedding type (linear or conv2d)
-        if embed_layer == 'linear':
+        if proj_type == 'linear':
             # Create linear projection for pre-patchified inputs
             # Input dimension is patch_size^2 * in_chans
             patch_dim = self.patch_size[0] * self.patch_size[1] * in_chans
-            self.norm_input = proj_norm_layer(patch_dim) if input_norm_layer else None
-            self.proj = nn.Linear(patch_dim, embed_dim, bias=bias)
+            assert not (input_norm_layer is True and norm_layer is None), \
+                "`norm_layer` must be given when input_norm_layer=True"
+            input_norm_layer = norm_layer if input_norm_layer is True else (input_norm_layer or None)
+            self.norm_input = input_norm_layer(patch_dim) if input_norm_layer else None
+            self.proj = nn.Linear(patch_dim, embed_dim, bias=proj_bias)
             self.flatten = False
             self.is_linear = True
         else:
             # Default to convolutional patch embedding for image inputs
-            assert input_norm_layer is None
+            assert not input_norm_layer
             self.norm_input = None
             self.proj = nn.Conv2d(
-                in_chans, embed_dim, kernel_size=patch_size, stride=patch_size, bias=bias
+                in_chans, embed_dim, kernel_size=patch_size, stride=patch_size, bias=proj_bias
             )
             self.flatten = True
             self.is_linear = False
 
         # Create normalization layer after the projection
-        self.norm_proj = proj_norm_layer(embed_dim) if proj_norm_layer else nn.Identity()
+        assert not (proj_norm_layer is True and norm_layer is None), \
+            "`norm_layer` must be given when proj_norm_layer=True"
+        proj_norm_layer = norm_layer if proj_norm_layer is True else (proj_norm_layer or None)
+        self.norm = proj_norm_layer(embed_dim) if proj_norm_layer else nn.Identity()
 
         # Create position embedding if needed - only for patches, never for prefix tokens
         if pos_embed in ('factorized', 'learned') and self.pos_embed_grid_size is None:
@@ -196,18 +281,16 @@ class FlexEmbeds(nn.Module):
             self.pos_embed_type = 'rope'
             # Rotary embeddings will be computed on-the-fly in the forward pass
         elif pos_embed == 'factorized':
+            assert self.pos_embed_grid_size is not None
             h, w = self.pos_embed_grid_size
             self.pos_embed_type = 'factorized'
             self.pos_embed_y = nn.Parameter(torch.randn(1, h, embed_dim) * .02)
             self.pos_embed_x = nn.Parameter(torch.randn(1, w, embed_dim) * .02)
         else:
-            # Store position embedding in (1, H, W, dim) format for easier resizing
+            assert self.pos_embed_grid_size is not None
             h, w = self.pos_embed_grid_size
             self.pos_embed = nn.Parameter(torch.randn(1, h, w, embed_dim) * .02)
             self.pos_embed_type = 'learned'
-
-        # Pre-normalization layer (separate from the main norm layer)
-        self.norm_final = final_norm_layer(embed_dim) if final_norm_layer is not None else nn.Identity()
 
         # Dropout layers
         self.pos_drop = nn.Dropout(p=pos_drop_rate)
@@ -260,86 +343,6 @@ class FlexEmbeds(nn.Module):
             return math.ceil(img_size[0] / self.patch_size[0]), math.ceil(img_size[1] / self.patch_size[1])
         else:
             return img_size[0] // self.patch_size[0], img_size[1] // self.patch_size[1]
-
-    def forward(self, x: torch.Tensor, patch_coord: Optional[torch.Tensor] = None) -> torch.Tensor:
-        """Forward pass for patch embedding with position encoding.
-
-        Args:
-            x: Input tensor [B, C, H, W] for conv mode or [B, N, P*P*C] for pre-patchified linear mode
-            patch_coord: Optional patch coordinates [B, N, 2] for NaFlex mode
-
-        Returns:
-            Embedded tensor with position encoding and class/register tokens applied.
-            Shape: [B, num_prefix_tokens + N, embed_dim]
-        """
-        # Apply patch embedding
-        naflex_grid_sizes: Optional[List[Tuple[int, int]]] = None
-        grid_size: Optional[List[int]] = None
-
-        B = x.shape[0]
-        if self.is_linear:
-            # Linear embedding path, works with NaFlex mode or standard 2D mode
-            if patch_coord is not None:
-                _assert(x.ndim == 3, 'Expecting patchified input with ndim == 3')
-                # Pre-patchified NaFlex mode, input is expected to be (B, N, P*P*C) where N is num_patches
-                # Calculate the appropriate grid size from coords
-                max_y = patch_coord[:, :, 0].max(dim=1)[0] + 1
-                max_x = patch_coord[:, :, 1].max(dim=1)[0] + 1
-                naflex_grid_sizes = [(int(h.item()), int(w.item())) for h, w in zip(max_y, max_x)]
-            else:
-                _assert(x.ndim == 4, 'Expecting 2D image input with input ndim == 4')
-                x, grid_size = batch_patchify(x, self.patch_size, pad=self.dynamic_img_pad)
-
-            if self.norm_input is not None:
-                x = self.norm_input(x)
-
-            x = self.proj(x)
-        else:
-            assert x.ndim == 4, 'Convolutional input must be 4D'
-            if self.dynamic_img_pad:
-                H, W = x.shape[-2:]
-                pad_h = (self.patch_size[0] - H % self.patch_size[0]) % self.patch_size[0]
-                pad_w = (self.patch_size[1] - W % self.patch_size[1]) % self.patch_size[1]
-                x = F.pad(x, (0, pad_w, 0, pad_h))
-
-            x = self.proj(x)
-
-            grid_size = x.shape[-2:]
-            if self.flatten:
-                x = x.flatten(2).transpose(1, 2)  # NCHW -> NLC
-
-        # Apply normalization after flattening
-        x = self.norm_proj(x)
-
-        if self.pos_embed_type == 'learned':
-            if naflex_grid_sizes is not None:
-                self._apply_learned_naflex_pos_embed(x, naflex_grid_sizes=naflex_grid_sizes)
-            else:
-                assert grid_size is not None
-                self._apply_learned_pos_embed(x, grid_size=grid_size)
-        elif self.pos_embed_type == 'factorized':
-            if naflex_grid_sizes is not None:
-                self._apply_factorized_naflex_pos_embed(x, naflex_grid_sizes=naflex_grid_sizes)
-        elif self.pos_embed_type == 'rope':
-            assert False, "ROPE not yet implemented"
-
-        # Prepare and add class and register tokens
-        to_cat = []
-        if self.cls_token is not None:
-            to_cat.append(self.cls_token.expand(B, -1, -1))
-        if self.reg_token is not None:
-            to_cat.append(self.reg_token.expand(B, -1, -1))
-        # Add tokens to the beginning
-        if to_cat:
-            x = torch.cat(to_cat + [x], dim=1)
-
-        # Apply final pre-transformer normalization if specified
-        x = self.norm_final(x)
-
-        # Apply dropouts
-        x = self.patch_drop(self.pos_drop(x))
-
-        return x
 
     #@torch.compiler.disable()
     def _apply_learned_naflex_pos_embed(
@@ -463,14 +466,16 @@ class FlexEmbeds(nn.Module):
         for bi, k in enumerate(naflex_grid_sizes):
             size_to_indices.setdefault(k, []).append(bi)
 
-        def _interp1d(table: torch.Tensor, length: int) -> torch.Tensor:
+        def _interp1d(table: torch.Tensor, new_length: int, orig_length: int) -> torch.Tensor:
             """
             Resample a 1-D positional-embedding table to specified length
             and return it in (1, L, C) layout, dtype matching x.
             """
+            if new_length == orig_length:
+                return table.to(dtype=x.dtype)
             return F.interpolate(
                 table.permute(0, 2, 1).float(),  # (1,C,L) → (1,C,L_out)
-                size=length,
+                size=new_length,
                 mode='linear',
                 align_corners=False,
             ).permute(0, 2, 1).to(dtype=x.dtype)  # → (1,L_out,C)
@@ -482,8 +487,8 @@ class FlexEmbeds(nn.Module):
             else:
                 len_y, len_x = target_h, target_w
 
-            pe_y = _interp1d(self.pos_embed_y, len_y)[:, :target_h]  # (1,H,C)
-            pe_x = _interp1d(self.pos_embed_x, len_x)[:, :target_w]  # (1,W,C)
+            pe_y = _interp1d(self.pos_embed_y, len_y, orig_h)[:, :target_h]  # (1,H,C)
+            pe_x = _interp1d(self.pos_embed_x, len_x, orig_w)[:, :target_w]  # (1,W,C)
 
             # Broadcast, add and flatten to sequence layout (row major)
             pos = pe_y.unsqueeze(2) + pe_x.unsqueeze(1)        # (1,H,W,C)
@@ -495,6 +500,82 @@ class FlexEmbeds(nn.Module):
                 torch.as_tensor(batch_indices, device=x.device),
                 pos[:, :seq_len].expand(len(batch_indices), -1, -1)
             )
+
+    def forward(self, x: torch.Tensor, patch_coord: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Forward pass for patch embedding with position encoding.
+
+        Args:
+            x: Input tensor [B, C, H, W] for conv mode or [B, N, P*P*C] for pre-patchified linear mode
+            patch_coord: Optional patch coordinates [B, N, 2] for NaFlex mode
+
+        Returns:
+            Embedded tensor with position encoding and class/register tokens applied.
+            Shape: [B, num_prefix_tokens + N, embed_dim]
+        """
+        # Apply patch embedding
+        naflex_grid_sizes: Optional[List[Tuple[int, int]]] = None
+        grid_size: Optional[List[int]] = None
+
+        B = x.shape[0]
+        if self.is_linear:
+            # Linear embedding path, works with NaFlex mode or standard 2D mode
+            if patch_coord is not None:
+                _assert(x.ndim == 3, 'Expecting patchified input with ndim == 3')
+                # Pre-patchified NaFlex mode, input is expected to be (B, N, P*P*C) where N is num_patches
+                # Calculate the appropriate grid size from coords
+                max_y = patch_coord[:, :, 0].max(dim=1)[0] + 1
+                max_x = patch_coord[:, :, 1].max(dim=1)[0] + 1
+                naflex_grid_sizes = [(int(h.item()), int(w.item())) for h, w in zip(max_y, max_x)]
+            else:
+                _assert(x.ndim == 4, 'Expecting 2D image input with input ndim == 4')
+                x, grid_size = batch_patchify(x, self.patch_size, pad=self.dynamic_img_pad)
+
+            if self.norm_input is not None:
+                x = self.norm_input(x)
+
+            x = self.proj(x)
+        else:
+            assert x.ndim == 4, 'Convolutional input must be 4D'
+            if self.dynamic_img_pad:
+                H, W = x.shape[-2:]
+                pad_h = (self.patch_size[0] - H % self.patch_size[0]) % self.patch_size[0]
+                pad_w = (self.patch_size[1] - W % self.patch_size[1]) % self.patch_size[1]
+                x = F.pad(x, (0, pad_w, 0, pad_h))
+
+            x = self.proj(x)
+
+            grid_size = x.shape[-2:]
+            if self.flatten:
+                x = x.flatten(2).transpose(1, 2)  # NCHW -> NLC
+
+        # Apply normalization after flattening
+        x = self.norm(x)
+
+        if self.pos_embed_type == 'learned':
+            if naflex_grid_sizes is not None:
+                self._apply_learned_naflex_pos_embed(x, naflex_grid_sizes=naflex_grid_sizes)
+            else:
+                assert grid_size is not None
+                self._apply_learned_pos_embed(x, grid_size=grid_size)
+        elif self.pos_embed_type == 'factorized':
+            if naflex_grid_sizes is not None:
+                self._apply_factorized_naflex_pos_embed(x, naflex_grid_sizes=naflex_grid_sizes)
+        elif self.pos_embed_type == 'rope':
+            assert False, "ROPE not yet implemented"
+
+        # Prepare and add class and register tokens
+        to_cat = []
+        if self.cls_token is not None:
+            to_cat.append(self.cls_token.expand(B, -1, -1))
+        if self.reg_token is not None:
+            to_cat.append(self.reg_token.expand(B, -1, -1))
+        # Add tokens to the beginning
+        if to_cat:
+            x = torch.cat(to_cat + [x], dim=1)
+
+        # Apply dropouts
+        x = self.pos_drop(x)
+        return x
 
 
 @register_notrace_function
@@ -572,6 +653,7 @@ def global_pool_naflex(
         patch_valid: Optional[torch.Tensor] = None,
         pool_type: str = 'token',
         num_prefix_tokens: int = 1,
+        reduce_include_prefix: bool = False,
 ) -> torch.Tensor:
     """Global pooling with NaFlex support for masked tokens.
 
@@ -582,21 +664,32 @@ def global_pool_naflex(
         x: Input tensor with shape [B, N, C]
         patch_valid: Optional validity mask for patches [B, N-num_prefix_tokens]
         pool_type: Type of pooling ('token', 'avg', 'avgmax', 'max')
-        num_prefix_tokens: Number of prefix tokens (class/register) to exclude from masking
+        num_prefix_tokens: Number of prefix tokens (class/register)
+        reduce_include_prefix: Whether to include prefix tokens in pooling reduction
 
     Returns:
         Pooled tensor with shape [B, C]
     """
     if patch_valid is None or pool_type not in ('avg', 'avgmax', 'max'):
         # Fall back to standard pooling
-        x = global_pool_nlc(x, pool_type=pool_type, num_prefix_tokens=num_prefix_tokens)
+        x = global_pool_nlc(
+            x,
+            pool_type=pool_type,
+            num_prefix_tokens=num_prefix_tokens,
+            reduce_include_prefix=reduce_include_prefix,
+        )
         return x
 
     # For NaFlex mode, we need to apply masked pooling to exclude padding tokens
-    # Extract only the patch part of the mask (excluding prefix tokens)
     if num_prefix_tokens > 0:
-        # Apply the mask to extract only valid tokens
-        x = x[:, num_prefix_tokens:]  # prefix tokens not included in pooling
+        if reduce_include_prefix:
+            # Include prefix tokens in pooling - they are always considered valid
+            # patch_valid only covers patch tokens, so create combined validity mask
+            prefix_valid = patch_valid.new_ones(x.shape[0], num_prefix_tokens)
+            patch_valid = torch.cat([prefix_valid, patch_valid], dim=1)
+        else:
+            # Exclude prefix tokens from pooling (default behavior)
+            x = x[:, num_prefix_tokens:]
 
     patch_valid_float = patch_valid.to(x.dtype)
     if pool_type == 'avg':
@@ -627,8 +720,8 @@ def global_pool_naflex(
         assert False
 
 
-class VisionTransformerFlex(nn.Module):
-    """Vision Transformer with NaFlex support for flexible input handling.
+class NaFlexVit(nn.Module):
+    """NaFlexVit: Vision Transformer with NaFlex support for flexible input handling.
 
     A flexible implementation of Vision Transformer that supports:
     - Standard image classification with various pooling strategies
@@ -642,170 +735,125 @@ class VisionTransformerFlex(nn.Module):
 
     def __init__(
             self,
-            patch_size: Union[int, Tuple[int, int]] = 16,
+            cfg: NaFlexVitCfg = None,
             in_chans: int = 3,
-            embed_dim: int = 768,
-            depth: int = 12,
-            num_heads: int = 12,
-            mlp_ratio: float = 4.,
-            qkv_bias: bool = True,
-            qk_norm: bool = False,
-            proj_bias: bool = True,
-            init_values: Optional[float] = None,
-            class_token: bool = False,
-            reg_tokens: int = 0,
-            pos_embed: str = 'learned',
-            pos_embed_grid_size: Optional[Tuple[int, int]] = (16, 16),
-            pos_embed_interp_mode: str = 'bicubic',
-            pos_embed_ar_preserving: bool = False,
-            default_img_size: Union[int, Tuple[int, int]] = 256,
-            dynamic_img_pad: bool = False,
-            pre_norm: bool = False,
-            final_norm: bool = True,
-            fc_norm: Optional[bool] = None,
             num_classes: int = 1000,
-            global_pool: str = 'map',
-            drop_rate: float = 0.,
-            pos_drop_rate: float = 0.,
-            patch_drop_rate: float = 0.,
-            proj_drop_rate: float = 0.,
-            attn_drop_rate: float = 0.,
-            drop_path_rate: float = 0.,
-            weight_init: str = '',
-            fix_init: bool = True,
-            embed_layer_type: str = 'linear',
-            embed_norm_layer: Optional[LayerType] = None,
-            norm_layer: Optional[LayerType] = None,
-            act_layer: Optional[LayerType] = None,
-            block_fn: Type[nn.Module] = Block,
-            mlp_layer: Type[nn.Module] = Mlp,
+            img_size: Union[int, Tuple[int, int]] = None,
+            **kwargs,
     ) -> None:
-        """Initialize VisionTransformerFlex model.
+        """Initialize NaFlexVit model.
 
         Args:
-            patch_size: Size of patches for patch embedding
+            cfg: Model configuration. If None, uses default FlexVitCfg
             in_chans: Number of input image channels
-            embed_dim: Transformer embedding dimension
-            depth: Number of transformer blocks
-            num_heads: Number of attention heads
-            mlp_ratio: Ratio of MLP hidden dimension to embedding dimension
-            qkv_bias: Whether to use bias in query, key, value projections
-            qk_norm: Whether to normalize query and key projections
-            proj_bias: Whether to use bias in linear projections
-            init_values: Layer-scale init values (layer-scale enabled if not None)
-            class_token: Whether to include a class token
-            reg_tokens: Number of register tokens to include
-            pos_embed: Type of position embedding
-            pos_embed_grid_size: Grid size for position embedding initialization
-            pos_embed_interp_mode: Interpolation mode for position embedding resizing
-            pos_embed_ar_preserving: Whether to preserve aspect ratio during position embedding interpolation
-            default_img_size: Default image size for position embedding grid calculation
-            dynamic_img_pad: Whether to enable dynamic padding for variable resolution
-            pre_norm: Whether to apply normalization before attention/MLP layers
-            final_norm: Whether to apply final normalization before classifier
-            fc_norm: Whether to normalize features before final classifier
             num_classes: Number of classification classes
-            global_pool: Type of global pooling for final sequence
-            drop_rate: Dropout rate for classifier
-            pos_drop_rate: Dropout rate for position embeddings
-            patch_drop_rate: Dropout rate for patch tokens
-            proj_drop_rate: Dropout rate for linear projections
-            attn_drop_rate: Dropout rate for attention weights
-            drop_path_rate: Stochastic depth drop rate
-            weight_init: Weight initialization scheme
-            fix_init: Apply weight initialization fix (scaling w/ layer index)
-            embed_layer_type: Type of embedding layer ('conv' or 'linear')
-            embed_norm_layer: Normalization layer for embeddings
-            norm_layer: Normalization layer for transformer blocks
-            act_layer: Activation layer for MLP blocks
-            block_fn: Transformer block implementation class
-            mlp_layer: MLP implementation class
+            img_size: Input image size for bwd compat with original vit (if pos_embed_grid_size not specified)
+            **kwargs: Additional config parameters to override cfg values
         """
         super().__init__()
-        assert global_pool in ('', 'avg', 'avgmax', 'max', 'token', 'map')
-        assert class_token or global_pool != 'token'
-        assert pos_embed in ('', 'none', 'learned', 'factorized')
-        norm_layer = get_norm_layer(norm_layer) or LayerNorm
-        embed_norm_layer = get_norm_layer(embed_norm_layer)
-        act_layer = get_act_layer(act_layer) or nn.GELU
 
+        # Initialize config
+        cfg = cfg or NaFlexVitCfg()
+        if kwargs:
+            cfg = _overlay_kwargs(cfg, **kwargs)
+
+        # Validate configuration
+        assert cfg.global_pool in ('', 'avg', 'avgmax', 'max', 'token', 'map')
+        assert cfg.class_token or cfg.global_pool != 'token'
+        assert cfg.pos_embed in ('', 'none', 'learned', 'factorized')
+
+        # Resolve layer implementations
+        norm_layer = get_norm_layer(cfg.norm_layer) or LayerNorm
+        embed_norm_layer = get_norm_layer(cfg.embed_norm_layer)
+        act_layer = get_act_layer(cfg.act_layer) or nn.GELU
+        block_fn = Block  # TODO: Support configurable block_fn via string lookup
+        mlp_layer = Mlp   # TODO: Support configurable mlp_layer via string lookup
+
+        # Store instance variables
         self.num_classes = num_classes
-        self.global_pool = global_pool
-        self.num_features = self.head_hidden_size = self.embed_dim = embed_dim  # for consistency with other models
-        self.num_prefix_tokens = 1 if class_token else 0
-        self.num_prefix_tokens += reg_tokens
-        self.num_reg_tokens = reg_tokens
-        self.has_class_token = class_token
+        self.global_pool = cfg.global_pool
+        self.num_features = self.head_hidden_size = self.embed_dim = cfg.embed_dim  # for consistency with other models
+        self.num_prefix_tokens = 1 if cfg.class_token else 0
+        self.num_prefix_tokens += cfg.reg_tokens
+        self.num_reg_tokens = cfg.reg_tokens
+        self.has_class_token = cfg.class_token
+        self.pool_include_prefix = cfg.pool_include_prefix
         self.grad_checkpointing = False
 
         # Initialize embedding module (includes patch, position embedding, and class/reg tokens)
-        # VisionTransformerEmbeds is always used - handles both linear and conv embedding
-        self.embeds = FlexEmbeds(
-            patch_size=patch_size,
+        # FlexEmbeds is always used - handles both linear and conv embedding
+        self.embeds = NaFlexEmbeds(
+            patch_size=cfg.patch_size,
             in_chans=in_chans,
-            embed_dim=embed_dim,
-            embed_layer=embed_layer_type,
+            embed_dim=cfg.embed_dim,
+            proj_type=cfg.embed_proj_type,
+            proj_bias=not cfg.pre_norm,  # disable bias if pre-norm is used (e.g. CLIP)
+            class_token=cfg.class_token,
+            reg_tokens=cfg.reg_tokens,
+            default_img_size=img_size,
+            dynamic_img_pad=cfg.dynamic_img_pad,
+            pos_embed=cfg.pos_embed,
+            pos_embed_grid_size=cfg.pos_embed_grid_size,
+            pos_embed_interp_mode=cfg.pos_embed_interp_mode,
+            pos_embed_ar_preserving=cfg.pos_embed_ar_preserving,
             proj_norm_layer=embed_norm_layer,
-            final_norm_layer=norm_layer if pre_norm else None,
-            pos_embed=pos_embed,
-            pos_embed_grid_size=pos_embed_grid_size,
-            pos_embed_interp_mode=pos_embed_interp_mode,
-            pos_embed_ar_preserving=pos_embed_ar_preserving,
-            pos_drop_rate=pos_drop_rate,
-            patch_drop_rate=patch_drop_rate,
-            class_token=class_token,
-            reg_tokens=reg_tokens,
-            default_img_size=default_img_size,
-            dynamic_img_pad=dynamic_img_pad,
-            bias=not pre_norm,  # disable bias if pre-norm is used (e.g. CLIP)
+            pos_drop_rate=cfg.pos_drop_rate,
+            patch_drop_rate=cfg.patch_drop_rate,
         )
+        self.norm_pre = norm_layer(cfg.embed_dim) if cfg.pre_norm else nn.Identity()
 
         # Transformer blocks
-        dpr = [x.item() for x in torch.linspace(0, drop_path_rate, depth)]  # stochastic depth decay rule
+        dpr = [x.item() for x in torch.linspace(0, cfg.drop_path_rate, cfg.depth)]  # stochastic depth decay rule
         self.blocks = nn.Sequential(*[
             block_fn(
-                dim=embed_dim,
-                num_heads=num_heads,
-                mlp_ratio=mlp_ratio,
-                qkv_bias=qkv_bias,
-                qk_norm=qk_norm,
-                proj_bias=proj_bias,
-                init_values=init_values,
-                proj_drop=proj_drop_rate,
-                attn_drop=attn_drop_rate,
+                dim=cfg.embed_dim,
+                num_heads=cfg.num_heads,
+                mlp_ratio=cfg.mlp_ratio,
+                qkv_bias=cfg.qkv_bias,
+                qk_norm=cfg.qk_norm,
+                proj_bias=cfg.proj_bias,
+                init_values=cfg.init_values,
+                proj_drop=cfg.proj_drop_rate,
+                attn_drop=cfg.attn_drop_rate,
                 drop_path=dpr[i],
                 norm_layer=norm_layer,
                 act_layer=act_layer,
                 mlp_layer=mlp_layer,
             )
-            for i in range(depth)])
+            for i in range(cfg.depth)])
 
         # Feature info for downstream tasks
-        patch_reduction = to_2tuple(patch_size)
+        patch_reduction = self.embeds.feat_ratio(as_scalar=True)
         self.feature_info = [
-            dict(module=f'blocks.{i}', num_chs=embed_dim, reduction=patch_reduction) for i in range(depth)]
+            dict(module=f'blocks.{i}', num_chs=cfg.embed_dim, reduction=patch_reduction)
+            for i in range(cfg.depth)
+        ]
 
-        self.norm = norm_layer(embed_dim) if final_norm and not fc_norm else nn.Identity()
+        self.norm = norm_layer(cfg.embed_dim) if cfg.final_norm and not cfg.fc_norm else nn.Identity()
 
         # Classifier Head
-        if global_pool == 'map':
+        if cfg.global_pool == 'map':
             self.attn_pool = AttentionPoolLatent(
                 self.embed_dim,
-                num_heads=num_heads,
-                mlp_ratio=mlp_ratio,
+                num_heads=cfg.num_heads,
+                mlp_ratio=cfg.mlp_ratio,
                 norm_layer=norm_layer,
                 act_layer=act_layer,
             )
         else:
             self.attn_pool = None
 
-        self.fc_norm = norm_layer(embed_dim) if final_norm and fc_norm else nn.Identity()
-        self.head_drop = nn.Dropout(drop_rate)
+        # Handle fc_norm default value
+        fc_norm = cfg.fc_norm
+        if fc_norm is None:
+            fc_norm = cfg.global_pool == 'avg'
+        self.fc_norm = norm_layer(cfg.embed_dim) if cfg.final_norm and fc_norm else nn.Identity()
+        self.head_drop = nn.Dropout(cfg.drop_rate)
         self.head = nn.Linear(self.embed_dim, num_classes) if num_classes > 0 else nn.Identity()
 
-        if weight_init != 'skip':
-            self.init_weights(weight_init)
-        if fix_init:
+        if cfg.weight_init != 'skip':
+            self.init_weights(cfg.weight_init)
+        if cfg.fix_init:
             self.fix_init_weight()
 
     def fix_init_weight(self) -> None:
@@ -917,7 +965,7 @@ class VisionTransformerFlex(nn.Module):
 
     def forward_intermediates(
             self,
-            x: torch.Tensor,
+            x: Union[torch.Tensor, Dict[str, torch.Tensor]],
             indices: Optional[Union[int, List[int]]] = None,
             return_prefix_tokens: bool = False,
             norm: bool = False,
@@ -954,13 +1002,21 @@ class VisionTransformerFlex(nn.Module):
         reshape = output_fmt == 'NCHW'
         intermediates = []
         take_indices, max_index = feature_take_indices(len(self.blocks), indices)
+        if isinstance(x, Dict):
+            # Handle dictionary input from NaFlex collator
+            patch_coord = x['patch_coord']
+            patch_valid = x['patch_valid']
+            patches = x['patches']
+        else:
+            patches = x
 
         # Create attention mask if patch_type is provided and mask is not
         if mask is None and patch_valid is not None:
-            mask = create_attention_mask(patch_valid, self.num_prefix_tokens, x.dtype)
+            mask = create_attention_mask(patch_valid, self.num_prefix_tokens, patches.dtype)
 
         # Forward pass through embedding
-        x = self.embeds(x, patch_coord=patch_coord, patch_valid=patch_valid)
+        x = self.embeds(patches, patch_coord=patch_coord)
+        x = self.norm_pre(x)
 
         # Forward pass through blocks
         if torch.jit.is_scripting() or not stop_early:  # can't slice blocks in torchscript
@@ -990,8 +1046,10 @@ class VisionTransformerFlex(nn.Module):
                 H, W = self.embeds.dynamic_feat_size((height, width))
             else:
                 H, W = grid_size
-            intermediates = [y.reshape(y.shape[0], H, W, -1).permute(0, 3, 1, 2).contiguous()
-                           for y in intermediates]
+            intermediates = [
+                y.reshape(y.shape[0], H, W, -1).permute(0, 3, 1, 2).contiguous()
+                for y in intermediates
+            ]
 
         # For dictionary output
         if output_dict:
@@ -1037,7 +1095,7 @@ class VisionTransformerFlex(nn.Module):
 
         # Pass through embedding module with patch coordinate/type support
         x = self.embeds(x, patch_coord=patch_coord)
-
+        x = self.norm_pre(x)
         # Apply transformer blocks with masked attention if mask provided
         if attn_mask is not None:
             # We need to apply blocks one by one with mask
@@ -1059,13 +1117,26 @@ class VisionTransformerFlex(nn.Module):
     ) -> torch.Tensor:
         if self.attn_pool is not None:
             # For attention pooling, we need to pass the mask for NaFlex models
-            attn_mask = create_attention_mask(
-                patch_valid,
-                symmetric=False,
-                q_len=1,
-                dtype=x.dtype,
-            )
-            x = self.attn_pool(x[:, self.num_prefix_tokens:], attn_mask=attn_mask)
+            if self.pool_include_prefix:
+                # Include all tokens in attention pooling - create mask for all tokens including prefix
+                attn_mask = create_attention_mask(
+                    patch_valid,
+                    num_prefix_tokens=self.num_prefix_tokens,
+                    symmetric=False,
+                    q_len=1,
+                    dtype=x.dtype,
+                )
+                x = self.attn_pool(x, attn_mask=attn_mask)
+            else:
+                # Exclude prefix tokens from attention pooling (default behavior)
+                attn_mask = create_attention_mask(
+                    patch_valid,
+                    num_prefix_tokens=0,  # No prefix tokens when we slice them off
+                    symmetric=False,
+                    q_len=1,
+                    dtype=x.dtype,
+                )
+                x = self.attn_pool(x[:, self.num_prefix_tokens:], attn_mask=attn_mask)
             return x
 
         pool_type = self.global_pool if pool_type is None else pool_type
@@ -1075,6 +1146,7 @@ class VisionTransformerFlex(nn.Module):
             patch_valid,
             pool_type=pool_type,
             num_prefix_tokens=self.num_prefix_tokens,
+            reduce_include_prefix=self.pool_include_prefix,
         )
         return x
 
@@ -1158,7 +1230,7 @@ def get_init_weights_vit(mode: str = 'jax', head_bias: float = 0.0) -> Callable:
         return init_weights_vit_timm
 
 
-def checkpoint_filter_fn(state_dict: Dict[str, Any], model: VisionTransformerFlex) -> Dict[str, Any]:
+def checkpoint_filter_fn(state_dict: Dict[str, Any], model: NaFlexVit) -> Dict[str, Any]:
     """Handle state dict conversion from original ViT to the new version with combined embedding."""
     from .vision_transformer import checkpoint_filter_fn as orig_filter_fn
 
@@ -1182,8 +1254,9 @@ def checkpoint_filter_fn(state_dict: Dict[str, Any], model: VisionTransformerFle
                 num_patches_no_prefix = num_patches - num_prefix_tokens
                 grid_size_no_prefix = math.sqrt(num_patches_no_prefix)
                 grid_size = math.sqrt(num_patches)
-                if (grid_size_no_prefix != grid_size and (
-                        grid_size_no_prefix.is_integer() and not grid_size.is_integer())):
+                if (grid_size_no_prefix != grid_size
+                        and (grid_size_no_prefix.is_integer() and not grid_size.is_integer())
+                ):
                     # make a decision, did the pos_embed of the original include the prefix tokens?
                     num_patches = num_patches_no_prefix
                     cls_token_emb = v[:, 0:num_cls_token]
@@ -1224,7 +1297,6 @@ def checkpoint_filter_fn(state_dict: Dict[str, Any], model: VisionTransformerFle
         elif k.startswith('patch_embed.'):
             suffix = k[12:]
             if suffix == 'proj.weight':
-                # FIXME confirm patchify memory layout across use cases
                 v = v.permute(0, 2, 3, 1).flatten(1)
             new_key = 'embeds.' + suffix
             out_dict[new_key] = v
@@ -1252,115 +1324,186 @@ def _cfg(url: str = '', **kwargs) -> Dict[str, Any]:
 
 
 default_cfgs = generate_default_cfgs({
-    'vit_naflex_base_patch16_gap': _cfg(),
-    'vit_naflex_base_patch16_map': _cfg(),
+    'naflexvit_base_patch16_gap': _cfg(),
+    'naflexvit_base_patch16_map': _cfg(),
 
-    'vit_naflex_base_patch16_siglip': _cfg(),
-    'vit_naflex_so400m_patch16_siglip': _cfg(),
-
-    # sbb model testijg
-    'vit_naflex_mediumd_patch16_reg4_gap.sbb2_r256_e200_in12k_ft_in1k': _cfg(
-        hf_hub_id='timm/vit_mediumd_patch16_reg4_gap_256.sbb2_e200_in12k_ft_in1k',
-        input_size=(3, 256, 256), crop_pct=0.95),
-    'vit_naflex_so150m2_patch16_reg1_gap.sbb_r256_e200_in12k_ft_in1k': _cfg(
-        hf_hub_id='timm/vit_so150m2_patch16_reg1_gap_256.sbb_e200_in12k_ft_in1k',
-        input_size=(3, 256, 256), crop_pct=1.0),
-    'vit_naflex_so150m2_patch16_reg1_gap.sbb_r384_e200_in12k_ft_in1k': _cfg(
-        hf_hub_id='timm/vit_so150m2_patch16_reg1_gap_384.sbb_e200_in12k_ft_in1k',
-        input_size=(3, 384, 384), crop_pct=1.0),
-    'vit_naflex_so150m2_patch16_reg1_gap.sbb_r448_e200_in12k_ft_in1k': _cfg(
-        hf_hub_id='timm/vit_so150m2_patch16_reg1_gap_448.sbb_e200_in12k_ft_in1k',
-        input_size=(3, 448, 448), crop_pct=1.0, crop_mode='squash'),
-
-    # traditional vit testing
-    'vit_naflex_base_patch16.augreg2_r224_in21k_ft_in1k': _cfg(
-        hf_hub_id='timm/vit_base_patch16_224.augreg2_in21k_ft_in1k'),
-    'vit_naflex_base_patch8.augreg2_r224_in21k_ft_in1k': _cfg(
-        hf_hub_id='timm/vit_base_patch16_224.augreg2_in21k_ft_in1k'),
+    'naflexvit_base_patch16_siglip': _cfg(),
+    'naflexvit_so400m_patch16_siglip': _cfg(),
 })
 
 
-def _create_vision_transformer_flex(variant: str, pretrained: bool = False, **kwargs) -> VisionTransformerFlex:
+def _create_naflexvit(variant: str, pretrained: bool = False, **kwargs) -> NaFlexVit:
+    out_indices = kwargs.pop('out_indices', 3)
+    cfg = kwargs.pop('cfg', NaFlexVitCfg())
+    cfg_field_names = {f.name for f in fields(NaFlexVitCfg)}
+    # pop in-place so the original kwargs is emptied of cfg-specific keys
+    cfg_updates = {k: kwargs.pop(k) for k in list(kwargs) if k in cfg_field_names}
+    if cfg_updates:
+        cfg = _overlay_kwargs(cfg, **cfg_updates)
+
     model = build_model_with_cfg(
-        VisionTransformerFlex, variant, pretrained,
+        NaFlexVit, variant, pretrained,
         pretrained_filter_fn=checkpoint_filter_fn,
+        cfg=cfg,
+        feature_cfg=dict(out_indices=out_indices, feature_cls='getter'),
         **kwargs,
     )
     return model
 
 
-@register_model
-def vit_naflex_base_patch16_gap(pretrained: bool = False, **kwargs) -> VisionTransformerFlex:
-    """ViT-New with NaFlex functionality for variable aspect ratios and resolutions.
+def _create_naflexvit_from_classic(
+        variant: str,
+        pretrained: bool = False,
+        **kwargs,
+) -> NaFlexVit:
+    """Create FlexVit model from classic VisionTransformer configuration.
+
+    This function handles the parameter mapping and configuration logic needed
+    to create FlexVit models that are compatible with classic VisionTransformer
+    configurations and pretrained weights.
+
+    Args:
+        variant: Model variant name
+        pretrained: Whether to load pretrained weights
+        **kwargs: Classic VisionTransformer parameters
+
+    Returns:
+        FlexVit model instance
     """
-    model_args = dict(
-        patch_size=16, embed_dim=768, depth=12, num_heads=12, init_values=1e-5,
-        global_pool='avg', reg_tokens=4, fc_norm=True, **kwargs)
-    model = _create_vision_transformer_flex(
-        'vit_naflex_base_patch16_gap', pretrained=pretrained, **dict(model_args, **kwargs))
+    # Remove VisionTransformer-specific parameters that don't apply to FlexVit
+    kwargs.pop('no_embed_class', None)
+    kwargs.pop('dynamic_img_size', None)
+
+    # Handle global pooling and fc_norm defaults that differ between ViT and FlexVit
+    gp = kwargs.pop('global_pool', 'token')  # Original ViTs default to cls token pooling
+    fc_norm = kwargs.pop('fc_norm', None)    # Original ViTs used fc_norm when not set and avg pooling used
+    if fc_norm is None and gp == 'avg':
+        fc_norm = True
+
+    # Set FlexVit-specific defaults that differ from VisionTransformer
+    flex_kwargs = {
+        'pos_embed_grid_size': None,  # rely on img_size (// patch_size) that will be passed through
+        'class_token': kwargs.get('class_token', True),
+        'global_pool': gp,
+        'fc_norm': fc_norm,
+        **kwargs  # User overrides take precedence
+    }
+
+    return _create_naflexvit(variant, pretrained, **flex_kwargs)
+
+
+@register_model
+def naflexvit_base_patch16_gap(pretrained: bool = False, **kwargs) -> NaFlexVit:
+    """ViT-Base with NaFlex functionality and global average pooling.
+    """
+    cfg = NaFlexVitCfg(
+        patch_size=16,
+        embed_dim=768,
+        depth=12,
+        num_heads=12,
+        init_values=1e-5,
+        global_pool='avg',
+        reg_tokens=4,
+        fc_norm=True,
+    )
+    model = _create_naflexvit('naflexvit_base_patch16_gap', pretrained=pretrained, cfg=cfg, **kwargs)
     return model
 
 
 @register_model
-def vit_naflex_base_patch16_map(pretrained: bool = False, **kwargs) -> VisionTransformerFlex:
-    """ViT-New with NaFlex functionality for variable aspect ratios and resolutions.
+def naflexvit_base_patch16_map(pretrained: bool = False, **kwargs) -> NaFlexVit:
+    """ViT-Base with NaFlex functionality and MAP attention pooling.
     """
-    model_args = dict(
-        patch_size=16, embed_dim=768, depth=12, num_heads=12, init_values=1e-5,
-        global_pool='map', reg_tokens=1)
-    model = _create_vision_transformer_flex(
-        'vit_naflex_base_patch16_map', pretrained=pretrained, **dict(model_args, **kwargs))
+    cfg = NaFlexVitCfg(
+        patch_size=16,
+        embed_dim=768,
+        depth=12,
+        num_heads=12,
+        init_values=1e-5,
+        global_pool='map',
+        reg_tokens=1,
+    )
+    model = _create_naflexvit('naflexvit_base_patch16_map', pretrained=pretrained, cfg=cfg, **kwargs)
     return model
 
 
 @register_model
-def vit_naflex_so150m2_patch16_reg1_gap(pretrained: bool = False, **kwargs) -> VisionTransformerFlex:
-    """ViT-New with NaFlex functionality for variable aspect ratios and resolutions.
+def naflexvit_so150m2_patch16_reg1_gap(pretrained: bool = False, **kwargs) -> NaFlexVit:
+    """ViT-SO150M2 with NaFlex functionality for variable aspect ratios and resolutions.
 
     This model supports:
     1. Variable aspect ratios and resolutions via patch coordinates
     2. Position embedding interpolation for arbitrary grid sizes
     3. Explicit patch coordinates and valid token masking
     """
-    model_args = dict(
-        patch_size=16, embed_dim=832, depth=21, num_heads=13, mlp_ratio=34/13, init_values=1e-5,
-        qkv_bias=False, reg_tokens=1, global_pool='avg', fc_norm=True)
-    model = _create_vision_transformer_flex(
-        'vit_naflex_so150m2_patch16_reg1_gap', pretrained=pretrained, **dict(model_args, **kwargs))
+    cfg = NaFlexVitCfg(
+        patch_size=16,
+        embed_dim=832,
+        depth=21,
+        num_heads=13,
+        mlp_ratio=34/13,
+        init_values=1e-5,
+        qkv_bias=False,
+        reg_tokens=1,
+        global_pool='avg',
+        fc_norm=True,
+    )
+    model = _create_naflexvit('naflexvit_so150m2_patch16_reg1_gap', pretrained=pretrained, cfg=cfg, **kwargs)
     return model
 
 
 @register_model
-def vit_naflex_base_patch16(pretrained: bool = False, **kwargs) -> VisionTransformerFlex:
-    """ ViT-Base (ViT-B/16) from original paper (https://arxiv.org/abs/2010.11929).
-    ImageNet-1k weights fine-tuned from in21k @ 224x224, source https://github.com/google-research/vision_transformer.
+def naflexvit_so150m2_patch16_reg1_map(pretrained: bool = False, **kwargs) -> NaFlexVit:
+    """ViT-SO150M2 with NaFlex functionality for variable aspect ratios and resolutions.
+
+    This model supports:
+    1. Variable aspect ratios and resolutions via patch coordinates
+    2. Position embedding interpolation for arbitrary grid sizes
+    3. Explicit patch coordinates and valid token masking
     """
-    model_args = dict(
-        patch_size=16, embed_dim=768, depth=12, num_heads=12,
-        global_pool='token', class_token=True, pos_embed_grid_size=(14, 14))
-    model = _create_vision_transformer_flex(
-        'vit_naflex_base_patch16', pretrained=pretrained, **dict(model_args, **kwargs))
+    cfg = NaFlexVitCfg(
+        patch_size=16,
+        embed_dim=832,
+        depth=21,
+        num_heads=13,
+        mlp_ratio=34/13,
+        init_values=1e-5,
+        qkv_bias=False,
+        reg_tokens=1,
+        global_pool='map',
+    )
+    model = _create_naflexvit('naflexvit_so150m2_patch16_reg1_map', pretrained=pretrained, cfg=cfg, **kwargs)
     return model
 
 
 @register_model
-def vit_naflex_base_patch16_siglip(pretrained: bool = False, **kwargs) -> VisionTransformerFlex:
-    """ViT-New with NaFlex functionality for variable aspect ratios and resolutions.
+def naflexvit_base_patch16_siglip(pretrained: bool = False, **kwargs) -> NaFlexVit:
+    """ViT-Base with NaFlex functionality and SigLIP-style configuration.
     """
-    model_args = dict(
-        patch_size=16, embed_dim=768, depth=12, num_heads=12, act_layer='gelu_tanh', global_pool='map')
-    model = _create_vision_transformer_flex(
-        'vit_naflex_base_patch16_siglip', pretrained=pretrained, **dict(model_args, **kwargs))
+    cfg = NaFlexVitCfg(
+        patch_size=16,
+        embed_dim=768,
+        depth=12,
+        num_heads=12,
+        act_layer='gelu_tanh',
+        global_pool='map',
+    )
+    model = _create_naflexvit('naflexvit_base_patch16_siglip', pretrained=pretrained, cfg=cfg, **kwargs)
     return model
 
 
 @register_model
-def vit_naflex_so400m_patch16_siglip(pretrained: bool = False, **kwargs) -> VisionTransformerFlex:
+def naflexvit_so400m_patch16_siglip(pretrained: bool = False, **kwargs) -> NaFlexVit:
     """ViT-SO400M with NaFlex functionality for variable aspect ratios and resolutions.
     """
-    model_args = dict(
-        patch_size=16, embed_dim=1152, depth=27, num_heads=16, mlp_ratio=3.7362,
-        act_layer='gelu_tanh', global_pool='map')
-    model = _create_vision_transformer_flex(
-        'vit_naflex_so400m_patch16_siglip', pretrained=pretrained, **dict(model_args, **kwargs))
+    cfg = NaFlexVitCfg(
+        patch_size=16,
+        embed_dim=1152,
+        depth=27,
+        num_heads=16,
+        mlp_ratio=3.7362,
+        act_layer='gelu_tanh',
+        global_pool='map',
+    )
+    model = _create_naflexvit('naflexvit_so400m_patch16_siglip', pretrained=pretrained, cfg=cfg, **kwargs)
     return model

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -43,7 +43,7 @@ from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD, IMAGENET_INCE
     OPENAI_CLIP_MEAN, OPENAI_CLIP_STD
 from timm.layers import Attention, PatchEmbed, Mlp, DropPath, AttentionPoolLatent, RmsNorm, PatchDropout, \
     SwiGLUPacked, SwiGLU, trunc_normal_, lecun_normal_, resample_patch_embed, resample_abs_pos_embed, use_fused_attn, \
-    get_act_layer, get_norm_layer, LayerType
+    get_act_layer, get_norm_layer, LayerType, maybe_add_mask
 from ._builder import build_model_with_cfg
 from ._features import feature_take_indices
 from ._manipulate import named_apply, checkpoint_seq, adapt_input_conv
@@ -256,8 +256,7 @@ class ParallelScalingBlock(nn.Module):
         else:
             q = q * self.scale
             attn = q @ k.transpose(-2, -1)
-            if attn_mask is not None:
-                attn = attn + attn_mask
+            attn = maybe_add_mask(attn, attn_mask)
             attn = attn.softmax(dim=-1)
             attn = self.attn_drop(attn)
             x_attn = attn @ v

--- a/timm/models/vision_transformer_flex.py
+++ b/timm/models/vision_transformer_flex.py
@@ -1027,6 +1027,7 @@ def _cfg(url: str = '', **kwargs) -> Dict[str, Any]:
 default_cfgs = generate_default_cfgs({
     'vit_naflex_base_patch16_gap': _cfg(),
     'vit_naflex_base_patch16_map': _cfg(),
+    'vit_naflex_so400m_patch16_map': _cfg(),
 
     # sbb model testijg
     'vit_naflex_mediumd_patch16_reg4_gap.sbb2_r256_e200_in12k_ft_in1k': _cfg(
@@ -1109,4 +1110,16 @@ def vit_naflex_base_patch16(pretrained: bool = False, **kwargs):
         patch_size=16, embed_dim=768, depth=12, num_heads=12,
         global_pool='token', class_token=True, pos_embed_grid_size=(14, 14))
     model = _create_vision_transformer_flex('vit_naflex_base_patch16', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
+
+
+@register_model
+def vit_naflex_so400m_patch16_map(pretrained=False, **kwargs):
+    """ViT-SO400M with NaFlex functionality for variable aspect ratios and resolutions.
+    """
+    model_args = dict(
+        patch_size=16, embed_dim=1152, depth=27, num_heads=16, mlp_ratio=3.7362, init_values=1e-5,
+        global_pool='map', class_token=False, reg_tokens=1, act_layer='gelu_tanh')
+    model = _create_vision_transformer_flex(
+        'vit_naflex_so400m_patch16_map', pretrained=pretrained, **dict(model_args, **kwargs))
     return model

--- a/timm/models/vision_transformer_flex.py
+++ b/timm/models/vision_transformer_flex.py
@@ -823,7 +823,7 @@ class VisionTransformerFlex(nn.Module):
             attn_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
 
-        if attn_mask is None and patch_valid is not None:
+        if attn_mask is None:
             attn_mask = create_attention_mask(
                 patch_valid,
                 num_prefix_tokens=self.num_prefix_tokens,

--- a/timm/models/vision_transformer_flex.py
+++ b/timm/models/vision_transformer_flex.py
@@ -1,0 +1,1045 @@
+""" Vision Transformer (New)
+
+An improved version of the Vision Transformer with:
+1. Encapsulated embedding and position encoding in a single module
+2. Support for linear patch embedding on pre-patchified inputs
+3. Support for NaFlex functionality (NaViT + FlexiViT)
+
+Based on:
+- Original Vision Transformer: https://arxiv.org/abs/2010.11929
+- FlexiViT: https://arxiv.org/abs/2212.08013
+- NaViT: https://arxiv.org/abs/2307.06304
+
+Copyright 2025
+"""
+
+import logging
+import math
+from collections import OrderedDict
+from functools import partial
+from typing import Callable, Dict, List, Optional, Set, Tuple, Type, Union, Final, Any, Literal
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD, IMAGENET_INCEPTION_MEAN, IMAGENET_INCEPTION_STD
+from timm.layers import AttentionPoolLatent, Mlp, to_2tuple, get_act_layer, get_norm_layer, LayerType, _assert
+from timm.models._builder import build_model_with_cfg
+from timm.models._features import feature_take_indices
+from timm.models._registry import register_model, generate_default_cfgs
+from timm.models._manipulate import checkpoint_seq, named_apply
+
+from .vision_transformer import Block, global_pool_nlc
+
+_logger = logging.getLogger(__name__)
+
+
+def batch_patchify(
+        x: torch.Tensor,
+        patch_size: Tuple[int, int],
+        pad: bool = True,
+) -> Tuple[torch.Tensor, Tuple[int, int]]:
+    B, C, H, W = x.shape
+    ph, pw = to_2tuple(patch_size)
+
+    # Ensure the image is divisible by patch size
+    if pad and (H % ph != 0 or W % pw != 0):
+        pad_h = (ph - H % ph) % ph
+        pad_w = (pw - W % pw) % pw
+        x = F.pad(x, (0, pad_w, 0, pad_h))
+
+    nh, nw = H // ph, W // pw
+    patches = x.view(B, C, nh, ph, nw, pw).permute(0, 2, 4, 3, 5, 1).reshape(B, nh * nw, ph * pw * C)
+
+    return patches, (nh, nw)
+
+
+class FlexEmbeds(nn.Module):
+    """ Na(Flex) Embedding module for Vision Transformers
+
+    This module encapsulates the complete embedding process for Vision Transformers:
+    1. Patch embedding (via Conv2d or Linear)
+    2. Class and register token preparation
+    3. Position embedding addition
+    4. Pre-normalization (if requested)
+    5. Dropout application
+
+    Also supports NaFlex functionality (NaViT + FlexiViT):
+    - Variable aspect ratio and resolution via patch coordinates
+    - Patch type indicators for handling padding tokens in attention
+    - Flexible position embedding interpolation for arbitrary grid sizes
+
+    Note: Only supports non-overlapping position and register tokens
+    (i.e., position embeddings do not include class/register tokens)
+
+    The patch embedding can be one of two types:
+    1. Conv2d-based (default): For standard image inputs [B, C, H, W]
+    2. Linear-based: For pre-patchified inputs [B, N, P*P*C]
+
+    """
+
+    def __init__(
+            self,
+            patch_size: Union[int, Tuple[int, int]] = 16,
+            in_chans: int = 3,
+            embed_dim: int = 768,
+            embed_layer: Optional[str] = None,  # 'conv' or 'linear', default is 'linear'
+            input_norm_layer: Optional[Type[nn.Module]] = None,
+            proj_norm_layer: Optional[Type[nn.Module]] = None,
+            final_norm_layer: Optional[Type[nn.Module]] = None,
+            pos_embed: str = 'learned',
+            pos_drop_rate: float = 0.,
+            patch_drop_rate: float = 0.,
+            class_token: bool = True,
+            reg_tokens: int = 0,
+            bias: bool = True,
+            dynamic_img_pad: bool = False,
+            pos_embed_grid_size: Optional[Tuple[int, int]] = (14, 14),
+            pos_embed_interp_mode: str = 'bicubic',
+            default_img_size: Union[int, Tuple[int, int]] = None,
+    ):
+        super().__init__()
+        self.has_class_token = class_token
+        self.num_reg_tokens = reg_tokens
+        self.pos_embed_interp_mode = pos_embed_interp_mode
+        self.patch_size = to_2tuple(patch_size)
+        self.in_chans = in_chans
+        self.embed_dim = embed_dim
+        self.dynamic_img_pad = dynamic_img_pad
+
+        # Calculate number of prefix tokens
+        self.num_prefix_tokens = 1 if class_token else 0
+        self.num_prefix_tokens += reg_tokens
+
+        # Create class and register tokens
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim)) if class_token else None
+        self.reg_token = nn.Parameter(torch.zeros(1, reg_tokens, embed_dim)) if reg_tokens else None
+
+        # Calculate grid size and number of patches
+        self.default_img_size: Optional[Tuple[int, int]] = None
+        self.pos_embed_grid_size: Optional[
+            Tuple[int, int]] = None  # Stores the grid size used for learned pos embed init
+        if pos_embed_grid_size is None and default_img_size is not None:
+            self.default_img_size = to_2tuple(default_img_size)
+            self.pos_embed_grid_size = tuple([s // p for s, p in zip(self.default_img_size, self.patch_size)])
+        elif pos_embed_grid_size is not None:
+            # Use provided pos_embed_grid_size for NaFlex mode
+            self.pos_embed_grid_size = pos_embed_grid_size
+
+        # Determine patch embedding type (linear or conv2d)
+        if embed_layer == 'linear':
+            # Create linear projection for pre-patchified inputs
+            # Input dimension is patch_size^2 * in_chans
+            patch_dim = self.patch_size[0] * self.patch_size[1] * in_chans
+            self.norm_input = proj_norm_layer(patch_dim) if input_norm_layer else None
+            self.proj = nn.Linear(patch_dim, embed_dim, bias=bias)
+            self.flatten = False
+            self.is_linear = True
+        else:
+            # Default to convolutional patch embedding for image inputs
+            assert input_norm_layer is None
+            self.norm_input = None
+            self.proj = nn.Conv2d(
+                in_chans, embed_dim, kernel_size=patch_size, stride=patch_size, bias=bias
+            )
+            self.flatten = True
+            self.is_linear = False
+
+        # Create normalization layer after the projection
+        self.norm_proj = proj_norm_layer(embed_dim) if proj_norm_layer else nn.Identity()
+
+        # Create position embedding if needed - only for patches, never for prefix tokens
+        if not pos_embed or pos_embed == 'none':
+            self.pos_embed = None
+            self.pos_embed_type = 'none'
+        elif pos_embed == 'rope':
+            self.pos_embed = None
+            self.pos_embed_type = 'rope'
+            # Rotary embeddings will be computed on-the-fly in the forward pass
+        else:
+            # Store position embedding in (1, H, W, dim) format for easier resizing
+            if self.pos_embed_grid_size is not None:
+                h, w = self.pos_embed_grid_size
+                self.pos_embed = nn.Parameter(torch.randn(1, h, w, embed_dim) * .02)
+                self.pos_embed_type = 'learned'
+            else:
+                raise ValueError("Cannot initialize position embeddings without grid_size. "
+                                 "Please provide img_size or pos_embed_grid_size")
+
+        # Pre-normalization layer (separate from the main norm layer)
+        self.norm_final = final_norm_layer(embed_dim) if final_norm_layer is not None else nn.Identity()
+
+        # Dropout layers
+        self.pos_drop = nn.Dropout(p=pos_drop_rate)
+        if patch_drop_rate > 0:
+            from timm.layers.patch_dropout import PatchDropout
+            self.patch_drop = PatchDropout(
+                patch_drop_rate,
+                num_prefix_tokens=self.num_prefix_tokens,
+            )
+        else:
+            self.patch_drop = nn.Identity()
+
+    def feature_info(self, location):
+        """Feature info utility method for feature extraction."""
+        return dict(num_chs=self.embed_dim, reduction=self.patch_size)
+
+    def feat_ratio(self, as_scalar=True):
+        """Return the feature reduction ratio (stride)."""
+        if as_scalar:
+            return max(self.patch_size)
+        else:
+            return self.patch_size
+
+    def dynamic_feat_size(self, img_size: Tuple[int, int]) -> Tuple[int, int]:
+        """ Get grid (feature) size for given image size taking account of dynamic padding.
+        """
+        if self.dynamic_img_pad:
+            return math.ceil(img_size[0] / self.patch_size[0]), math.ceil(img_size[1] / self.patch_size[1])
+        else:
+            return img_size[0] // self.patch_size[0], img_size[1] // self.patch_size[1]
+
+    def forward(self, x, patch_coord=None, patch_valid=None):
+        """Forward pass for combined embedding
+
+        Args:
+            x: Input tensor [B, C, H, W] or pre-patchified [B, N, P*P*C]
+            patch_coord: Optional patch coordinates [B, N, 2] for NaFlex
+            patch_valid: Optional patch type indicators (1=patch, 0=padding) for NaFlex
+
+        Returns:
+            Embedded tensor with position encoding and class/register tokens applied
+            If patch_type is provided, also returns attention mask
+        """
+        # Apply patch embedding
+        naflex_grid_sizes: Optional[List[Tuple[int, int]]] = None
+        grid_size: Optional[Tuple[int, int]] = None
+
+        if self.is_linear:
+            # Linear embedding path, works with NaFlex mode or standard 2D mode
+            B = x.shape[0]
+            if x.ndim == 3:
+                # pre-patchified NaFlex mode, input is expected to be (B, N, P*P*C) where N is num_patches
+                _assert(patch_coord is not None, 'patch_coord must not be None in NaFlex mode')
+
+                # Calculate the appropriate grid size from coords
+                max_y = patch_coord[:, :, 0].max(dim=1)[0] + 1
+                max_x = patch_coord[:, :, 1].max(dim=1)[0] + 1
+                naflex_grid_sizes = [(h.item(), w.item()) for h, w in zip(max_y, max_x)]
+            else:
+                x, grid_size = batch_patchify(x, self.patch_size, pad=self.dynamic_img_pad)
+
+            if self.norm_input is not None:
+                x = self.norm_input(x)
+
+            x = self.proj(x)
+        else:
+            assert x.ndim == 4, 'Convolutional input must be 4D'
+            if self.dynamic_img_pad:
+                H, W = x.shape[-2:]
+                pad_h = (self.patch_size[0] - H % self.patch_size[0]) % self.patch_size[0]
+                pad_w = (self.patch_size[1] - W % self.patch_size[1]) % self.patch_size[1]
+                x = F.pad(x, (0, pad_w, 0, pad_h))
+
+            x = self.proj(x)
+
+            grid_size = x.shape[-2:]
+            if self.flatten:
+                x = x.flatten(2).transpose(1, 2)  # NCHW -> NLC
+
+        # Apply normalization after flattening
+        x = self.norm_proj(x)
+
+        if self.pos_embed_type == 'learned':
+            if naflex_grid_sizes:
+                self._apply_learned_naflex_pos_embed(x, naflex_grid_sizes=naflex_grid_sizes)
+            else:
+                self._apply_learned_pos_embed(x, grid_size=grid_size)
+        elif self.pos_embed_type == 'rope':
+            assert False, "ROPE not yet implemented"
+
+        # Prepare and add class and register tokens
+        to_cat = []
+        if self.cls_token is not None:
+            to_cat.append(self.cls_token.expand(B, -1, -1))
+        if self.reg_token is not None:
+            to_cat.append(self.reg_token.expand(B, -1, -1))
+        # Add tokens to the beginning
+        if to_cat:
+            x = torch.cat(to_cat + [x], dim=1)
+
+        # Apply final pre-transformer normalization if specified
+        x = self.norm_final(x)
+
+        # Apply dropouts
+        x = self.patch_drop(self.pos_drop(x))
+
+        return x
+
+    def _apply_learned_naflex_pos_embed(
+            self,
+            x: torch.Tensor,
+            naflex_grid_sizes: List[Tuple[int, int]],
+    ):
+        orig_h, orig_w = self.pos_embed.shape[1:3]
+
+        # Determine unique grid sizes
+        size_to_indices = {}
+        for bi, (h, w) in enumerate(naflex_grid_sizes):
+            if not (h, w) in size_to_indices:
+                size_to_indices[(h, w)] = [bi]
+            else:
+                size_to_indices[(h, w)].append(bi)
+
+        # Handle each batch element separately with its own grid size
+        for (h, w), batch_indices in size_to_indices.items():
+            # Interpolate only once for this (h, w)
+            if (h == orig_h) and (w == orig_w):
+                pos_embed_flat = self.pos_embed.reshape(orig_h * orig_w, -1)
+            else:
+                pos_embed_resized = F.interpolate(
+                    self.pos_embed.permute(0, 3, 1, 2),  # B,C,H,W
+                    size=(h, w),
+                    mode=self.pos_embed_interp_mode,
+                    align_corners=False,
+                    antialias=True,
+                )
+                pos_embed_flat = pos_embed_resized.permute(0, 2, 3, 1).reshape(h * w, -1)
+
+            seq_len = min(x.shape[1], pos_embed_flat.shape[0])
+            x[batch_indices, :seq_len].add_(pos_embed_flat[:seq_len])
+
+    def _apply_learned_pos_embed(
+            self,
+            x: torch.Tensor,
+            grid_size: Tuple[int, int],
+    ):
+        orig_h, orig_w = self.pos_embed.shape[1:3]
+        if grid_size[0] != orig_h or grid_size[1] != orig_w:
+            # Resize if needed - directly using F.interpolate
+            pos_embed = F.interpolate(
+                self.pos_embed.permute(0, 3, 1, 2),  # B,C,H,W
+                size=grid_size,
+                mode=self.pos_embed_interp_mode,
+                align_corners=False,
+                antialias=True,
+            )
+            # Convert back and flatten
+            pos_embed = pos_embed.permute(0, 2, 3, 1)
+            pos_embed = pos_embed.reshape(1, grid_size[0] * grid_size[1], -1)
+
+        else:
+            # No resize needed, just flatten
+            pos_embed = self.pos_embed.reshape(1, orig_h * orig_w, -1)
+
+        x.add_(pos_embed)
+
+
+def create_attention_mask(
+        patch_valid: Optional[torch.Tensor],
+        num_prefix_tokens: int = 0,
+        dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Create attention mask from patch type information.
+
+    Used for NaFlex mode to handle variable token counts and padding tokens.
+
+    Args:
+        patch_valid: Tensor of shape [B, N] with True for valid patches, False for padding
+        num_prefix_tokens: Number of prefix tokens (class token, register tokens)
+        dtype: Dtype of the attention mask
+
+    Returns:
+        Attention mask of shape [B, seq_len, seq_len] where seq_len = N + num_prefix_tokens,
+        or None if patch_type is None
+    """
+    patch_valid = patch_valid.bool()
+    B = patch_valid.shape[0]
+    device = patch_valid.device
+
+    if num_prefix_tokens > 0:
+        prefix_valid = torch.ones((B, num_prefix_tokens), device=device, dtype=torch.bool)
+        patch_valid = torch.cat([prefix_valid, patch_valid], dim=1)
+
+    mask_bool = (patch_valid.unsqueeze(-1) & patch_valid.unsqueeze(1)).unsqueeze(1)
+    mask_float = torch.zeros_like(mask_bool, dtype=dtype)
+    mask_float.masked_fill_(~mask_bool, torch.finfo(mask_float.dtype).min)
+
+    return mask_float
+
+def create_attention_mask2(
+    patch_valid: Optional[torch.Tensor],
+    num_prefix_tokens: int = 0,
+    q_len: Optional[int] = None,
+    dtype: torch.dtype = torch.float32,
+) -> Optional[torch.Tensor]:
+    """Create expanded attention mask from patch validity info.
+
+    Used for NaFlex mode to handle variable token counts and padding tokens.
+
+    Args:
+        patch_valid: Tensor of shape [B, N] with True for valid patches, False for padding
+        num_prefix_tokens: Number of prefix tokens (class token, register tokens)
+        q_len: Length override for query sequence
+        dtype: Dtype of the attention mask
+
+    Returns:
+        Attention mask of shape [B, seq_len, seq_len] where seq_len = N + num_prefix_tokens,
+        or None if patch_type is None
+    """
+    patch_valid = patch_valid.bool()
+    B, kv_len = patch_valid.shape
+    device = patch_valid.device
+
+    if num_prefix_tokens > 0:
+        prefix_valid = torch.ones((B, num_prefix_tokens), device=device, dtype=torch.bool)
+        patch_valid = torch.cat([prefix_valid, patch_valid], dim=1)
+        kv_len = patch_valid.shape[1]
+
+    q_len = q_len if q_len is not None else kv_len
+
+    mask_bool = patch_valid[:, None, None, :].expand(B, 1, q_len, kv_len).to(dtype)
+    mask_float = torch.zeros_like(mask_bool, dtype=dtype)
+    mask_float.masked_fill_(~mask_bool, torch.finfo(mask_float.dtype).min)
+
+    return mask_float
+
+
+def create_pool_mask(
+        patch_valid: Optional[torch.Tensor],
+        dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    patch_valid = patch_valid.bool()
+    mask_bool = patch_valid[:, None, None, :]
+    mask_float = torch.zeros_like(mask_bool, dtype=dtype)
+    mask_float.masked_fill_(~mask_bool, torch.finfo(mask_float.dtype).min)
+
+    return mask_float
+
+
+class VisionTransformerFlex(nn.Module):
+    """ Vision Transformer (Na)Flex
+
+    A flexible implementation of Vision Transformer with:
+    1. Encapsulated embedding and position encoding in a single module
+    2. Support for linear patch embedding on pre-patchified inputs
+    3. Support for variable sequence length / aspect ratio images (NaFlex)
+    """
+
+    def __init__(
+            self,
+            patch_size: Union[int, Tuple[int, int]] = 16,
+            in_chans: int = 3,
+            embed_dim: int = 768,
+            depth: int = 12,
+            num_heads: int = 12,
+            mlp_ratio: float = 4.,
+            qkv_bias: bool = True,
+            qk_norm: bool = False,
+            proj_bias: bool = True,
+            init_values: Optional[float] = None,
+            class_token: bool = False,
+            reg_tokens: int = 0,
+            pos_embed: str = 'learn',
+            pos_embed_grid_size: Optional[Tuple[int, int]] = (16, 16),
+            pos_embed_interp_mode: str = 'bicubic',
+            default_img_size: Union[int, Tuple[int, int]] = 256,
+            dynamic_img_pad: bool = False,
+            pre_norm: bool = False,
+            final_norm: bool = True,
+            fc_norm: Optional[bool] = None,
+            num_classes: int = 1000,
+            global_pool: str = 'map',
+            drop_rate: float = 0.,
+            pos_drop_rate: float = 0.,
+            patch_drop_rate: float = 0.,
+            proj_drop_rate: float = 0.,
+            attn_drop_rate: float = 0.,
+            drop_path_rate: float = 0.,
+            weight_init: str = '',
+            fix_init: bool = True,
+            embed_layer_type: str = 'linear',
+            embed_norm_layer: Optional[LayerType] = None,
+            norm_layer: Optional[LayerType] = None,
+            act_layer: Optional[LayerType] = None,
+            block_fn: Type[nn.Module] = Block,
+            mlp_layer: Type[nn.Module] = Mlp,
+    ) -> None:
+        """
+        Args:
+            patch_size: Patch size.
+            in_chans: Number of image input channels.
+            embed_dim: Transformer embedding dimension.
+            depth: Depth of transformer.
+            num_heads: Number of attention heads.
+            mlp_ratio: Ratio of mlp hidden dim to embedding dim.
+            qkv_bias: Enable bias for qkv projections if True.
+            init_values: Layer-scale init values (layer-scale enabled if not None).
+            class_token: Use class token.
+            reg_tokens: Number of register tokens.
+            pos_embed: Type of position embedding.
+            pos_embed_grid_size: Size of position embedding grid.
+            pos_embed_interp_mode: Interpolation mode for position embedding.
+            default_img_size: Input image size.
+            pre_norm: Enable norm after embeddings, before transformer blocks (standard in CLIP ViT).
+            final_norm: Enable norm after transformer blocks, before head (standard in most ViT).
+            fc_norm: Move final norm after pool (instead of before), if None, enabled when global_pool == 'avg'.
+            num_classes: Number of classes for classification head.
+            global_pool: Type of global pooling for final sequence (default: 'token').
+            drop_rate: Head dropout rate.
+            pos_drop_rate: Position embedding dropout rate.
+            attn_drop_rate: Attention dropout rate.
+            drop_path_rate: Stochastic depth rate.
+            weight_init: Weight initialization scheme.
+            fix_init: Apply weight initialization fix (scaling w/ layer index).
+            embed_layer_type: Patch embedding implementation (e.g., 'linear', 'conv').
+            embed_norm_layer: Normalization layer to use / override in patch embed module.
+            norm_layer: Normalization layer.
+            act_layer: MLP activation layer.
+            block_fn: Transformer block layer.
+        """
+        super().__init__()
+        assert global_pool in ('', 'avg', 'avgmax', 'max', 'token', 'map')
+        assert class_token or global_pool != 'token'
+        assert pos_embed in ('', 'none', 'learn')
+        norm_layer = get_norm_layer(norm_layer) or partial(nn.LayerNorm, eps=1e-6)
+        embed_norm_layer = get_norm_layer(embed_norm_layer)
+        act_layer = get_act_layer(act_layer) or nn.GELU
+
+        self.num_classes = num_classes
+        self.global_pool = global_pool
+        self.num_features = self.head_hidden_size = self.embed_dim = embed_dim  # for consistency with other models
+        self.num_prefix_tokens = 1 if class_token else 0
+        self.num_prefix_tokens += reg_tokens
+        self.num_reg_tokens = reg_tokens
+        self.has_class_token = class_token
+        self.grad_checkpointing = False
+
+        # Initialize embedding module (includes patch, position embedding, and class/reg tokens)
+        # VisionTransformerEmbeds is always used - handles both linear and conv embedding
+        self.embeds = FlexEmbeds(
+            patch_size=patch_size,
+            in_chans=in_chans,
+            embed_dim=embed_dim,
+            embed_layer=embed_layer_type,
+            proj_norm_layer=embed_norm_layer,
+            final_norm_layer=norm_layer if pre_norm else None,
+            pos_embed=pos_embed,
+            pos_embed_grid_size=pos_embed_grid_size,
+            pos_embed_interp_mode=pos_embed_interp_mode,
+            pos_drop_rate=pos_drop_rate,
+            patch_drop_rate=patch_drop_rate,
+            class_token=class_token,
+            reg_tokens=reg_tokens,
+            default_img_size=default_img_size,
+            dynamic_img_pad=dynamic_img_pad,
+            bias=not pre_norm,  # disable bias if pre-norm is used (e.g. CLIP)
+        )
+
+        # Transformer blocks
+        dpr = [x.item() for x in torch.linspace(0, drop_path_rate, depth)]  # stochastic depth decay rule
+        self.blocks = nn.Sequential(*[
+            block_fn(
+                dim=embed_dim,
+                num_heads=num_heads,
+                mlp_ratio=mlp_ratio,
+                qkv_bias=qkv_bias,
+                qk_norm=qk_norm,
+                proj_bias=proj_bias,
+                init_values=init_values,
+                proj_drop=proj_drop_rate,
+                attn_drop=attn_drop_rate,
+                drop_path=dpr[i],
+                norm_layer=norm_layer,
+                act_layer=act_layer,
+                mlp_layer=mlp_layer,
+            )
+            for i in range(depth)])
+
+        # Feature info for downstream tasks
+        patch_reduction = to_2tuple(patch_size)
+        self.feature_info = [
+            dict(module=f'blocks.{i}', num_chs=embed_dim, reduction=patch_reduction) for i in range(depth)]
+
+        self.norm = norm_layer(embed_dim) if final_norm and not fc_norm else nn.Identity()
+
+        # Classifier Head
+        if global_pool == 'map':
+            self.attn_pool = AttentionPoolLatent(
+                self.embed_dim,
+                num_heads=num_heads,
+                mlp_ratio=mlp_ratio,
+                norm_layer=norm_layer,
+                act_layer=act_layer,
+            )
+        else:
+            self.attn_pool = None
+
+        self.fc_norm = norm_layer(embed_dim) if final_norm and fc_norm else nn.Identity()
+        self.head_drop = nn.Dropout(drop_rate)
+        self.head = nn.Linear(self.embed_dim, num_classes) if num_classes > 0 else nn.Identity()
+
+        if weight_init != 'skip':
+            self.init_weights(weight_init)
+        if fix_init:
+            self.fix_init_weight()
+
+    def fix_init_weight(self):
+        def rescale(param, _layer_id):
+            param.div_(math.sqrt(2.0 * _layer_id))
+
+        for layer_id, layer in enumerate(self.blocks):
+            rescale(layer.attn.proj.weight.data, layer_id + 1)
+            rescale(layer.mlp.fc2.weight.data, layer_id + 1)
+
+    def init_weights(self, mode: str = '') -> None:
+        assert mode in ('jax', 'jax_nlhb', 'moco', '')
+        head_bias = -math.log(self.num_classes) if 'nlhb' in mode else 0.
+        named_apply(get_init_weights_vit(mode, head_bias), self)
+
+    @torch.jit.ignore()
+    def load_pretrained(self, checkpoint_path: str, prefix: str = '') -> None:
+        # Custom loading for the new model structure
+        from .vision_transformer import _load_weights as _orig_load_weights
+
+        def _load_weights_adapter(model, checkpoint_path, prefix=''):
+            """Adapter function to handle the different model structure"""
+            state_dict = torch.load(checkpoint_path, map_location='cpu')
+            if isinstance(state_dict, dict) and 'state_dict' in state_dict:
+                state_dict = state_dict['state_dict']
+
+            # Map original keys to new structure
+            for k in list(state_dict.keys()):
+                if k.startswith('cls_token'):
+                    state_dict['embeds.' + k] = state_dict.pop(k)
+                elif k.startswith('reg_token'):
+                    state_dict['embeds.' + k] = state_dict.pop(k)
+                elif k.startswith('pos_embed'):
+                    state_dict['embeds.' + k] = state_dict.pop(k)
+                elif k.startswith('patch_embed'):
+                    state_dict['embeds.' + k[12:]] = state_dict.pop(k)
+
+            return _orig_load_weights(model, state_dict, prefix)
+
+        _load_weights_adapter(self, checkpoint_path, prefix)
+
+    @torch.jit.ignore
+    def no_weight_decay(self) -> Set:
+        skip_list = {'embeds.pos_embed', 'embeds.cls_token', 'embeds.reg_token'}
+        return skip_list
+
+    @torch.jit.ignore
+    def group_matcher(self, coarse: bool = False) -> Dict:
+        return dict(
+            stem=r'^embeds',  # stem and embed
+            blocks=[(r'^blocks\.(\d+)', None), (r'^norm', (99999,))]
+        )
+
+    @torch.jit.ignore
+    def set_grad_checkpointing(self, enable: bool = True) -> None:
+        self.grad_checkpointing = enable
+        if hasattr(self.embeds, 'patch_embed') and hasattr(self.embeds.patch_embed, 'set_grad_checkpointing'):
+            self.embeds.patch_embed.set_grad_checkpointing(enable)
+
+    @torch.jit.ignore
+    def get_classifier(self) -> nn.Module:
+        return self.head
+
+    def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None):
+        self.num_classes = num_classes
+        if global_pool is not None:
+            assert global_pool in ('', 'avg', 'avgmax', 'max', 'token', 'map')
+            if global_pool == 'map' and self.attn_pool is None:
+                assert False, "Cannot currently add attention pooling in reset_classifier()."
+            elif global_pool != 'map' and self.attn_pool is not None:
+                self.attn_pool = None  # remove attention pooling
+            self.global_pool = global_pool
+        self.head = nn.Linear(self.embed_dim, num_classes) if num_classes > 0 else nn.Identity()
+
+    def forward_intermediates(
+            self,
+            x: torch.Tensor,
+            indices: Optional[Union[int, List[int]]] = None,
+            return_prefix_tokens: bool = False,
+            norm: bool = False,
+            stop_early: bool = False,
+            output_fmt: str = 'NCHW',
+            intermediates_only: bool = False,
+            output_dict: bool = False,
+            patch_coord: Optional[torch.Tensor] = None,
+            patch_valid: Optional[torch.Tensor] = None,
+            mask: Optional[torch.Tensor] = None,
+    ) -> Union[List[torch.Tensor], Tuple[torch.Tensor, List[torch.Tensor]], Dict[str, Any]]:
+        """ Forward features that returns intermediates.
+
+        Args:
+            x: Input image tensor
+            indices: Take last n blocks if int, all if None, select matching indices if sequence
+            return_prefix_tokens: Return both prefix and spatial intermediate tokens
+            norm: Apply norm layer to all intermediates
+            stop_early: Stop iterating over blocks when last desired intermediate hit
+            output_fmt: Shape of intermediate feature outputs
+            intermediates_only: Only return intermediate features
+            output_dict: Return outputs as a dictionary with 'image_features' and 'image_intermediates' keys
+            patch_coord: Optional patch coordinates [B, N, 2] for NaFlex mode
+            patch_valid: Optional patch type indicators (1=patch, 0=padding) for NaFlex
+            mask: Optional attention mask
+        Returns:
+            A tuple with (final_features, intermediates), a list of intermediate features, or a dictionary containing
+            'image_features' and 'image_intermediates' (and optionally 'image_intermediates_prefix')
+        """
+
+        # FIXME unfinished / untested
+
+        assert output_fmt in ('NCHW', 'NLC'), 'Output format must be one of NCHW or NLC.'
+        reshape = output_fmt == 'NCHW'
+        intermediates = []
+        take_indices, max_index = feature_take_indices(len(self.blocks), indices)
+
+        # Create attention mask if patch_type is provided and mask is not
+        if mask is None and patch_valid is not None:
+            mask = create_attention_mask(patch_valid, self.num_prefix_tokens, x.dtype)
+
+        # Forward pass through embedding
+        x = self.embeds(x, patch_coord=patch_coord, patch_valid=patch_valid)
+
+        # Forward pass through blocks
+        if torch.jit.is_scripting() or not stop_early:  # can't slice blocks in torchscript
+            blocks = self.blocks
+        else:
+            blocks = self.blocks[:max_index + 1]
+            
+        for i, blk in enumerate(blocks):
+            x = blk(x, attn_mask=mask)
+            if i in take_indices:
+                # normalize intermediates with final norm layer if enabled
+                intermediates.append(self.norm(x) if norm else x)
+
+        # Process intermediates
+        if self.num_prefix_tokens:
+            # split prefix (e.g. class, distill) and spatial feature tokens
+            prefix_tokens = [y[:, 0:self.num_prefix_tokens] for y in intermediates]
+            intermediates = [y[:, self.num_prefix_tokens:] for y in intermediates]
+        else:
+            prefix_tokens = None
+
+        if reshape:
+            # reshape to BCHW output format
+            grid_size = self.embeds.pos_embed_grid_size
+            if hasattr(self.embeds, 'dynamic_feat_size') and len(x.shape) >= 4:
+                _, height, width, _ = x.shape if len(x.shape) == 4 else (None, *x.shape[-3:-1], None)
+                H, W = self.embeds.dynamic_feat_size((height, width))
+            else:
+                H, W = grid_size
+            intermediates = [y.reshape(y.shape[0], H, W, -1).permute(0, 3, 1, 2).contiguous() 
+                           for y in intermediates]
+
+        # For dictionary output
+        if output_dict:
+            result_dict = {}
+            # Intermediates are always included
+            result_dict['image_intermediates'] = intermediates
+            if prefix_tokens is not None and return_prefix_tokens:
+                result_dict['image_intermediates_prefix'] = prefix_tokens
+                
+            # Only include features if not intermediates_only
+            if not intermediates_only:
+                x_final = self.norm(x)
+                result_dict['image_features'] = x_final
+                
+            return result_dict
+            
+        # For non-dictionary output, maintain the original behavior
+        if not torch.jit.is_scripting() and return_prefix_tokens and prefix_tokens is not None:
+            # return_prefix not support in torchscript due to poor type handling
+            intermediates = list(zip(intermediates, prefix_tokens))
+
+        if intermediates_only:
+            return intermediates
+
+        x = self.norm(x)
+
+        return x, intermediates
+
+    def forward_features(
+            self,
+            x: torch.Tensor,
+            patch_coord: Optional[torch.Tensor] = None,
+            patch_valid: Optional[torch.Tensor] = None,
+            attn_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        # Pass through embedding module with patch coordinate/type support
+        x = self.embeds(x, patch_coord=patch_coord, patch_valid=patch_valid)
+        
+        # Apply transformer blocks with masked attention if mask provided
+        if attn_mask is not None:
+            # We need to apply blocks one by one with mask
+            for blk in self.blocks:
+                x = blk(x, attn_mask=attn_mask)
+        elif self.grad_checkpointing and not torch.jit.is_scripting():
+            x = checkpoint_seq(self.blocks, x)
+        else:
+            x = self.blocks(x)
+            
+        x = self.norm(x)
+        return x
+
+    def _pool(
+            self,
+            x: torch.Tensor,
+            pool_type: Optional[str] = None,
+            patch_valid: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if self.attn_pool is not None:
+            # For attention pooling, we need to pass the mask for NaFlex models
+            attn_mask = create_pool_mask(patch_valid, dtype=x.dtype)
+            x = self.attn_pool(x[:, self.num_prefix_tokens:], attn_mask=attn_mask)
+            return x
+        
+        pool_type = self.global_pool if pool_type is None else pool_type
+        
+        # Handle padding mask for average pooling
+        if patch_valid is not None and pool_type in ('avg', 'avgmax'):
+            # For NaFlex mode, we need to apply masked pooling to exclude padding tokens
+            # Extract only the patch part of the mask (excluding prefix tokens)
+            if self.num_prefix_tokens > 0:
+                # Apply the mask to extract only valid tokens
+                x = x[:, self.num_prefix_tokens:]  # prefix tokens not included in pooling
+
+            if pool_type == 'avg':
+                # Compute masked average pooling
+                # Sum valid tokens and divide by count of valid tokens
+                masked_sums = (x * patch_valid.unsqueeze(-1).float()).sum(dim=1)
+                valid_counts = patch_valid.float().sum(dim=1, keepdim=True).clamp(min=1)
+                pooled = masked_sums / valid_counts
+                return pooled
+            elif pool_type == 'avgmax':
+                # For avgmax, compute masked average and masked max
+                # For max, we set masked positions to large negative value
+                masked_sums = (x * patch_valid.unsqueeze(-1).float()).sum(dim=1)
+                valid_counts = patch_valid.float().sum(dim=1, keepdim=True).clamp(min=1)
+                masked_avg = masked_sums / valid_counts
+
+                # For max pooling with mask
+                masked_x = x.clone()
+                masked_x[~patch_valid] = torch.finfo(masked_x.dtype).min
+                masked_max = masked_x.max(dim=1)[0]
+
+                # Combine average and max
+                return 0.5 * (masked_avg + masked_max)
+
+        # Fall back to standard pooling
+        x = global_pool_nlc(x, pool_type=pool_type, num_prefix_tokens=self.num_prefix_tokens)
+        return x
+
+    def forward_head(
+            self,
+            x: torch.Tensor,
+            pre_logits: bool = False,
+            patch_valid: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        x = self._pool(x, patch_valid=patch_valid)
+        x = self.fc_norm(x)
+        x = self.head_drop(x)
+        return x if pre_logits else self.head(x)
+
+    def forward(
+            self,
+            x: Union[torch.Tensor, Dict[str, torch.Tensor]],
+            patch_coord: Optional[torch.Tensor] = None,
+            patch_valid: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Forward pass with optional NaFlex support.
+        
+        Args:
+            x: Input tensor [B, C, H, W] or pre-patchified tensor [B, N, P*P*C] or NaFlex dict
+            patch_coord: Optional patch coordinates [B, N, 2] for NaFlex mode
+            patch_valid: Optional patch type indicators (1=patch, 0=padding) for NaFlex
+            
+        Returns:
+            Model output tensor
+        """
+        # Handle dictionary input from NaFlex collator
+        if isinstance(x, dict):
+            assert patch_coord is None
+            assert patch_valid is None
+            # Extract the required components from the dictionary
+            patch_coord = x['patch_coord']
+            patch_valid = x['patch_valid']
+            patches = x['patches']
+
+            if False:
+                # DEBUG, reconstruct patches
+                for i in range(len(patches)):
+                    patch = patches[i][patch_valid[i]]
+                    h = (patch_coord[i, :, 0].max() + 1).item()
+                    w = (patch_coord[i, :, 1].max() + 1).item()
+                    patch = patch.reshape(h, w, 16, 16, 3).permute(4, 0, 2, 1, 3)
+                    patch = patch.reshape(3, h*16, w*16)
+                    from torchvision.utils import save_image
+                    save_image(patch, f'patch_{i}.jpg', normalize=True)
+        else:
+            patches = x
+
+        # Create attention mask if patch_type is provided
+        if patch_valid is not None:
+            attn_mask = create_attention_mask(
+                patch_valid,
+                num_prefix_tokens=self.num_prefix_tokens,
+                dtype=patches.dtype
+            )
+        else:
+            attn_mask = None
+
+        # Forward features with mask
+        x = self.forward_features(
+            patches,
+            patch_coord=patch_coord,
+            patch_valid=patch_valid,
+            attn_mask=attn_mask,
+        )
+
+        # Pass mask to forward_head for masked pooling
+        x = self.forward_head(
+            x,
+            patch_valid=patch_valid,
+        )
+        return x
+
+
+def get_init_weights_vit(mode: str = 'jax', head_bias: float = 0.0) -> Callable:
+    """Function imported from vision_transformer.py to maintain compatibility"""
+    from .vision_transformer import init_weights_vit_jax, init_weights_vit_moco, init_weights_vit_timm
+    
+    if 'jax' in mode:
+        return partial(init_weights_vit_jax, head_bias=head_bias)
+    elif 'moco' in mode:
+        return init_weights_vit_moco
+    else:
+        return init_weights_vit_timm
+
+
+def _cfg(url: str = '', **kwargs) -> Dict[str, Any]:
+    return {
+        'url': url,
+        'num_classes': 1000,
+        'input_size': (3, 256, 256),
+        'pool_size': None,
+        'crop_pct': 0.95,
+        'interpolation': 'bicubic',
+        'mean': IMAGENET_INCEPTION_MEAN,
+        'std': IMAGENET_INCEPTION_STD,
+        'first_conv': 'embeds.proj',
+        'classifier': 'head',
+        'license': 'apache-2.0',
+        **kwargs,
+    }
+
+
+default_cfgs = generate_default_cfgs({
+    'vit_naflex_base_patch16': _cfg(),
+    'vit_naflex_base_patch16_gap': _cfg(),
+    'vit_naflex_base_patch16_map': _cfg(),
+})
+
+
+def _create_vision_transformer_flex(variant, pretrained=False, **kwargs):
+    model = build_model_with_cfg(
+        VisionTransformerFlex, variant, pretrained,
+        pretrained_filter_fn=checkpoint_filter_fn,
+        **kwargs,
+    )
+    return model
+
+
+@register_model
+def vit_naflex_base_patch16(pretrained=False, **kwargs):
+    """ViT-New with NaFlex functionality for variable aspect ratios and resolutions.
+    
+    This model supports:
+    1. Variable aspect ratios and resolutions via patch coordinates
+    2. Position embedding interpolation for arbitrary grid sizes
+    3. Explicit patch coordinates and valid token masking
+    """
+    model_args = dict(
+        patch_size=16, embed_dim=768, depth=12, num_heads=12, **kwargs)
+    model = _create_vision_transformer_flex(
+        'vit_naflex_base_patch16', pretrained=pretrained, **model_args)
+    return model
+
+
+@register_model
+def vit_naflex_base_patch16_gap(pretrained=False, **kwargs):
+    """ViT-New with NaFlex functionality for variable aspect ratios and resolutions.
+    """
+    model_args = dict(
+        patch_size=16, embed_dim=768, depth=12, num_heads=12,
+        global_pool='avg', class_token=False, reg_tokens=4, **kwargs)
+    model = _create_vision_transformer_flex(
+        'vit_naflex_base_patch16_gap', pretrained=pretrained, **model_args)
+    return model
+
+
+@register_model
+def vit_naflex_base_patch16_map(pretrained=False, **kwargs):
+    """ViT-New with NaFlex functionality for variable aspect ratios and resolutions.
+    """
+    model_args = dict(
+        patch_size=16, embed_dim=768, depth=12, num_heads=12, global_pool='map', **kwargs)
+    model = _create_vision_transformer_flex(
+        'vit_naflex_base_patch16_map', pretrained=pretrained, **model_args)
+    return model
+
+
+def checkpoint_filter_fn(state_dict, model):
+    """Handle state dict conversion from original ViT to the new version with combined embedding."""
+    from .vision_transformer import checkpoint_filter_fn as orig_filter_fn
+
+    # FIXME conversion of existing vit checkpoints has not been finished or tested
+
+    # Handle CombinedEmbed module pattern
+    out_dict = {}
+    for k, v in state_dict.items():
+        # Convert tokens and embeddings to combined_embed structure
+        if k == 'pos_embed':
+            # Handle position embedding format conversion - from (1, N, C) to (1, H, W, C)
+            if hasattr(model.embeds, 'pos_embed') and v.ndim == 3:
+                # Original format is (1, N, C) - need to reshape to (1, H, W, C)
+                num_patches = v.shape[1]
+                grid_size = int(math.sqrt(num_patches))
+                
+                # Check if it's a perfect square for a standard grid
+                if grid_size * grid_size == num_patches:
+                    # Reshape from (1, N, C) to (1, H, W, C)
+                    v = v.reshape(1, grid_size, grid_size, v.shape[2])
+                else:
+                    # Not a square grid, we need to get the actual dimensions
+                    if hasattr(model.embeds.patch_embed, 'grid_size'):
+                        h, w = model.embeds.patch_embed.grid_size
+                        if h * w == num_patches:
+                            # We have the right dimensions
+                            v = v.reshape(1, h, w, v.shape[2])
+                        else:
+                            # Dimensions don't match, use interpolation
+                            _logger.warning(
+                                f"Position embedding size mismatch: checkpoint={num_patches}, model={(h * w)}. "
+                                f"Using default initialization and will resize in forward pass."
+                            )
+                            # Keep v as is, the forward pass will handle resizing
+            
+            out_dict['embeds.pos_embed'] = v
+            
+        elif k == 'cls_token':
+            out_dict['embeds.cls_token'] = v
+        elif k == 'reg_token':
+            out_dict['embeds.reg_token'] = v
+        # Convert patch_embed.X to embeds.patch_embed.X
+        elif k.startswith('patch_embed.'):
+            new_key = 'embeds.' + k[12:]
+            out_dict[new_key] = v
+        else:
+            out_dict[k] = v
+            
+    # Call the original filter function to handle other patterns
+    return orig_filter_fn(out_dict, model)

--- a/timm/models/vision_transformer_flex.py
+++ b/timm/models/vision_transformer_flex.py
@@ -362,7 +362,7 @@ def create_attention_mask(
     symmetric: bool = True,
     q_len: Optional[int] = None,
     dtype: torch.dtype = torch.float32,
-) -> torch.Tensor:
+) -> Optional[torch.Tensor]:
     """Creates an attention mask from patch validity information.
 
     Supports two modes controlled by `symmetric`:
@@ -392,6 +392,9 @@ def create_attention_mask(
         Shape is [B, 1, seq_len, seq_len] if symmetric=True,
         or [B, 1, q_len, kv_len] if symmetric=False.
     """
+    if patch_valid is None:
+        return None
+
     patch_valid = patch_valid.bool() # Ensure boolean type
     B, N = patch_valid.shape
     kv_len = N # Initial key/value length is the number of patches

--- a/timm/models/vision_transformer_flex.py
+++ b/timm/models/vision_transformer_flex.py
@@ -356,10 +356,9 @@ def create_attention_mask(
     """
     patch_valid = patch_valid.bool()
     B = patch_valid.shape[0]
-    device = patch_valid.device
 
     if num_prefix_tokens > 0:
-        prefix_valid = torch.ones((B, num_prefix_tokens), device=device, dtype=torch.bool)
+        prefix_valid = patch_valid.new_ones((B, num_prefix_tokens))
         patch_valid = torch.cat([prefix_valid, patch_valid], dim=1)
 
     mask_bool = (patch_valid.unsqueeze(-1) & patch_valid.unsqueeze(1)).unsqueeze(1)
@@ -390,10 +389,9 @@ def create_attention_mask2(
     """
     patch_valid = patch_valid.bool()
     B, kv_len = patch_valid.shape
-    device = patch_valid.device
 
     if num_prefix_tokens > 0:
-        prefix_valid = torch.ones((B, num_prefix_tokens), device=device, dtype=torch.bool)
+        prefix_valid = patch_valid.new_ones((B, num_prefix_tokens))
         patch_valid = torch.cat([prefix_valid, patch_valid], dim=1)
         kv_len = patch_valid.shape[1]
 

--- a/train.py
+++ b/train.py
@@ -1142,7 +1142,10 @@ def train_one_epoch(
 
             if args.distributed:
                 # scale gradient btw distributed ranks, each one can have different batch size
-                global_batch_size = utils.reduce_tensor(torch.tensor(batch_size, device=device), 1) # SUM
+                global_batch_size = utils.reduce_tensor(
+                    torch.tensor(batch_size, device=device, dtype=torch.float32),
+                    1 # SUM
+                )
                 dist_scale = args.world_size * batch_size / global_batch_size
             else:
                 dist_scale = None


### PR DESCRIPTION
Working:
* 'flex' ViT w/ NaFlex position embedding resize, pre-patched input, attention padding masks
* Single node train.py works with a custom naflex data-pipeline via a dataset wrapper that handles random seq-len & batch-size selection, constrains images to seq-len while keeping aspect ratio (with randomizations)
* A much faster patch embed kernel resample, torch only, can be used in forward()
* A 4-GPU distributed training run completed with decent results
* NaFlex patch mode compatible mixup & cutmix and random erasing implementation
* Add randomization of the patch_size along with seq_len 
* SigLip-2 NaFlex vision encoder weight port (tested with un-pushed OpenCLIP mods), matches expected results
* weight loading / translation for existing vits (all but 2 existing vision_transformer.py vits load with `use_naflex=True` flag in create_model())

Not tested / not completed:
* bigger distributed runs needed
* dataset wrapper for iterable datasets (wds, tfds, iterable hfds) needs to be added
* more model definitions
* Integration of naflex data pipeline components into OpenCLIP
