### PR TITLE
Add LightlyTrain Integration for Pretraining Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   * `vit_so150m2_patch16_reg1_gap_256.sbb_e200_in12k_ft_in1k` - 87.3% top-1
   * `vit_so150m2_patch16_reg4_gap_256.sbb_e200_in12k`
 * Updated InternViT-300M '2.5' weights
+* Release 1.0.15
 
 ## Feb 1, 2025
 * FYI PyTorch 2.6 & Python 3.13 are tested and working w/ current main and released version of `timm`
@@ -452,6 +453,8 @@ All model architecture families include variants with pretrained weights. There 
 * SelecSLS - https://arxiv.org/abs/1907.00837
 * Selective Kernel Networks - https://arxiv.org/abs/1903.06586
 * Sequencer2D - https://arxiv.org/abs/2205.01972
+* SigLIP (image encoder) - https://arxiv.org/abs/2303.15343
+* SigLIP 2 (image encoder) - https://arxiv.org/abs/2502.14786
 * Swin S3 (AutoFormerV2) - https://arxiv.org/abs/2111.14725
 * Swin Transformer - https://arxiv.org/abs/2103.14030
 * Swin Transformer V2 - https://arxiv.org/abs/2111.09883


### PR DESCRIPTION
[LightlyTrain](https://github.com/lightly-ai/lightly-train) is a novel pretraining framework built with PyTorch. It lets you pretrain any computer vision model on your unlabeled data, by leveraging distillation from powerful vision models and using self-supervised learning. With only a few lines of code, the community can pretrain domain-specific backbones for any downstream task with a TIMM backbone and beyond.

LightlyTrain supports all TIMM models out-of-the-box. You can start pretraining simply by:

```python
import lightly_train

if __name__ == "__main__":
    lightly_train.train(
        out="out/my_experiment",                # Output directory.
        data="my_data_dir",                     # Directory with images.
        model="timm/resnet18",                  # Pass the timm model.
    )
```

and reload the exported model by TIMM directly for your own use

```python
import timm

model = timm.create_model(
  model_name="resnet18",
  checkpoint_path="out/my_experiment/exported_models/exported_last.pt",
)
```

You can also check our [docs](https://docs.lightly.ai/train/stable/index.html) and [product page](https://www.lightly.ai/lightlytrain) for more details.

## Changes

This PR contains the link to our GitHub Repo in the "Awesome PyTorch Resources - Training / Frameworks" section.