### PR TITLE
Add-lightly-train-to-training-frameworks-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ One of the greatest assets of PyTorch is the community and their contributions. 
 
 ### Training / Frameworks
 * fastai - https://github.com/fastai/fastai
+* lightly_train - https://github.com/lightly-ai/lightly-train
 
 ## Licenses
 


### PR DESCRIPTION
Add `lightly_train` GitHub Repo Link to the "Awesome PyTorch Resources - Training / Frameworks" section in TIMM README.