### PR TITLE
Add SwiftFormer, SHViT, StarNet, FasterNet and GhostNetV3

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -53,13 +53,14 @@ FEAT_INTER_FILTERS = [
     'vision_transformer', 'vision_transformer_sam', 'vision_transformer_hybrid', 'vision_transformer_relpos',
     'beit', 'mvitv2', 'eva', 'cait', 'xcit', 'volo', 'twins', 'deit', 'swin_transformer', 'swin_transformer_v2',
     'swin_transformer_v2_cr', 'maxxvit', 'efficientnet', 'mobilenetv3', 'levit', 'efficientformer', 'resnet',
-    'regnet', 'byobnet', 'byoanet', 'mlp_mixer', 'hiera', 'fastvit', 'hieradet_sam2', 'aimv2*'
+    'regnet', 'byobnet', 'byoanet', 'mlp_mixer', 'hiera', 'fastvit', 'hieradet_sam2', 'aimv2*', 'swiftformer',
+    'starnet', 'shvit',
 ]
 
 # transformer / hybrid models don't support full set of spatial / feature APIs and/or have spatial output.
 NON_STD_FILTERS = [
     'vit_*', 'tnt_*', 'pit_*', 'coat_*', 'cait_*', '*mixer_*', 'gmlp_*', 'resmlp_*', 'twins_*',
-    'convit_*', 'levit*', 'visformer*', 'deit*', 'xcit_*', 'crossvit_*', 'beit*', 'aimv2*',
+    'convit_*', 'levit*', 'visformer*', 'deit*', 'xcit_*', 'crossvit_*', 'beit*', 'aimv2*', 'swiftformer_*',
     'poolformer_*', 'volo_*', 'sequencer2d_*', 'mvitv2*', 'gcvit*', 'efficientformer*', 'sam_hiera*',
     'eva_*', 'flexivit*', 'eva02*', 'samvit_*', 'efficientvit_m*', 'tiny_vit_*', 'hiera_*', 'vitamin*', 'test_vit*',
 ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,7 +56,7 @@ FEAT_INTER_FILTERS = [
     'regnet', 'byobnet', 'byoanet', 'mlp_mixer', 'hiera', 'fastvit', 'hieradet_sam2', 'aimv2*',
     'tiny_vit', 'vovnet', 'tresnet', 'rexnet', 'resnetv2', 'repghost', 'repvit', 'pvt_v2', 'nextvit', 'nest',
     'mambaout', 'inception_next', 'inception_v4', 'hgnet', 'gcvit', 'focalnet', 'efficientformer_v2', 'edgenext',
-    'davit', 'rdnet', 'convnext', 'pit', 'starnet', 'shvit', 'fasternet', 'swiftformer',
+    'davit', 'rdnet', 'convnext', 'pit', 'starnet', 'shvit', 'fasternet', 'swiftformer', 'ghostnet',
 ]
 
 # transformer / hybrid models don't support full set of spatial / feature APIs and/or have spatial output.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -54,7 +54,7 @@ FEAT_INTER_FILTERS = [
     'beit', 'mvitv2', 'eva', 'cait', 'xcit', 'volo', 'twins', 'deit', 'swin_transformer', 'swin_transformer_v2',
     'swin_transformer_v2_cr', 'maxxvit', 'efficientnet', 'mobilenetv3', 'levit', 'efficientformer', 'resnet',
     'regnet', 'byobnet', 'byoanet', 'mlp_mixer', 'hiera', 'fastvit', 'hieradet_sam2', 'aimv2*', 'swiftformer',
-    'starnet', 'shvit',
+    'starnet', 'shvit', 'fasternet',
 ]
 
 # transformer / hybrid models don't support full set of spatial / feature APIs and/or have spatial output.
@@ -219,6 +219,7 @@ def test_model_backward(model_name, batch_size):
 EARLY_POOL_MODELS = (
     timm.models.EfficientVit,
     timm.models.EfficientVitLarge,
+    timm.models.FasterNet,
     timm.models.HighPerfGpuNet,
     timm.models.GhostNet,
     timm.models.MetaNeXt, # InceptionNeXt

--- a/timm/models/__init__.py
+++ b/timm/models/__init__.py
@@ -60,6 +60,7 @@ from .rexnet import *
 from .selecsls import *
 from .senet import *
 from .sequencer import *
+from .shvit import *
 from .sknet import *
 from .starnet import *
 from .swiftformer import *

--- a/timm/models/__init__.py
+++ b/timm/models/__init__.py
@@ -20,6 +20,7 @@ from .efficientnet import *
 from .efficientvit_mit import *
 from .efficientvit_msra import *
 from .eva import *
+from .fasternet import *
 from .fastvit import *
 from .focalnet import *
 from .gcvit import *

--- a/timm/models/__init__.py
+++ b/timm/models/__init__.py
@@ -61,6 +61,7 @@ from .selecsls import *
 from .senet import *
 from .sequencer import *
 from .sknet import *
+from .starnet import *
 from .swiftformer import *
 from .swin_transformer import *
 from .swin_transformer_v2 import *

--- a/timm/models/__init__.py
+++ b/timm/models/__init__.py
@@ -61,6 +61,7 @@ from .selecsls import *
 from .senet import *
 from .sequencer import *
 from .sknet import *
+from .swiftformer import *
 from .swin_transformer import *
 from .swin_transformer_v2 import *
 from .swin_transformer_v2_cr import *

--- a/timm/models/fasternet.py
+++ b/timm/models/fasternet.py
@@ -369,32 +369,31 @@ class FasterNet(nn.Module):
 
 
 def checkpoint_filter_fn(state_dict: Dict[str, torch.Tensor], model: nn.Module) -> Dict[str, torch.Tensor]:
-    if 'avgpool_pre_head' in state_dict:
-        return state_dict
-
-    out_dict = {
-        'conv_head.weight': state_dict.pop('avgpool_pre_head.1.weight'),
-        'classifier.weight': state_dict.pop('head.weight'),
-        'classifier.bias': state_dict.pop('head.bias')
-    }
-
-    stage_mapping = {
-        'stages.1.': 'stages.1.downsample.',
-        'stages.2.': 'stages.1.',
-        'stages.3.': 'stages.2.downsample.',
-        'stages.4.': 'stages.2.',
-        'stages.5.': 'stages.3.downsample.',
-        'stages.6.': 'stages.3.'
-    }
-
-    for k, v in state_dict.items():
-        for old_prefix, new_prefix in stage_mapping.items():
-            if k.startswith(old_prefix):
-                k = k.replace(old_prefix, new_prefix)
-                break
-        out_dict[k] = v
-
-    return out_dict
+    # if 'avgpool_pre_head' in state_dict:
+    #     return state_dict
+    #
+    # out_dict = {
+    #     'conv_head.weight': state_dict.pop('avgpool_pre_head.1.weight'),
+    #     'classifier.weight': state_dict.pop('head.weight'),
+    #     'classifier.bias': state_dict.pop('head.bias')
+    # }
+    #
+    # stage_mapping = {
+    #     'stages.1.': 'stages.1.downsample.',
+    #     'stages.2.': 'stages.1.',
+    #     'stages.3.': 'stages.2.downsample.',
+    #     'stages.4.': 'stages.2.',
+    #     'stages.5.': 'stages.3.downsample.',
+    #     'stages.6.': 'stages.3.'
+    # }
+    #
+    # for k, v in state_dict.items():
+    #     for old_prefix, new_prefix in stage_mapping.items():
+    #         if k.startswith(old_prefix):
+    #             k = k.replace(old_prefix, new_prefix)
+    #             break
+    #     out_dict[k] = v
+    return state_dict
 
 
 def _cfg(url: str = '', **kwargs: Any) -> Dict[str, Any]:
@@ -412,28 +411,28 @@ def _cfg(url: str = '', **kwargs: Any) -> Dict[str, Any]:
 
 default_cfgs = generate_default_cfgs({
     'fasternet_t0.in1k': _cfg(
-        # hf_hub_id='timm/',
-        url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_t0-epoch.281-val_acc1.71.9180.pth',
+        hf_hub_id='timm/',
+        #url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_t0-epoch.281-val_acc1.71.9180.pth',
     ),
     'fasternet_t1.in1k': _cfg(
-        # hf_hub_id='timm/',
-        url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_t1-epoch.291-val_acc1.76.2180.pth',
+        hf_hub_id='timm/',
+        #url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_t1-epoch.291-val_acc1.76.2180.pth',
     ),
     'fasternet_t2.in1k': _cfg(
-        # hf_hub_id='timm/',
-        url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_t2-epoch.289-val_acc1.78.8860.pth',
+        hf_hub_id='timm/',
+        #url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_t2-epoch.289-val_acc1.78.8860.pth',
     ),
     'fasternet_s.in1k': _cfg(
-        # hf_hub_id='timm/',
-        url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_s-epoch.299-val_acc1.81.2840.pth',
+        hf_hub_id='timm/',
+        #url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_s-epoch.299-val_acc1.81.2840.pth',
     ),
     'fasternet_m.in1k': _cfg(
-        # hf_hub_id='timm/',
-        url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_m-epoch.291-val_acc1.82.9620.pth',
+        hf_hub_id='timm/',
+        #url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_m-epoch.291-val_acc1.82.9620.pth',
     ),
     'fasternet_l.in1k': _cfg(
-        # hf_hub_id='timm/',
-        url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_l-epoch.299-val_acc1.83.5060.pth',
+        hf_hub_id='timm/',
+        #url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_l-epoch.299-val_acc1.83.5060.pth',
     ),
 })
 

--- a/timm/models/fasternet.py
+++ b/timm/models/fasternet.py
@@ -1,5 +1,22 @@
+"""FasterNet
+Run, Don't Walk: Chasing Higher FLOPS for Faster Neural Networks
+- paper: https://arxiv.org/abs/2303.03667
+- code: https://github.com/JierunChen/FasterNet
+
+@article{chen2023run,
+  title={Run, Don't Walk: Chasing Higher FLOPS for Faster Neural Networks},
+  author={Chen, Jierun and Kao, Shiu-hong and He, Hao and Zhuo, Weipeng and Wen, Song and Lee, Chul-Ho and Chan, S-H Gary},
+  journal={arXiv preprint arXiv:2303.03667},
+  year={2023}
+}
+
+Modifications by / Copyright 2025 Ryan Hou & Ross Wightman, original copyrights below
+"""
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 from functools import partial
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn

--- a/timm/models/fasternet.py
+++ b/timm/models/fasternet.py
@@ -1,0 +1,459 @@
+from functools import partial
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
+from timm.layers import SelectAdaptivePool2d, Linear, DropPath, trunc_normal_, LayerType
+from ._builder import build_model_with_cfg
+from ._features import feature_take_indices
+from ._manipulate import checkpoint_seq
+from ._registry import register_model, generate_default_cfgs
+
+__all__ = ['FasterNet']
+
+
+class Partial_conv3(nn.Module):
+    def __init__(self, dim: int, n_div: int, forward: str):
+        super().__init__()
+        self.dim_conv3 = dim // n_div
+        self.dim_untouched = dim - self.dim_conv3
+        self.partial_conv3 = nn.Conv2d(self.dim_conv3, self.dim_conv3, 3, 1, 1, bias=False)
+
+        if forward == 'slicing':
+            self.forward = self.forward_slicing
+        elif forward == 'split_cat':
+            self.forward = self.forward_split_cat
+        else:
+            raise NotImplementedError
+
+    def forward_slicing(self, x: torch.Tensor) -> torch.Tensor:
+        # only for inference
+        x = x.clone()   # !!! Keep the original input intact for the residual connection later
+        x[:, :self.dim_conv3, :, :] = self.partial_conv3(x[:, :self.dim_conv3, :, :])
+        return x
+
+    def forward_split_cat(self, x: torch.Tensor) -> torch.Tensor: 
+        # for training/inference
+        x1, x2 = torch.split(x, [self.dim_conv3, self.dim_untouched], dim=1)
+        x1 = self.partial_conv3(x1)
+        x = torch.cat((x1, x2), 1)
+        return x
+
+
+class MLPBlock(nn.Module):
+    def __init__(
+            self,
+            dim: int,
+            n_div: int,
+            mlp_ratio: float,
+            drop_path: float,
+            layer_scale_init_value: float,
+            act_layer: LayerType = partial(nn.ReLU, inplace=True),
+            norm_layer: LayerType = nn.BatchNorm2d,
+            pconv_fw_type: str = 'split_cat',
+    ):
+        super().__init__()
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        
+        self.mlp = nn.Sequential(*[
+            nn.Conv2d(dim, mlp_hidden_dim, 1, bias=False),
+            norm_layer(mlp_hidden_dim),
+            act_layer(),
+            nn.Conv2d(mlp_hidden_dim, dim, 1, bias=False),
+        ])
+
+        self.spatial_mixing = Partial_conv3(dim, n_div, pconv_fw_type)
+
+        if layer_scale_init_value > 0:
+            self.layer_scale = nn.Parameter(
+                layer_scale_init_value * torch.ones((dim)), requires_grad=True)
+        else:
+            self.layer_scale = None
+
+        self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        shortcut = x
+        x = self.spatial_mixing(x)
+        if self.layer_scale is not None:
+            x = shortcut + self.drop_path(
+                self.layer_scale.unsqueeze(-1).unsqueeze(-1) * self.mlp(x))
+        else:
+            x = shortcut + self.drop_path(self.mlp(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(
+            self,
+            dim: int,
+            depth: int,
+            n_div: int,
+            mlp_ratio: float,
+            drop_path: float,
+            layer_scale_init_value: float,
+            act_layer: LayerType = partial(nn.ReLU, inplace=True),
+            norm_layer: LayerType = nn.BatchNorm2d,
+            pconv_fw_type: str = 'split_cat',
+            use_merge: bool = True,
+            merge_size: Union[int, Tuple[int, int]] = 2,
+    ):
+        super().__init__()
+        self.blocks = nn.Sequential(*[
+            MLPBlock(
+                dim=dim,
+                n_div=n_div,
+                mlp_ratio=mlp_ratio,
+                drop_path=drop_path[i],
+                layer_scale_init_value=layer_scale_init_value,
+                norm_layer=norm_layer,
+                act_layer=act_layer,
+                pconv_fw_type=pconv_fw_type
+            )
+            for i in range(depth)
+        ])
+        self.down = PatchMerging(
+            dim=dim // 2,
+            patch_size=merge_size,
+            norm_layer=norm_layer,
+        ) if use_merge else nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.blocks(self.down(x))
+        return x
+
+
+class PatchEmbed(nn.Module):
+    def __init__(
+            self,
+            in_chans: int,
+            embed_dim: int, 
+            patch_size: Union[int, Tuple[int, int]] = 4,
+            norm_layer: LayerType = nn.BatchNorm2d,
+    ):
+        super().__init__()
+        self.proj = nn.Conv2d(in_chans, embed_dim, patch_size, patch_size, bias=False)
+        self.norm = norm_layer(embed_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.norm(self.proj(x))
+
+
+class PatchMerging(nn.Module):
+    def __init__(
+            self,
+            dim: int,
+            patch_size: Union[int, Tuple[int, int]] = 2,
+            norm_layer: LayerType = nn.BatchNorm2d,
+    ):
+        super().__init__()
+        self.reduction = nn.Conv2d(dim, 2 * dim, patch_size, patch_size, bias=False)
+        self.norm = norm_layer(2 * dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.norm(self.reduction(x))
+
+
+class FasterNet(nn.Module):
+    def __init__(
+            self,
+            in_chans: int = 3,
+            num_classes: int = 1000,
+            global_pool: str = 'avg',
+            embed_dim: int = 96,
+            depths: Union[int, Tuple[int, ...]] = (1, 2, 8, 2),
+            mlp_ratio: float = 2.,
+            n_div: int = 4,
+            patch_size: Union[int, Tuple[int, int]] = 4,
+            merge_size: Union[int, Tuple[int, int]] = 2,
+            patch_norm: bool = True,
+            feature_dim: int = 1280,
+            drop_rate: float = 0.,
+            drop_path_rate: float = 0.1,
+            layer_scale_init_value: float = 0.,
+            act_layer: LayerType = partial(nn.ReLU, inplace=True),
+            norm_layer: LayerType = nn.BatchNorm2d,
+            pconv_fw_type: str = 'split_cat',
+    ):
+        super().__init__()
+        assert pconv_fw_type in ('split_cat', 'slicing',)
+        self.num_classes = num_classes
+        self.drop_rate = drop_rate
+        if not isinstance(depths, (list, tuple)):
+            depths = (depths)  # it means the model has only one stage
+        self.num_stages = len(depths)
+        self.feature_info = []
+        self.grad_checkpointing = False
+
+        self.patch_embed = PatchEmbed(
+            in_chans=in_chans,
+            embed_dim=embed_dim,
+            patch_size=patch_size,
+            norm_layer=norm_layer if patch_norm else nn.Identity,
+        )
+        # stochastic depth decay rule
+        dpr = [x.item() for x in torch.linspace(0, drop_path_rate, sum(depths))]
+
+        # build layers
+        stages_list = []
+        for i in range(self.num_stages):
+            dim = int(embed_dim * 2 ** i)
+            stage = Block(
+                dim=dim,
+                depth=depths[i],
+                n_div=n_div,
+                mlp_ratio=mlp_ratio,
+                drop_path=dpr[sum(depths[:i]):sum(depths[:i + 1])],
+                layer_scale_init_value=layer_scale_init_value,
+                norm_layer=norm_layer,
+                act_layer=act_layer,
+                pconv_fw_type=pconv_fw_type,
+                use_merge=False if i == 0 else True,
+                merge_size=merge_size,
+            )
+            stages_list.append(stage)
+            self.feature_info += [dict(num_chs=dim, reduction=2**(i+2), module=f'stages.{i}')]
+        self.stages = nn.Sequential(*stages_list)
+
+        # building last several layers
+        self.num_features = prev_chs = int(embed_dim * 2 ** (self.num_stages - 1))
+        self.head_hidden_size = out_chs = feature_dim # 1280
+        self.global_pool = SelectAdaptivePool2d(pool_type=global_pool)
+        self.conv_head = nn.Conv2d(prev_chs, out_chs, 1, 1, 0, bias=False)
+        self.act = act_layer()
+        self.flatten = nn.Flatten(1) if global_pool else nn.Identity()  # don't flatten if pooling disabled
+        self.classifier = Linear(out_chs, num_classes, bias=True) if num_classes > 0 else nn.Identity()
+        self._initialize_weights()
+
+    def _initialize_weights(self):
+        for name, m in self.named_modules():
+            if isinstance(m, nn.Linear):
+                trunc_normal_(m.weight, std=.02)
+                if isinstance(m, nn.Linear) and m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.Conv2d):
+                trunc_normal_(m.weight, std=.02)
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+
+    @torch.jit.ignore
+    def group_matcher(self, coarse: bool = False) -> Dict[str, Any]:
+        matcher = dict(
+            stem=r'patch_embed',
+            blocks=[
+                (r'^stages\.(\d+)' if coarse else r'^stages\.(\d+)\.(\d+)', None),
+                (r'conv_head', (99999,))
+            ]
+        )
+        return matcher
+
+    @torch.jit.ignore
+    def set_grad_checkpointing(self, enable: bool = True):
+        self.grad_checkpointing = enable
+
+    @torch.jit.ignore
+    def get_classifier(self) -> nn.Module:
+        return self.classifier
+
+    def reset_classifier(self, num_classes: int, global_pool: str = 'avg'):
+        self.num_classes = num_classes
+        # cannot meaningfully change pooling of efficient head after creation
+        self.global_pool = SelectAdaptivePool2d(pool_type=global_pool)
+        self.flatten = nn.Flatten(1) if global_pool else nn.Identity()  # don't flatten if pooling disabled
+        self.classifier = Linear(self.head_hidden_size, num_classes) if num_classes > 0 else nn.Identity()
+
+    def forward_intermediates(
+            self,
+            x: torch.Tensor,
+            indices: Optional[Union[int, List[int]]] = None,
+            norm: bool = False,
+            stop_early: bool = False,
+            output_fmt: str = 'NCHW',
+            intermediates_only: bool = False,
+    ) -> Union[List[torch.Tensor], Tuple[torch.Tensor, List[torch.Tensor]]]:
+        """ Forward features that returns intermediates.
+
+        Args:
+            x: Input image tensor
+            indices: Take last n blocks if int, all if None, select matching indices if sequence
+            norm: Apply norm layer to compatible intermediates
+            stop_early: Stop iterating over blocks when last desired intermediate hit
+            output_fmt: Shape of intermediate feature outputs
+            intermediates_only: Only return intermediate features
+        Returns:
+
+        """
+        assert output_fmt in ('NCHW',), 'Output shape must be NCHW.'
+        intermediates = []
+        take_indices, max_index = feature_take_indices(len(self.stages), indices)
+
+        # forward pass
+        x = self.patch_embed(x)
+        if torch.jit.is_scripting() or not stop_early:  # can't slice blocks in torchscript
+            stages = self.stages
+        else:
+            stages = self.stages[:max_index + 1]
+
+        for feat_idx, stage in enumerate(stages):
+            x = stage(x)
+            if feat_idx in take_indices:
+                intermediates.append(x) 
+
+        if intermediates_only:
+            return intermediates
+
+        return x, intermediates
+
+    def prune_intermediate_layers(
+            self,
+            indices: Union[int, List[int]] = 1,
+            prune_norm: bool = False,
+            prune_head: bool = True,
+    ):
+        """ Prune layers not required for specified intermediates.
+        """
+        take_indices, max_index = feature_take_indices(len(self.stages), indices)
+        self.stages = self.stages[:max_index + 1]  # truncate blocks w/ stem as idx 0
+        if prune_head:
+            self.reset_classifier(0, '')
+        return take_indices
+
+    def forward_features(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.patch_embed(x)
+        if self.grad_checkpointing and not torch.jit.is_scripting():
+            x = checkpoint_seq(self.stages, x, flatten=True)
+        else:
+            x = self.stages(x)
+        return x
+
+    def forward_head(self, x: torch.Tensor, pre_logits: bool = False) -> torch.Tensor:
+        x = self.global_pool(x)
+        x = self.conv_head(x)
+        x = self.act(x)
+        x = self.flatten(x)
+        if self.drop_rate > 0.:
+            x = F.dropout(x, p=self.drop_rate, training=self.training)
+        return x if pre_logits else self.classifier(x)
+    
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.forward_features(x)
+        x = self.forward_head(x)
+        return x
+
+
+def checkpoint_filter_fn(state_dict: Dict[str, torch.Tensor], model: nn.Module) -> Dict[str, torch.Tensor]:
+    if 'avgpool_pre_head' in state_dict:
+        return state_dict
+
+    out_dict = {
+        'conv_head.weight': state_dict.pop('avgpool_pre_head.1.weight'),
+        'classifier.weight': state_dict.pop('head.weight'),
+        'classifier.bias': state_dict.pop('head.bias')
+    }
+
+    stage_mapping = {
+        'stages.1.': 'stages.1.down.',
+        'stages.2.': 'stages.1.',
+        'stages.3.': 'stages.2.down.',
+        'stages.4.': 'stages.2.',
+        'stages.5.': 'stages.3.down.',
+        'stages.6.': 'stages.3.'
+    }
+
+    for k, v in state_dict.items():
+        for old_prefix, new_prefix in stage_mapping.items():
+            if k.startswith(old_prefix):
+                k = k.replace(old_prefix, new_prefix)
+                break
+        out_dict[k] = v
+
+    return out_dict
+
+
+def _cfg(url: str = '', **kwargs: Any) -> Dict[str, Any]:
+    return {
+        'url': url, 'num_classes': 1000, 'input_size': (3, 224, 224), 'pool_size': (7, 7),
+        'crop_pct': 1.0, 'interpolation': 'bicubic', 'test_crop_pct': 0.9,
+        'mean': IMAGENET_DEFAULT_MEAN, 'std': IMAGENET_DEFAULT_STD,
+        'first_conv': 'patch_embed.proj', 'classifier': 'classifier',
+        'paper_ids': 'arXiv:2303.03667',
+        'paper_name': "Run, Don't Walk: Chasing Higher FLOPS for Faster Neural Networks",
+        'origin_url': 'https://github.com/JierunChen/FasterNet',
+        **kwargs
+    }
+
+
+default_cfgs = generate_default_cfgs({
+    'fasternet_t0.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_t0-epoch.281-val_acc1.71.9180.pth',
+    ),
+    'fasternet_t1.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_t1-epoch.291-val_acc1.76.2180.pth',
+    ),
+    'fasternet_t2.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_t2-epoch.289-val_acc1.78.8860.pth',
+    ),
+    'fasternet_s.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_s-epoch.299-val_acc1.81.2840.pth',
+    ),
+    'fasternet_m.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_m-epoch.291-val_acc1.82.9620.pth',
+    ),
+    'fasternet_l.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_l-epoch.299-val_acc1.83.5060.pth',
+    ),
+})
+
+
+def _create_fasternet(variant: str, pretrained: bool = False, **kwargs: Any) -> FasterNet:
+    model = build_model_with_cfg(
+        FasterNet, variant, pretrained,
+        pretrained_filter_fn=checkpoint_filter_fn,
+        feature_cfg=dict(out_indices=(0, 1, 2, 3), flatten_sequential=True),
+        **kwargs,
+    )
+    return model
+
+
+@register_model
+def fasternet_t0(pretrained: bool = False, **kwargs: Any) -> FasterNet:
+    model_args = dict(embed_dim=40, depths=(1, 2, 8, 2), drop_path_rate=0.0, act_layer=nn.GELU)
+    return _create_fasternet('fasternet_t0', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def fasternet_t1(pretrained: bool = False, **kwargs: Any) -> FasterNet:
+    model_args = dict(embed_dim=64, depths=(1, 2, 8, 2), drop_path_rate=0.02, act_layer=nn.GELU)
+    return _create_fasternet('fasternet_t1', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def fasternet_t2(pretrained: bool = False, **kwargs: Any) -> FasterNet:
+    model_args = dict(embed_dim=96, depths=(1, 2, 8, 2), drop_path_rate=0.05)
+    return _create_fasternet('fasternet_t2', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def fasternet_s(pretrained: bool = False, **kwargs: Any) -> FasterNet:
+    model_args = dict(embed_dim=128, depths=(1, 2, 13, 2), drop_path_rate=0.1)
+    return _create_fasternet('fasternet_s', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def fasternet_m(pretrained: bool = False, **kwargs: Any) -> FasterNet:
+    model_args = dict(embed_dim=144, depths=(3, 4, 18, 3), drop_path_rate=0.2)
+    return _create_fasternet('fasternet_m', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def fasternet_l(pretrained: bool = False, **kwargs: Any) -> FasterNet:
+    model_args = dict(embed_dim=192, depths=(3, 4, 18, 3), drop_path_rate=0.3)
+    return _create_fasternet('fasternet_l', pretrained=pretrained, **dict(model_args, **kwargs))

--- a/timm/models/fasternet.py
+++ b/timm/models/fasternet.py
@@ -102,6 +102,7 @@ class MLPBlock(nn.Module):
             x = shortcut + self.drop_path(self.mlp(x))
         return x
 
+
 class Block(nn.Module):
     def __init__(
             self,

--- a/timm/models/ghostnet.py
+++ b/timm/models/ghostnet.py
@@ -872,8 +872,8 @@ default_cfgs = generate_default_cfgs({
     ),
     'ghostnetv3_050.untrained': _cfg(),
     'ghostnetv3_100.in1k': _cfg(
-        # hf_hub_id='timm/',
-        url='https://github.com/huawei-noah/Efficient-AI-Backbones/releases/download/GhostNetV3/ghostnetv3-1.0.pth.tar'
+        hf_hub_id='timm/',
+        #url='https://github.com/huawei-noah/Efficient-AI-Backbones/releases/download/GhostNetV3/ghostnetv3-1.0.pth.tar'
     ),
     'ghostnetv3_130.untrained': _cfg(),
     'ghostnetv3_160.untrained': _cfg(),

--- a/timm/models/ghostnet.py
+++ b/timm/models/ghostnet.py
@@ -2,23 +2,27 @@
 An implementation of GhostNet & GhostNetV2 Models as defined in:
 GhostNet: More Features from Cheap Operations. https://arxiv.org/abs/1911.11907
 GhostNetV2: Enhance Cheap Operation with Long-Range Attention. https://proceedings.neurips.cc/paper_files/paper/2022/file/40b60852a4abdaa696b5a1a78da34635-Paper-Conference.pdf
+GhostNetV3: Exploring the Training Strategies for Compact Models. https://arxiv.org/abs/2404.11202
 
 The train script & code of models at:
 Original model: https://github.com/huawei-noah/CV-backbones/tree/master/ghostnet_pytorch
 Original model: https://github.com/huawei-noah/Efficient-AI-Backbones/blob/master/ghostnetv2_pytorch/model/ghostnetv2_torch.py
+Original model: https://github.com/huawei-noah/Efficient-AI-Backbones/blob/master/ghostnetv3_pytorch/ghostnetv3.py
 """
 import math
 from functools import partial
-from typing import Optional
+from typing import Any, Callable, Dict, List, Set, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
 from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
-from timm.layers import SelectAdaptivePool2d, Linear, make_divisible
+from timm.layers import SelectAdaptivePool2d, Linear, make_divisible, LayerType
+from timm.utils.model import reparameterize_model
 from ._builder import build_model_with_cfg
 from ._efficientnet_blocks import SqueezeExcite, ConvBnAct
+from ._features import feature_take_indices
 from ._manipulate import checkpoint_seq
 from ._registry import register_model, generate_default_cfgs
 
@@ -31,14 +35,13 @@ _SE_LAYER = partial(SqueezeExcite, gate_layer='hard_sigmoid', rd_round_fn=partia
 class GhostModule(nn.Module):
     def __init__(
             self,
-            in_chs,
-            out_chs,
-            kernel_size=1,
-            ratio=2,
-            dw_size=3,
-            stride=1,
-            use_act=True,
-            act_layer=nn.ReLU,
+            in_chs: int,
+            out_chs: int,
+            kernel_size: int = 1,
+            ratio: int = 2,
+            dw_size: int = 3,
+            stride: int = 1,
+            act_layer: LayerType = nn.ReLU,
     ):
         super(GhostModule, self).__init__()
         self.out_chs = out_chs
@@ -48,16 +51,16 @@ class GhostModule(nn.Module):
         self.primary_conv = nn.Sequential(
             nn.Conv2d(in_chs, init_chs, kernel_size, stride, kernel_size // 2, bias=False),
             nn.BatchNorm2d(init_chs),
-            act_layer(inplace=True) if use_act else nn.Identity(),
+            act_layer(inplace=True),
         )
 
         self.cheap_operation = nn.Sequential(
             nn.Conv2d(init_chs, new_chs, dw_size, 1, dw_size//2, groups=init_chs, bias=False),
             nn.BatchNorm2d(new_chs),
-            act_layer(inplace=True) if use_act else nn.Identity(),
+            act_layer(inplace=True),
         )
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x1 = self.primary_conv(x)
         x2 = self.cheap_operation(x1)
         out = torch.cat([x1, x2], dim=1)
@@ -67,14 +70,13 @@ class GhostModule(nn.Module):
 class GhostModuleV2(nn.Module):
     def __init__(
             self,
-            in_chs,
-            out_chs,
-            kernel_size=1,
-            ratio=2,
-            dw_size=3,
-            stride=1,
-            use_act=True,
-            act_layer=nn.ReLU,
+            in_chs: int,
+            out_chs: int,
+            kernel_size: int = 1,
+            ratio: int = 2,
+            dw_size: int = 3,
+            stride: int = 1,
+            act_layer: LayerType = nn.ReLU,
     ):
         super().__init__()
         self.gate_fn = nn.Sigmoid()
@@ -84,12 +86,12 @@ class GhostModuleV2(nn.Module):
         self.primary_conv = nn.Sequential(
             nn.Conv2d(in_chs, init_chs, kernel_size, stride, kernel_size // 2, bias=False),
             nn.BatchNorm2d(init_chs),
-            act_layer(inplace=True) if use_act else nn.Identity(),
+            act_layer(inplace=True),
         )
         self.cheap_operation = nn.Sequential(
             nn.Conv2d(init_chs, new_chs, dw_size, 1, dw_size // 2, groups=init_chs, bias=False),
             nn.BatchNorm2d(new_chs),
-            act_layer(inplace=True) if use_act else nn.Identity(),
+            act_layer(inplace=True),
         )
         self.short_conv = nn.Sequential(
             nn.Conv2d(in_chs, out_chs, kernel_size, stride, kernel_size // 2, bias=False),
@@ -100,7 +102,7 @@ class GhostModuleV2(nn.Module):
             nn.BatchNorm2d(out_chs),
         )
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         res = self.short_conv(F.avg_pool2d(x, kernel_size=2, stride=2))
         x1 = self.primary_conv(x)
         x2 = self.cheap_operation(x1)
@@ -109,19 +111,239 @@ class GhostModuleV2(nn.Module):
             self.gate_fn(res), size=(out.shape[-2], out.shape[-1]), mode='nearest')
 
 
+class GhostModuleV3(nn.Module):
+    def __init__(
+            self, 
+            in_chs: int,
+            out_chs: int,
+            kernel_size: int = 1,
+            ratio: int = 2,
+            dw_size: int = 3,
+            stride: int = 1,
+            act_layer: LayerType = nn.ReLU,
+            mode: str = 'original',
+    ):
+        super(GhostModuleV3, self).__init__()
+        self.gate_fn = nn.Sigmoid()
+        self.out_chs = out_chs
+        init_chs = math.ceil(out_chs / ratio)
+        new_chs = init_chs * (ratio - 1)
+        self.mode = mode
+        self.num_conv_branches = 3
+        self.infer_mode = False
+        if not self.infer_mode:
+            self.primary_conv = nn.Identity()
+            self.cheap_operation = nn.Identity()
+
+        self.primary_rpr_skip = None
+        self.primary_rpr_scale = None
+        self.primary_rpr_conv = nn.ModuleList(
+            [ConvBnAct(in_chs, init_chs, kernel_size, stride, pad_type=kernel_size // 2, \
+                    act_layer=None) for _ in range(self.num_conv_branches)]
+        )
+        # Re-parameterizable scale branch
+        self.primary_activation = act_layer(inplace=True)
+        self.cheap_rpr_skip = nn.BatchNorm2d(init_chs)
+        self.cheap_rpr_conv = nn.ModuleList(
+            [ConvBnAct(init_chs, new_chs, dw_size, 1, pad_type=dw_size // 2, group_size=1, \
+                    act_layer=None) for _ in range(self.num_conv_branches)]
+        )
+        # Re-parameterizable scale branch
+        self.cheap_rpr_scale = ConvBnAct(init_chs, new_chs, 1, 1, pad_type=0, group_size=1, act_layer=None)
+        self.cheap_activation = act_layer(inplace=True)
+
+        self.short_conv = nn.Sequential( 
+            nn.Conv2d(in_chs, out_chs, kernel_size, stride, kernel_size//2, bias=False),
+            nn.BatchNorm2d(out_chs),
+            nn.Conv2d(out_chs, out_chs, kernel_size=(1,5), stride=1, padding=(0,2), groups=out_chs, bias=False),
+            nn.BatchNorm2d(out_chs),
+            nn.Conv2d(out_chs, out_chs, kernel_size=(5,1), stride=1, padding=(2,0), groups=out_chs, bias=False),
+            nn.BatchNorm2d(out_chs),
+        ) if self.mode in ['shortcut'] else nn.Identity()
+
+        self.in_channels = init_chs
+        self.groups = init_chs
+        self.kernel_size = dw_size
+            
+    def forward(self, x):
+        if self.infer_mode:
+            x1 = self.primary_conv(x)
+            x2 = self.cheap_operation(x1)
+        else:
+            x1 = 0
+            for primary_rpr_conv in self.primary_rpr_conv:
+                x1 += primary_rpr_conv(x)
+            x1 = self.primary_activation(x1)
+
+            x2 = self.cheap_rpr_scale(x1) + self.cheap_rpr_skip(x1)
+            for cheap_rpr_conv in self.cheap_rpr_conv:
+                x2 += cheap_rpr_conv(x1)
+            x2 = self.cheap_activation(x2)
+        
+        out = torch.cat([x1,x2], dim=1)
+        if self.mode not in ['shortcut']:       
+            return out
+        else:
+            res = self.short_conv(F.avg_pool2d(x, kernel_size=2, stride=2))
+            return out[:,:self.out_chs,:,:] * F.interpolate(
+                self.gate_fn(res), size=(out.shape[-2], out.shape[-1]), mode='nearest')
+
+    def _get_kernel_bias_primary(self):
+        kernel_scale = 0
+        bias_scale = 0
+        if self.primary_rpr_scale is not None:
+            kernel_scale, bias_scale = self._fuse_bn_tensor(self.primary_rpr_scale)
+            pad = self.kernel_size // 2
+            kernel_scale = F.pad(kernel_scale, [pad, pad, pad, pad])
+
+        kernel_identity = 0
+        bias_identity = 0
+        if self.primary_rpr_skip is not None:
+            kernel_identity, bias_identity = self._fuse_bn_tensor(self.primary_rpr_skip)
+
+        kernel_conv = 0
+        bias_conv = 0
+        for ix in range(self.num_conv_branches):
+            _kernel, _bias = self._fuse_bn_tensor(self.primary_rpr_conv[ix])
+            kernel_conv += _kernel
+            bias_conv += _bias
+
+        kernel_final = kernel_conv + kernel_scale + kernel_identity
+        bias_final = bias_conv + bias_scale + bias_identity
+        return kernel_final, bias_final
+    
+    def _get_kernel_bias_cheap(self):
+        kernel_scale = 0
+        bias_scale = 0
+        if self.cheap_rpr_scale is not None:
+            kernel_scale, bias_scale = self._fuse_bn_tensor(self.cheap_rpr_scale)
+            pad = self.kernel_size // 2
+            kernel_scale = F.pad(kernel_scale, [pad, pad, pad, pad])
+
+        kernel_identity = 0
+        bias_identity = 0
+        if self.cheap_rpr_skip is not None:
+            kernel_identity, bias_identity = self._fuse_bn_tensor(self.cheap_rpr_skip)
+
+        kernel_conv = 0
+        bias_conv = 0
+        for ix in range(self.num_conv_branches):
+            _kernel, _bias = self._fuse_bn_tensor(self.cheap_rpr_conv[ix])
+            kernel_conv += _kernel
+            bias_conv += _bias
+
+        kernel_final = kernel_conv + kernel_scale + kernel_identity
+        bias_final = bias_conv + bias_scale + bias_identity
+        return kernel_final, bias_final
+    
+    def _fuse_bn_tensor(self, branch):
+        if isinstance(branch, ConvBnAct):
+            kernel = branch.conv.weight
+            running_mean = branch.bn1.running_mean
+            running_var = branch.bn1.running_var
+            gamma = branch.bn1.weight
+            beta = branch.bn1.bias
+            eps = branch.bn1.eps
+        else:
+            assert isinstance(branch, nn.BatchNorm2d)
+            if not hasattr(self, 'id_tensor'):
+                input_dim = self.in_channels // self.groups
+                kernel_value = torch.zeros(
+                    (self.in_channels, input_dim, self.kernel_size, self.kernel_size),
+                    dtype=branch.weight.dtype,
+                    device=branch.weight.device
+                )
+                for i in range(self.in_channels):
+                    kernel_value[i, i % input_dim,
+                                 self.kernel_size // 2,
+                                 self.kernel_size // 2] = 1
+                self.id_tensor = kernel_value
+            kernel = self.id_tensor
+            running_mean = branch.running_mean
+            running_var = branch.running_var
+            gamma = branch.weight
+            beta = branch.bias
+            eps = branch.eps
+        std = (running_var + eps).sqrt()
+        t = (gamma / std).reshape(-1, 1, 1, 1)
+        return kernel * t, beta - running_mean * gamma / std
+
+    def switch_to_deploy(self):
+        if self.infer_mode:
+            return
+        primary_kernel, primary_bias = self._get_kernel_bias_primary()
+        self.primary_conv = nn.Conv2d(
+            in_channels=self.primary_rpr_conv[0].conv.in_channels,
+            out_channels=self.primary_rpr_conv[0].conv.out_channels,
+            kernel_size=self.primary_rpr_conv[0].conv.kernel_size,
+            stride=self.primary_rpr_conv[0].conv.stride,
+            padding=self.primary_rpr_conv[0].conv.padding,
+            dilation=self.primary_rpr_conv[0].conv.dilation,
+            groups=self.primary_rpr_conv[0].conv.groups,
+            bias=True
+        )
+        self.primary_conv.weight.data = primary_kernel
+        self.primary_conv.bias.data = primary_bias
+        self.primary_conv = nn.Sequential(
+            self.primary_conv, 
+            self.primary_activation if self.primary_activation is not None else nn.Sequential()
+        )
+
+        cheap_kernel, cheap_bias = self._get_kernel_bias_cheap()
+        self.cheap_operation = nn.Conv2d(
+            in_channels=self.cheap_rpr_conv[0].conv.in_channels,
+            out_channels=self.cheap_rpr_conv[0].conv.out_channels,
+            kernel_size=self.cheap_rpr_conv[0].conv.kernel_size,
+            stride=self.cheap_rpr_conv[0].conv.stride,
+            padding=self.cheap_rpr_conv[0].conv.padding,
+            dilation=self.cheap_rpr_conv[0].conv.dilation,
+            groups=self.cheap_rpr_conv[0].conv.groups,
+            bias=True
+        )
+        self.cheap_operation.weight.data = cheap_kernel
+        self.cheap_operation.bias.data = cheap_bias
+
+        self.cheap_operation = nn.Sequential(
+            self.cheap_operation, 
+            self.cheap_activation if self.cheap_activation is not None else nn.Sequential()
+        )
+
+        # Delete un-used branches
+        for para in self.parameters():
+            para.detach_()
+        if hasattr(self, 'primary_rpr_conv'):
+            self.__delattr__('primary_rpr_conv')
+        if hasattr(self, 'primary_rpr_scale'):
+            self.__delattr__('primary_rpr_scale')
+        if hasattr(self, 'primary_rpr_skip'):
+            self.__delattr__('primary_rpr_skip')
+
+        if hasattr(self, 'cheap_rpr_conv'):
+            self.__delattr__('cheap_rpr_conv')
+        if hasattr(self, 'cheap_rpr_scale'):
+            self.__delattr__('cheap_rpr_scale')
+        if hasattr(self, 'cheap_rpr_skip'):
+            self.__delattr__('cheap_rpr_skip')
+
+        self.infer_mode = True
+        
+    def reparameterize(self):
+        self.switch_to_deploy()
+
+
 class GhostBottleneck(nn.Module):
-    """ Ghost bottleneck w/ optional SE"""
+    """ GhostV1/V2 bottleneck w/ optional SE"""
 
     def __init__(
             self,
-            in_chs,
-            mid_chs,
-            out_chs,
-            dw_kernel_size=3,
-            stride=1,
-            act_layer=nn.ReLU,
-            se_ratio=0.,
-            mode='original',
+            in_chs: int,
+            mid_chs: int,
+            out_chs: int,
+            dw_kernel_size: int = 3,
+            stride: int = 1,
+            act_layer: Callable = nn.ReLU,
+            se_ratio: float = 0.,
+            mode: str = 'original',
     ):
         super(GhostBottleneck, self).__init__()
         has_se = se_ratio is not None and se_ratio > 0.
@@ -129,9 +351,9 @@ class GhostBottleneck(nn.Module):
 
         # Point-wise expansion
         if mode == 'original':
-            self.ghost1 = GhostModule(in_chs, mid_chs, use_act=True, act_layer=act_layer)
+            self.ghost1 = GhostModule(in_chs, mid_chs, act_layer=act_layer)
         else:
-            self.ghost1 = GhostModuleV2(in_chs, mid_chs, use_act=True, act_layer=act_layer)
+            self.ghost1 = GhostModuleV2(in_chs, mid_chs, act_layer=act_layer)
 
         # Depth-wise convolution
         if self.stride > 1:
@@ -147,7 +369,7 @@ class GhostBottleneck(nn.Module):
         self.se = _SE_LAYER(mid_chs, rd_ratio=se_ratio) if has_se else None
 
         # Point-wise linear projection
-        self.ghost2 = GhostModule(mid_chs, out_chs, use_act=False)
+        self.ghost2 = GhostModule(mid_chs, out_chs, act_layer=nn.Identity)
         
         # shortcut
         if in_chs == out_chs and self.stride == 1:
@@ -162,7 +384,7 @@ class GhostBottleneck(nn.Module):
                 nn.BatchNorm2d(out_chs),
             )
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         shortcut = x
 
         # 1st ghost bottleneck
@@ -184,17 +406,194 @@ class GhostBottleneck(nn.Module):
         return x
 
 
+class GhostBottleneckV3(nn.Module): 
+    """ GhostV3 bottleneck w/ optional SE"""
+
+    def __init__(
+            self, 
+            in_chs: int, 
+            mid_chs: int, 
+            out_chs: int, 
+            dw_kernel_size: int = 3,
+            stride: int = 1,
+            act_layer: LayerType = nn.ReLU,
+            se_ratio: float = 0.,
+            mode: str = 'original',
+    ):
+        super(GhostBottleneckV3, self).__init__()
+        has_se = se_ratio is not None and se_ratio > 0.
+        self.stride = stride
+
+        self.num_conv_branches = 3
+        self.infer_mode = False
+        if not self.infer_mode:
+            self.conv_dw = nn.Identity()
+            self.bn_dw = nn.Identity()
+
+        # Point-wise expansion
+        self.ghost1 = GhostModuleV3(in_chs, mid_chs, act_layer=act_layer, mode=mode)
+
+        # Depth-wise convolution
+        if self.stride > 1:
+            self.dw_rpr_conv = nn.ModuleList(
+                [ConvBnAct(mid_chs, mid_chs, dw_kernel_size, stride, pad_type=(dw_kernel_size - 1) // 2, 
+                        group_size=1, act_layer=None) for _ in range(self.num_conv_branches)]
+            )
+            # Re-parameterizable scale branch
+            self.dw_rpr_scale = ConvBnAct(mid_chs, mid_chs, 1, 2, pad_type=0, group_size=1, act_layer=None)
+            self.kernel_size = dw_kernel_size
+            self.in_channels = mid_chs
+        else:
+            self.dw_rpr_conv = nn.ModuleList()
+            self.dw_rpr_scale = nn.Identity()
+        self.dw_rpr_skip = None
+
+        # Squeeze-and-excitation
+        self.se = _SE_LAYER(mid_chs, rd_ratio=se_ratio) if has_se else nn.Identity()
+
+        # Point-wise linear projection
+        self.ghost2 = GhostModuleV3(mid_chs, out_chs, act_layer=nn.Identity, mode='original')
+        
+        # shortcut
+        if in_chs == out_chs and self.stride == 1:
+            self.shortcut = nn.Identity()
+        else:
+            self.shortcut = nn.Sequential(
+                nn.Conv2d(
+                    in_chs, in_chs, dw_kernel_size, stride=stride,
+                    padding=(dw_kernel_size-1)//2, groups=in_chs, bias=False),
+                nn.BatchNorm2d(in_chs),
+                nn.Conv2d(in_chs, out_chs, 1, stride=1, padding=0, bias=False),
+                nn.BatchNorm2d(out_chs),
+            )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        shortcut = x
+
+        # 1st ghost bottleneck
+        x = self.ghost1(x)
+
+        # Depth-wise convolution
+        if self.stride > 1:
+            if self.infer_mode:
+                x = self.conv_dw(x)
+                x = self.bn_dw(x)
+            else:
+                x1 = self.dw_rpr_scale(x)
+                for dw_rpr_conv in self.dw_rpr_conv:
+                    x1 += dw_rpr_conv(x)
+                x = x1
+
+        # Squeeze-and-excitation
+        x = self.se(x)
+
+        # 2nd ghost bottleneck
+        x = self.ghost2(x)
+        
+        x += self.shortcut(shortcut)
+        return x
+
+    def _get_kernel_bias_dw(self):
+        kernel_scale = 0
+        bias_scale = 0
+        if self.dw_rpr_scale is not None:
+            kernel_scale, bias_scale = self._fuse_bn_tensor(self.dw_rpr_scale)
+            pad = self.kernel_size // 2
+            kernel_scale = F.pad(kernel_scale, [pad, pad, pad, pad])
+
+        kernel_identity = 0
+        bias_identity = 0
+        if self.dw_rpr_skip is not None:
+            kernel_identity, bias_identity = self._fuse_bn_tensor(self.dw_rpr_skip)
+
+        kernel_conv = 0
+        bias_conv = 0
+        for ix in range(self.num_conv_branches):
+            _kernel, _bias = self._fuse_bn_tensor(self.dw_rpr_conv[ix])
+            kernel_conv += _kernel
+            bias_conv += _bias
+
+        kernel_final = kernel_conv + kernel_scale + kernel_identity
+        bias_final = bias_conv + bias_scale + bias_identity
+        return kernel_final, bias_final
+
+    def _fuse_bn_tensor(self, branch):
+        if isinstance(branch, ConvBnAct):
+            kernel = branch.conv.weight
+            running_mean = branch.bn1.running_mean
+            running_var = branch.bn1.running_var
+            gamma = branch.bn1.weight
+            beta = branch.bn1.bias
+            eps = branch.bn1.eps
+        else:
+            assert isinstance(branch, nn.BatchNorm2d)
+            if not hasattr(self, 'id_tensor'):
+                input_dim = self.in_channels // self.groups
+                kernel_value = torch.zeros(
+                    (self.in_channels, input_dim, self.kernel_size, self.kernel_size),
+                    dtype=branch.weight.dtype,
+                    device=branch.weight.device
+                )
+                for i in range(self.in_channels):
+                    kernel_value[i, i % input_dim,
+                                 self.kernel_size // 2,
+                                 self.kernel_size // 2] = 1
+                self.id_tensor = kernel_value
+            kernel = self.id_tensor
+            running_mean = branch.running_mean
+            running_var = branch.running_var
+            gamma = branch.weight
+            beta = branch.bias
+            eps = branch.eps
+        std = (running_var + eps).sqrt()
+        t = (gamma / std).reshape(-1, 1, 1, 1)
+        return kernel * t, beta - running_mean * gamma / std
+
+    def switch_to_deploy(self):    
+        if self.infer_mode or self.stride == 1:
+            return
+        dw_kernel, dw_bias = self._get_kernel_bias_dw()
+        self.conv_dw = nn.Conv2d(
+            in_channels=self.dw_rpr_conv[0].conv.in_channels,
+            out_channels=self.dw_rpr_conv[0].conv.out_channels,
+            kernel_size=self.dw_rpr_conv[0].conv.kernel_size,
+            stride=self.dw_rpr_conv[0].conv.stride,
+            padding=self.dw_rpr_conv[0].conv.padding,
+            dilation=self.dw_rpr_conv[0].conv.dilation,
+            groups=self.dw_rpr_conv[0].conv.groups,
+            bias=True
+        )
+        self.conv_dw.weight.data = dw_kernel
+        self.conv_dw.bias.data = dw_bias
+        self.bn_dw = nn.Identity()
+
+        # Delete un-used branches
+        for para in self.parameters():
+            para.detach_()
+        if hasattr(self, 'dw_rpr_conv'):
+            self.__delattr__('dw_rpr_conv')
+        if hasattr(self, 'dw_rpr_scale'):
+            self.__delattr__('dw_rpr_scale')
+        if hasattr(self, 'dw_rpr_skip'):
+            self.__delattr__('dw_rpr_skip')
+
+        self.infer_mode = True
+            
+    def reparameterize(self):
+        self.switch_to_deploy()
+
+
 class GhostNet(nn.Module):
     def __init__(
             self,
             cfgs,
-            num_classes=1000,
-            width=1.0,
-            in_chans=3,
-            output_stride=32,
-            global_pool='avg',
-            drop_rate=0.2,
-            version='v1',
+            num_classes: int = 1000,
+            width: float = 1.0,
+            in_chans: int = 3,
+            output_stride: int = 32,
+            global_pool: str = 'avg',
+            drop_rate: float = 0.2,
+            version: str = 'v1',
     ):
         super(GhostNet, self).__init__()
         # setting of inverted residual blocks
@@ -204,6 +603,7 @@ class GhostNet(nn.Module):
         self.drop_rate = drop_rate
         self.grad_checkpointing = False
         self.feature_info = []
+        Bottleneck = GhostBottleneckV3 if version == 'v3' else GhostBottleneck
 
         # building first layer
         stem_chs = make_divisible(16 * width, 4)
@@ -227,7 +627,9 @@ class GhostNet(nn.Module):
                 layer_kwargs = {}
                 if version == 'v2' and layer_idx > 1:
                     layer_kwargs['mode'] = 'attn'
-                layers.append(GhostBottleneck(prev_chs, mid_chs, out_chs, k, s, se_ratio=se_ratio, **layer_kwargs))
+                if version == 'v3' and layer_idx > 1:
+                    layer_kwargs['mode'] = 'shortcut'
+                layers.append(Bottleneck(prev_chs, mid_chs, out_chs, k, s, se_ratio=se_ratio, **layer_kwargs))
                 prev_chs = out_chs
                 layer_idx += 1
             if s > 1:
@@ -255,7 +657,11 @@ class GhostNet(nn.Module):
         # FIXME init
 
     @torch.jit.ignore
-    def group_matcher(self, coarse=False):
+    def no_weight_decay(self) -> Set:
+        return set()
+
+    @torch.jit.ignore
+    def group_matcher(self, coarse: bool = False) -> Dict[str, Any]:
         matcher = dict(
             stem=r'^conv_stem|bn1',
             blocks=[
@@ -266,7 +672,7 @@ class GhostNet(nn.Module):
         return matcher
 
     @torch.jit.ignore
-    def set_grad_checkpointing(self, enable=True):
+    def set_grad_checkpointing(self, enable: bool = True):
         self.grad_checkpointing = enable
 
     @torch.jit.ignore
@@ -280,7 +686,73 @@ class GhostNet(nn.Module):
         self.flatten = nn.Flatten(1) if global_pool else nn.Identity()  # don't flatten if pooling disabled
         self.classifier = Linear(self.head_hidden_size, num_classes) if num_classes > 0 else nn.Identity()
 
-    def forward_features(self, x):
+    def forward_intermediates(
+            self,
+            x: torch.Tensor,
+            indices: Optional[Union[int, List[int]]] = None,
+            norm: bool = False,
+            stop_early: bool = False,
+            output_fmt: str = 'NCHW',
+            intermediates_only: bool = False,
+    ) -> Union[List[torch.Tensor], Tuple[torch.Tensor, List[torch.Tensor]]]:
+        """ Forward features that returns intermediates.
+
+        Args:
+            x: Input image tensor
+            indices: Take last n blocks if int, all if None, select matching indices if sequence
+            norm: Apply norm layer to compatible intermediates
+            stop_early: Stop iterating over blocks when last desired intermediate hit
+            output_fmt: Shape of intermediate feature outputs
+            intermediates_only: Only return intermediate features
+        Returns:
+
+        """
+        assert output_fmt in ('NCHW',), 'Output shape must be NCHW.'
+        intermediates = []
+        stage_ends = [-1] + [int(info['module'].split('.')[-1]) for info in self.feature_info[1:]]
+        take_indices, max_index = feature_take_indices(len(stage_ends), indices)
+        take_indices = [stage_ends[i]+1 for i in take_indices]
+        max_index = stage_ends[max_index]
+
+        # forward pass
+        feat_idx = 0
+        x = self.conv_stem(x)
+        if feat_idx in take_indices:
+            intermediates.append(x)
+        x = self.bn1(x)
+        x = self.act1(x)
+        if torch.jit.is_scripting() or not stop_early:  # can't slice blocks in torchscript
+            stages = self.blocks
+        else:
+            stages = self.blocks[:max_index + 1]
+
+        for feat_idx, stage in enumerate(stages, start=1):
+            x = stage(x)
+            if feat_idx in take_indices:
+                intermediates.append(x) 
+
+        if intermediates_only:
+            return intermediates
+
+        return x, intermediates
+
+    def prune_intermediate_layers(
+            self,
+            indices: Union[int, List[int]] = 1,
+            prune_norm: bool = False,
+            prune_head: bool = True,
+    ):
+        """ Prune layers not required for specified intermediates.
+        """
+        stage_ends = [-1] + [int(info['module'].split('.')[-1]) for info in self.feature_info[1:]]
+        take_indices, max_index = feature_take_indices(len(stage_ends), indices)
+        max_index = stage_ends[max_index]
+        self.blocks = self.blocks[:max_index + 1]  # truncate blocks w/ stem as idx 0
+        if prune_head:
+            self.reset_classifier(0, '')
+        return take_indices 
+
+    def forward_features(self, x: torch.Tensor) -> torch.Tensor:
         x = self.conv_stem(x)
         x = self.bn1(x)
         x = self.act1(x)
@@ -290,7 +762,7 @@ class GhostNet(nn.Module):
             x = self.blocks(x)
         return x
 
-    def forward_head(self, x, pre_logits: bool = False):
+    def forward_head(self, x: torch.Tensor, pre_logits: bool = False) -> torch.Tensor:
         x = self.global_pool(x)
         x = self.conv_head(x)
         x = self.act2(x)
@@ -299,22 +771,32 @@ class GhostNet(nn.Module):
             x = F.dropout(x, p=self.drop_rate, training=self.training)
         return x if pre_logits else self.classifier(x)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.forward_features(x)
         x = self.forward_head(x)
         return x
 
+    def convert_to_deploy(self):
+        reparameterize_model(self, inplace=False)
 
-def checkpoint_filter_fn(state_dict, model: nn.Module):
+
+def checkpoint_filter_fn(state_dict: Dict[str, torch.Tensor], model: nn.Module) -> Dict[str, torch.Tensor]:
+    if 'state_dict' in state_dict:
+        state_dict = state_dict['state_dict']
+
     out_dict = {}
     for k, v in state_dict.items():
+        if 'bn.' in k and '.ghost' in k:
+            k = k.replace('bn.', 'bn1.')
+        if 'bn.' in k and '.dw_rpr_' in k:
+            k = k.replace('bn.', 'bn1.')
         if 'total' in k:
             continue
         out_dict[k] = v
     return out_dict
 
 
-def _create_ghostnet(variant, width=1.0, pretrained=False, **kwargs):
+def _create_ghostnet(variant: str, width: float = 1.0, pretrained: bool = False, **kwargs: Any) -> GhostNet:
     """
     Constructs a GhostNet model
     """
@@ -388,6 +870,13 @@ default_cfgs = generate_default_cfgs({
         hf_hub_id='timm/',
         # url='https://github.com/huawei-noah/Efficient-AI-Backbones/releases/download/GhostNetV2/ck_ghostnetv2_16.pth.tar'
     ),
+    'ghostnetv3_050.untrained': _cfg(),
+    'ghostnetv3_100.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/huawei-noah/Efficient-AI-Backbones/releases/download/GhostNetV3/ghostnetv3-1.0.pth.tar'
+    ),
+    'ghostnetv3_130.untrained': _cfg(),
+    'ghostnetv3_160.untrained': _cfg(),
 })
 
 
@@ -430,4 +919,32 @@ def ghostnetv2_130(pretrained=False, **kwargs) -> GhostNet:
 def ghostnetv2_160(pretrained=False, **kwargs) -> GhostNet:
     """ GhostNetV2-1.6x """
     model = _create_ghostnet('ghostnetv2_160', width=1.6, pretrained=pretrained, version='v2', **kwargs)
+    return model
+
+
+@register_model
+def ghostnetv3_050(pretrained: bool = False, **kwargs: Any) -> GhostNet:
+    """ GhostNetV3-0.5x """
+    model = _create_ghostnet('ghostnetv3_050', width=0.5, pretrained=pretrained, version='v3', **kwargs)
+    return model
+
+
+@register_model
+def ghostnetv3_100(pretrained: bool = False, **kwargs: Any) -> GhostNet:
+    """ GhostNetV3-1.0x """
+    model = _create_ghostnet('ghostnetv3_100', width=1.0, pretrained=pretrained, version='v3', **kwargs)
+    return model
+
+
+@register_model
+def ghostnetv3_130(pretrained: bool = False, **kwargs: Any) -> GhostNet:
+    """ GhostNetV3-1.3x """
+    model = _create_ghostnet('ghostnetv3_130', width=1.3, pretrained=pretrained, version='v3', **kwargs)
+    return model
+
+
+@register_model
+def ghostnetv3_160(pretrained: bool = False, **kwargs: Any) -> GhostNet:
+    """ GhostNetV3-1.6x """
+    model = _create_ghostnet('ghostnetv3_160', width=1.6, pretrained=pretrained, version='v3', **kwargs)
     return model

--- a/timm/models/shvit.py
+++ b/timm/models/shvit.py
@@ -1,0 +1,522 @@
+"""SHViT
+SHViT: Single-Head Vision Transformer with Memory Efficient Macro Design
+Code: https://github.com/ysj9909/SHViT
+Paper: https://arxiv.org/abs/2401.16456
+
+@inproceedings{yun2024shvit,
+  author={Yun, Seokju and Ro, Youngmin},
+  title={SHViT: Single-Head Vision Transformer with Memory Efficient Macro Design},
+  booktitle={Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
+  pages={5756--5767},
+  year={2024}
+}
+"""
+import re
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
+from timm.layers import GroupNorm1, SqueezeExcite, SelectAdaptivePool2d, LayerType, trunc_normal_
+from ._builder import build_model_with_cfg
+from ._features import feature_take_indices
+from ._manipulate import checkpoint_seq
+from ._registry import register_model, generate_default_cfgs
+
+__all__ = ['SHViT']
+
+
+class Residule(nn.Module):
+    def __init__(self, m: nn.Module):
+        super().__init__()
+        self.m = m
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.m(x)
+
+    @torch.no_grad()
+    def fuse(self) -> nn.Module:
+        if isinstance(self.m, Conv2d_BN):
+            m = self.m.fuse()
+            assert(m.groups == m.in_channels)
+            identity = torch.ones(m.weight.shape[0], m.weight.shape[1], 1, 1)
+            identity = F.pad(identity, [1,1,1,1])
+            m.weight += identity.to(m.weight.device)
+            return m
+        else:
+            return self
+
+
+class Conv2d_BN(nn.Sequential):
+    def __init__(
+            self,
+            in_channels: int,
+            out_channels: int,
+            kernel_size: int = 1,
+            stride: int = 1,
+            padding: int = 0,
+            bn_weight_init: int = 1,
+            **kwargs
+    ):
+        super().__init__()
+        self.add_module('c', nn.Conv2d(
+            in_channels, out_channels, kernel_size, stride, padding, bias=False, **kwargs))
+        self.add_module('bn', nn.BatchNorm2d(out_channels))
+        nn.init.constant_(self.bn.weight, bn_weight_init)
+        nn.init.constant_(self.bn.bias, 0)
+
+    @torch.no_grad()
+    def fuse(self) -> nn.Conv2d:
+        c, bn = self._modules.values()
+        w = bn.weight / (bn.running_var + bn.eps) ** 0.5
+        w = c.weight * w[:, None, None, None]
+        b = bn.bias - bn.running_mean * bn.weight / (bn.running_var + bn.eps) ** 0.5
+        m = nn.Conv2d(
+            in_channels=w.size(1) * self.c.groups, 
+            out_channels=w.size(0), 
+            kernel_size=w.shape[2:], 
+            stride=self.c.stride, 
+            padding=self.c.padding, 
+            dilation=self.c.dilation, 
+            groups=self.c.groups,
+            device=c.weight.device,
+            dtype=c.weight.dtype,
+        )
+        m.weight.data.copy_(w)
+        m.bias.data.copy_(b)
+        return m
+
+
+class BN_Linear(nn.Sequential):
+    def __init__(
+            self,
+            in_features: int,
+            out_features: int,
+            bias: bool = True,
+            std: float = 0.02,
+    ):
+        super().__init__()
+        self.add_module('bn', nn.BatchNorm1d(in_features))
+        self.add_module('l', nn.Linear(in_features, out_features, bias=bias))
+        trunc_normal_(self.l.weight, std=std)
+        if bias:
+            nn.init.constant_(self.l.bias, 0)
+
+    @torch.no_grad()
+    def fuse(self) -> nn.Linear:
+        bn, l = self._modules.values()
+        w = bn.weight / (bn.running_var + bn.eps) ** 0.5
+        b = bn.bias - self.bn.running_mean * self.bn.weight / (bn.running_var + bn.eps) ** 0.5
+        w = l.weight * w[None, :]
+        if l.bias is None:
+            b = b @ self.l.weight.T
+        else:
+            b = (l.weight @ b[:, None]).view(-1) + self.l.bias
+        m = nn.Linear(w.size(1), w.size(0), device=l.weight.device, dtype=l.weight.dtype)
+        m.weight.data.copy_(w)
+        m.bias.data.copy_(b)
+        return m
+
+
+class PatchMerging(nn.Module):
+    def __init__(self, dim: int, out_dim: int, act_layer: LayerType = nn.ReLU):
+        super().__init__()
+        hid_dim = int(dim * 4)
+        self.conv1 = Conv2d_BN(dim, hid_dim)
+        self.act1 = act_layer()
+        self.conv2 = Conv2d_BN(hid_dim, hid_dim, 3, 2, 1, groups=hid_dim)
+        self.act2 = act_layer()
+        self.se = SqueezeExcite(hid_dim, 0.25)
+        self.conv3 = Conv2d_BN(hid_dim, out_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv1(x)
+        x = self.act1(x)
+        x = self.conv2(x)
+        x = self.act2(x)
+        x = self.se(x)
+        x = self.conv3(x)
+        return x
+
+
+class FFN(nn.Module):
+    def __init__(self, dim: int, embed_dim: int, act_layer: LayerType = nn.ReLU):
+        super().__init__()
+        self.pw1 = Conv2d_BN(dim, embed_dim)
+        self.act = act_layer()
+        self.pw2 = Conv2d_BN(embed_dim, dim, bn_weight_init=0)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.pw1(x)
+        x = self.act(x)
+        x = self.pw2(x)
+        return x
+
+
+class SHSA(nn.Module):
+    """Single-Head Self-Attention"""
+    def __init__(
+            self,
+            dim: int,
+            qk_dim: int,
+            pdim: int,
+            norm_layer: LayerType = GroupNorm1,
+            act_layer: LayerType = nn.ReLU,
+    ):
+        super().__init__()
+        self.scale = qk_dim ** -0.5
+        self.qk_dim = qk_dim
+        self.dim = dim
+        self.pdim = pdim
+
+        self.pre_norm = norm_layer(pdim)
+
+        self.qkv = Conv2d_BN(pdim, qk_dim * 2 + pdim)
+        self.proj = nn.Sequential(act_layer(), Conv2d_BN(dim, dim, bn_weight_init=0)) 
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, _, H, W = x.shape
+        x1, x2 = torch.split(x, [self.pdim, self.dim - self.pdim], dim = 1)
+        x1 = self.pre_norm(x1)
+        qkv = self.qkv(x1)
+        q, k, v = torch.split(qkv, [self.qk_dim, self.qk_dim, self.pdim], dim=1)
+        q, k, v = q.flatten(2), k.flatten(2), v.flatten(2)
+        
+        attn = (q.transpose(-2, -1) @ k) * self.scale
+        attn = attn.softmax(dim=-1)
+        x1 = (v @ attn.transpose(-2, -1)).reshape(B, self.pdim, H, W)
+        x = self.proj(torch.cat([x1, x2], dim = 1))
+        return x
+
+
+class BasicBlock(nn.Module):
+    def __init__(
+            self,
+            dim: int,
+            qk_dim: int,
+            pdim: int,
+            type: str,
+            norm_layer: LayerType = GroupNorm1,
+            act_layer: LayerType = nn.ReLU,
+    ):
+        super().__init__()
+        self.conv = Residule(Conv2d_BN(dim, dim, 3, 1, 1, groups=dim, bn_weight_init=0))
+        if type == "s": 
+            self.mixer = Residule(SHSA(dim, qk_dim, pdim, norm_layer, act_layer))
+        else: 
+            self.mixer = nn.Identity()
+        self.ffn = Residule(FFN(dim, int(dim * 2)))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv(x)
+        x = self.mixer(x)
+        x = self.ffn(x)
+        return x
+
+
+class StageBlock(nn.Module):
+    def __init__(
+            self,
+            prev_dim: int,
+            dim: int,
+            qk_dim: int,
+            pdim: int,
+            type: str,
+            depth: int,
+            norm_layer: LayerType = GroupNorm1,
+            act_layer: LayerType = nn.ReLU,
+    ):
+        super().__init__()
+        self.down = nn.Sequential(
+            Residule(Conv2d_BN(prev_dim, prev_dim, 3, 1, 1, groups=prev_dim)),
+            Residule(FFN(prev_dim, int(prev_dim * 2), act_layer)),
+            PatchMerging(prev_dim, dim, act_layer),
+            Residule(Conv2d_BN(dim, dim, 3, 1, 1, groups=dim)),
+            Residule(FFN(dim, int(dim * 2), act_layer)),
+        ) if prev_dim is not None else nn.Identity()
+
+        self.block = nn.Sequential(*[
+            BasicBlock(dim, qk_dim, pdim, type, norm_layer, act_layer) for _ in range(depth)
+        ])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.down(x)
+        x = self.block(x)
+        return x
+
+
+class SHViT(nn.Module):
+    def __init__(
+            self,
+            in_chans: int = 3,
+            num_classes: int = 1000,
+            global_pool: str = 'avg',
+            embed_dim: Tuple[int, int, int] = (128, 256, 384),
+            partial_dim: Tuple[int, int, int] = (32, 64, 96),
+            qk_dim: Tuple[int, int, int] = (16, 16, 16),
+            depth: Tuple[int, int, int] = (1, 2, 3),
+            types: Tuple[str, str, str] = ("s", "s", "s"),
+            drop_rate: float = 0.,
+            norm_layer: LayerType = GroupNorm1,
+            act_layer: LayerType = nn.ReLU,
+    ):
+        super().__init__()
+        self.num_classes = num_classes
+        self.drop_rate = drop_rate
+        self.grad_checkpointing = False
+        self.feature_info = []
+
+        # Patch embedding
+        self.patch_embed = nn.Sequential(
+            Conv2d_BN(in_chans, embed_dim[0] // 8, 3, 2, 1),
+            act_layer(),
+            Conv2d_BN(embed_dim[0] // 8, embed_dim[0] // 4, 3, 2, 1),
+            act_layer(),
+            Conv2d_BN(embed_dim[0] // 4, embed_dim[0] // 2, 3, 2, 1),
+            act_layer(),
+            Conv2d_BN(embed_dim[0] // 2, embed_dim[0], 3, 2, 1)
+        )
+
+        # Build SHViT blocks
+        blocks = []
+        prev_chs = None
+        for i in range(len(embed_dim)):
+            blocks.append(StageBlock(
+                prev_dim=prev_chs,
+                dim=embed_dim[i],
+                qk_dim=qk_dim[i],
+                pdim=partial_dim[i],
+                type=types[i],
+                depth=depth[i],
+                norm_layer=norm_layer,
+                act_layer=act_layer,
+            ))
+            prev_chs = embed_dim[i]
+            self.feature_info.append(dict(num_chs=prev_chs, reduction=2**(i+4), module=f'blocks.{i}'))
+            
+        self.blocks = nn.Sequential(*blocks)
+        # Classifier head
+        self.num_features = self.head_hidden_size = embed_dim[-1]
+        self.global_pool = SelectAdaptivePool2d(pool_type=global_pool)
+        self.flatten = nn.Flatten(1) if global_pool else nn.Identity()  # don't flatten if pooling disabled
+        self.head = BN_Linear(self.head_hidden_size, num_classes) if num_classes > 0 else nn.Identity()
+
+    @torch.jit.ignore
+    def no_weight_decay(self) -> Set:
+        return set()
+
+    @torch.jit.ignore
+    def group_matcher(self, coarse: bool = False) -> Dict[str, Any]:
+        matcher = dict(stem=r'^patch_embed', blocks=[(r'^blocks\.(\d+)', None)])
+        return matcher
+
+    @torch.jit.ignore
+    def set_grad_checkpointing(self, enable: bool = True):
+        self.grad_checkpointing = enable
+
+    @torch.jit.ignore
+    def get_classifier(self) -> nn.Module:
+        return self.head.l
+    
+    def reset_classifier(self, num_classes: int, global_pool: str = 'avg'):
+        self.num_classes = num_classes
+        # cannot meaningfully change pooling of efficient head after creation
+        self.global_pool = SelectAdaptivePool2d(pool_type=global_pool)
+        self.flatten = nn.Flatten(1) if global_pool else nn.Identity()  # don't flatten if pooling disabled
+        self.head = BN_Linear(self.head_hidden_size, num_classes) if num_classes > 0 else nn.Identity()
+
+    def forward_intermediates(
+            self,
+            x: torch.Tensor,
+            indices: Optional[Union[int, List[int]]] = None,
+            norm: bool = False,
+            stop_early: bool = False,
+            output_fmt: str = 'NCHW',
+            intermediates_only: bool = False,
+    ) -> Union[List[torch.Tensor], Tuple[torch.Tensor, List[torch.Tensor]]]:
+        """ Forward features that returns intermediates.
+
+        Args:
+            x: Input image tensor
+            indices: Take last n blocks if int, all if None, select matching indices if sequence
+            norm: Apply norm layer to compatible intermediates
+            stop_early: Stop iterating over blocks when last desired intermediate hit
+            output_fmt: Shape of intermediate feature outputs
+            intermediates_only: Only return intermediate features
+        Returns:
+
+        """
+        assert output_fmt in ('NCHW',), 'Output shape must be NCHW.'
+        intermediates = []
+        take_indices, max_index = feature_take_indices(len(self.blocks), indices)
+
+        # forward pass
+        x = self.patch_embed(x)
+        if torch.jit.is_scripting() or not stop_early:  # can't slice blocks in torchscript
+            stages = self.blocks
+        else:
+            stages = self.blocks[:max_index + 1]
+
+        for feat_idx, stage in enumerate(stages):
+            x = stage(x)
+            if feat_idx in take_indices:
+                intermediates.append(x) 
+
+        if intermediates_only:
+            return intermediates
+
+        return x, intermediates
+
+    def prune_intermediate_layers(
+            self,
+            indices: Union[int, List[int]] = 1,
+            prune_norm: bool = False,
+            prune_head: bool = True,
+    ):
+        """ Prune layers not required for specified intermediates.
+        """
+        take_indices, max_index = feature_take_indices(len(self.blocks), indices)
+        self.blocks = self.blocks[:max_index + 1]  # truncate blocks w/ stem as idx 0
+        if prune_head:
+            self.reset_classifier(0, '')
+        return take_indices
+
+    def forward_features(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.patch_embed(x)
+        if self.grad_checkpointing and not torch.jit.is_scripting():
+            x = checkpoint_seq(self.blocks, x, flatten=True)
+        else:
+            x = self.blocks(x)
+        return x
+
+    def forward_head(self, x: torch.Tensor, pre_logits: bool = False) -> torch.Tensor:
+        x = self.global_pool(x)
+        x = self.flatten(x)
+        if self.drop_rate > 0.:
+            x = F.dropout(x, p=self.drop_rate, training=self.training)
+        return x if pre_logits else self.head(x)
+    
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.forward_features(x)
+        x = self.forward_head(x)
+        return x
+
+    @torch.no_grad()
+    def fuse(self):
+        def fuse_children(net):
+            for child_name, child in net.named_children():
+                if hasattr(child, 'fuse'):
+                    fused = child.fuse()
+                    setattr(net, child_name, fused)
+                    fuse_children(fused)
+                else:
+                    fuse_children(child)
+
+        fuse_children(self)
+
+
+def checkpoint_filter_fn(state_dict: Dict[str, torch.Tensor], model: nn.Module) -> Dict[str, torch.Tensor]:
+    if 'model' in state_dict:
+        state_dict = state_dict['model']
+    out_dict = {}
+
+    replace_rules = [
+        (re.compile(r'^blocks1\.'), 'blocks.0.block.'),
+        (re.compile(r'^blocks2\.'), 'blocks.1.block.'),
+        (re.compile(r'^blocks3\.'), 'blocks.2.block.'),
+    ]
+    downsample_mapping = {}
+    for i in range(1, 3):
+        downsample_mapping[f'^blocks\\.{i}\\.block\\.0\\.0\\.'] = f'blocks.{i}.down.0.'
+        downsample_mapping[f'^blocks\\.{i}\\.block\\.0\\.1\\.'] = f'blocks.{i}.down.1.'
+        downsample_mapping[f'^blocks\\.{i}\\.block\\.1\\.'] = f'blocks.{i}.down.2.'
+        downsample_mapping[f'^blocks\\.{i}\\.block\\.2\\.0\\.'] = f'blocks.{i}.down.3.'
+        downsample_mapping[f'^blocks\\.{i}\\.block\\.2\\.1\\.'] = f'blocks.{i}.down.4.'
+        for j in range(3, 10):
+            downsample_mapping[f'^blocks\\.{i}\\.block\\.{j}\\.'] = f'blocks.{i}.block.{j - 3}.'
+
+    downsample_patterns = [
+        (re.compile(pattern), replacement) for pattern, replacement in downsample_mapping.items()]
+
+    for k, v in state_dict.items():
+        for pattern, replacement in replace_rules:
+            k = pattern.sub(replacement, k)
+        for pattern, replacement in downsample_patterns:
+            k = pattern.sub(replacement, k)
+        out_dict[k] = v
+
+    return out_dict
+
+
+def _cfg(url: str = '', **kwargs: Any) -> Dict[str, Any]:
+    return {
+        'url': url, 'num_classes': 1000, 'input_size': (3, 224, 224), 'pool_size': (4, 4),
+        'crop_pct': 0.875, 'interpolation': 'bicubic',
+        'mean': IMAGENET_DEFAULT_MEAN, 'std': IMAGENET_DEFAULT_STD,
+        'first_conv': 'patch_embed.0.c', 'classifier': 'head.l',
+        'paper_ids': 'arXiv:2401.16456',
+        'paper_name': 'SHViT: Single-Head Vision Transformer with Memory Efficient Macro Design',
+        'origin_url': 'https://github.com/ysj9909/SHViT',
+        **kwargs
+    }
+
+
+default_cfgs = generate_default_cfgs({
+    'shvit_s1.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/ysj9909/SHViT/releases/download/v1.0/shvit_s1.pth',
+    ),
+    'shvit_s2.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/ysj9909/SHViT/releases/download/v1.0/shvit_s2.pth',
+    ),
+    'shvit_s3.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/ysj9909/SHViT/releases/download/v1.0/shvit_s3.pth',
+    ),
+    'shvit_s4.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/ysj9909/SHViT/releases/download/v1.0/shvit_s4.pth',
+        input_size=(3, 256, 256),
+    ),
+})
+
+
+def _create_shvit(variant: str, pretrained: bool = False, **kwargs: Any) -> SHViT:
+    model = build_model_with_cfg(
+        SHViT, variant, pretrained,
+        pretrained_filter_fn=checkpoint_filter_fn,
+        feature_cfg=dict(out_indices=(0, 1, 2), flatten_sequential=True),
+        **kwargs,
+    )
+    return model
+
+
+@register_model
+def shvit_s1(pretrained: bool = False, **kwargs: Any) -> SHViT:
+    model_args = dict(
+        embed_dim=(128, 224, 320), depth=(2, 4, 5), partial_dim=(32, 48, 68), types=("i", "s", "s"))
+    return _create_shvit('shvit_s1', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def shvit_s2(pretrained: bool = False, **kwargs: Any) -> SHViT:
+    model_args = dict(
+        embed_dim=(128, 308, 448), depth=(2, 4, 5), partial_dim=(32, 66, 96), types=("i", "s", "s"))
+    return _create_shvit('shvit_s2', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def shvit_s3(pretrained: bool = False, **kwargs: Any) -> SHViT:
+    model_args = dict(
+        embed_dim=(192, 352, 448), depth=(3, 5, 5), partial_dim=(48, 75, 96), types=("i", "s", "s"))
+    return _create_shvit('shvit_s3', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def shvit_s4(pretrained: bool = False, **kwargs: Any) -> SHViT:
+    model_args = dict(
+        embed_dim=(224, 336, 448), depth=(4, 7, 6), partial_dim=(48, 72, 96), types=("i", "s", "s"))
+    return _create_shvit('shvit_s4', pretrained=pretrained, **dict(model_args, **kwargs))

--- a/timm/models/starnet.py
+++ b/timm/models/starnet.py
@@ -1,0 +1,344 @@
+"""
+Implementation of Prof-of-Concept Network: StarNet.
+
+We make StarNet as simple as possible [to show the key contribution of element-wise multiplication]:
+    - like NO layer-scale in network design,
+    - and NO EMA during training,
+    - which would improve the performance further.
+
+Created by: Xu Ma (Email: ma.xu1@northeastern.edu)
+Modified Date: Mar/29/2024
+"""
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
+from timm.layers import DropPath, SelectAdaptivePool2d, Linear, LayerType, trunc_normal_
+from ._builder import build_model_with_cfg
+from ._features import feature_take_indices
+from ._manipulate import checkpoint_seq
+from ._registry import register_model, generate_default_cfgs
+
+__all__ = ['StarNet']
+
+
+class ConvBN(nn.Sequential):
+    def __init__(
+            self,
+            in_channels: int,
+            out_channels: int,
+            kernel_size: int = 1,
+            stride: int = 1,
+            padding: int = 0,
+            with_bn: bool = True,
+            **kwargs
+    ):
+        super().__init__()
+        self.add_module('conv', nn.Conv2d(
+            in_channels, out_channels, kernel_size, stride=stride, padding=padding, **kwargs))
+        if with_bn:
+            self.add_module('bn', nn.BatchNorm2d(out_channels))
+            nn.init.constant_(self.bn.weight, 1)
+            nn.init.constant_(self.bn.bias, 0)
+
+
+class Block(nn.Module):
+    def __init__(
+            self,
+            dim: int,
+            mlp_ratio: int = 3,
+            drop_path: float = 0.,
+            act_layer: LayerType = nn.ReLU6,
+    ):
+        super().__init__()
+        self.dwconv = ConvBN(dim, dim, 7, 1, 3, groups=dim, with_bn=True)
+        self.f1 = ConvBN(dim, mlp_ratio * dim, 1, with_bn=False)
+        self.f2 = ConvBN(dim, mlp_ratio * dim, 1, with_bn=False)
+        self.g = ConvBN(mlp_ratio * dim, dim, 1, with_bn=True)
+        self.dwconv2 = ConvBN(dim, dim, 7, 1, 3, groups=dim, with_bn=False)
+        self.act = act_layer()
+        self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        x = self.dwconv(x)
+        x1, x2 = self.f1(x), self.f2(x)
+        x = self.act(x1) * x2
+        x = self.dwconv2(self.g(x))
+        x = residual + self.drop_path(x)
+        return x
+
+
+class StarNet(nn.Module):
+    def __init__(
+            self,
+            base_dim: int = 32,
+            depths: List[int] = [3, 3, 12, 5],
+            mlp_ratio: int = 4,
+            drop_rate: float = 0.,
+            drop_path_rate: float = 0.,
+            act_layer: LayerType = nn.ReLU6,
+            num_classes: int = 1000,
+            in_chans: int = 3,
+            global_pool: str = 'avg',
+            output_stride: int = 32,
+            **kwargs,
+    ):
+        super().__init__()
+        assert output_stride == 32
+        self.num_classes = num_classes
+        self.drop_rate = drop_rate
+        self.grad_checkpointing = False
+        self.feature_info = []
+        stem_chs = 32
+        
+        # stem layer
+        self.stem = nn.Sequential(
+            ConvBN(in_chans, stem_chs, kernel_size=3, stride=2, padding=1), 
+            act_layer(),
+        )
+        prev_chs = stem_chs
+
+        # build stages
+        dpr = [x.item() for x in torch.linspace(0, drop_path_rate, sum(depths))] # stochastic depth
+        stages = []
+        cur = 0
+        for i_layer in range(len(depths)):
+            embed_dim = base_dim * 2 ** i_layer
+            down_sampler = ConvBN(prev_chs, embed_dim, 3, stride=2, padding=1)
+            blocks = [Block(embed_dim, mlp_ratio, dpr[cur + i], act_layer) for i in range(depths[i_layer])]
+            cur += depths[i_layer]
+            prev_chs = embed_dim
+            stages.append(nn.Sequential(down_sampler, *blocks))
+            self.feature_info.append(dict(
+                    num_chs=prev_chs, reduction=2**(i_layer+2), module=f'stages.{i_layer}'))
+        self.stages = nn.Sequential(*stages)
+        # head
+        self.num_features = self.head_hidden_size = prev_chs
+        self.norm = nn.BatchNorm2d(self.num_features)
+        self.global_pool = SelectAdaptivePool2d(pool_type=global_pool)
+        self.flatten = nn.Flatten(1) if global_pool else nn.Identity()  # don't flatten if pooling disabled
+        self.head = Linear(self.num_features, num_classes) if num_classes > 0 else nn.Identity()
+        self.apply(self._init_weights)
+
+    def _init_weights(self, m):
+        if isinstance(m, (nn.Linear, nn.Conv2d)):
+            trunc_normal_(m.weight, std=.02)
+            if isinstance(m, nn.Linear) and m.bias is not None:
+                nn.init.constant_(m.bias, 0)
+        elif isinstance(m, nn.BatchNorm2d):
+            nn.init.constant_(m.bias, 0)
+            nn.init.constant_(m.weight, 1.0)
+
+    @torch.jit.ignore
+    def no_weight_decay(self) -> Set:
+        return set()
+
+    @torch.jit.ignore
+    def group_matcher(self, coarse: bool = False) -> Dict[str, Any]:
+        matcher = dict(
+            stem=r'^stem\.\d+',
+            blocks=[(r'^stages\.(\d+)', None), (r'^norm', (99999,))]
+        )
+        return matcher
+
+    @torch.jit.ignore
+    def set_grad_checkpointing(self, enable: bool = True):
+        self.grad_checkpointing = enable
+
+    @torch.jit.ignore
+    def get_classifier(self) -> nn.Module:
+        return self.head
+
+    def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None):
+        self.num_classes = num_classes
+        if global_pool is not None:
+            # NOTE: cannot meaningfully change pooling of efficient head after creation
+            self.global_pool = SelectAdaptivePool2d(pool_type=global_pool)
+            self.flatten = nn.Flatten(1) if global_pool else nn.Identity()  # don't flatten if pooling disabled
+        self.head = Linear(self.head_hidden_size, num_classes) if num_classes > 0 else nn.Identity()
+
+    def forward_intermediates(
+            self,
+            x: torch.Tensor,
+            indices: Optional[Union[int, List[int]]] = None,
+            norm: bool = False,
+            stop_early: bool = False,
+            output_fmt: str = 'NCHW',
+            intermediates_only: bool = False,
+    ) -> Union[List[torch.Tensor], Tuple[torch.Tensor, List[torch.Tensor]]]:
+        """ Forward features that returns intermediates.
+
+        Args:
+            x: Input image tensor
+            indices: Take last n blocks if int, all if None, select matching indices if sequence
+            norm: Apply norm layer to compatible intermediates
+            stop_early: Stop iterating over blocks when last desired intermediate hit
+            output_fmt: Shape of intermediate feature outputs
+            intermediates_only: Only return intermediate features
+        Returns:
+
+        """
+        assert output_fmt in ('NCHW',), 'Output shape must be NCHW.'
+        intermediates = []
+        take_indices, max_index = feature_take_indices(len(self.stages), indices)
+        last_idx = len(self.stages) - 1
+
+        # forward pass
+        x = self.stem(x)
+        if torch.jit.is_scripting() or not stop_early:  # can't slice blocks in torchscript
+            stages = self.stages
+        else:
+            stages = self.stages[:max_index + 1]
+
+        for feat_idx, stage in enumerate(stages):
+            x = stage(x)
+            if feat_idx in take_indices:
+                if norm and feat_idx == last_idx:
+                    x_inter = self.norm(x)  # applying final norm last intermediate
+                else:
+                    x_inter = x
+                intermediates.append(x_inter) 
+
+        if intermediates_only:
+            return intermediates
+
+        x = self.norm(x)
+
+        return x, intermediates
+
+    def prune_intermediate_layers(
+            self,
+            indices: Union[int, List[int]] = 1,
+            prune_norm: bool = False,
+            prune_head: bool = True,
+    ):
+        """ Prune layers not required for specified intermediates.
+        """
+        take_indices, max_index = feature_take_indices(len(self.stages), indices)
+        self.stages = self.stages[:max_index + 1]  # truncate blocks w/ stem as idx 0
+        if prune_norm:
+            self.norm = nn.Identity()
+        if prune_head:
+            self.reset_classifier(0, '')
+        return take_indices
+
+    def forward_features(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.stem(x)
+        if self.grad_checkpointing and not torch.jit.is_scripting():
+            x = checkpoint_seq(self.stages, x, flatten=True)
+        else:
+            x = self.stages(x)
+        x = self.norm(x)
+        return x
+
+    def forward_head(self, x: torch.Tensor, pre_logits: bool = False) -> torch.Tensor:
+        x = self.global_pool(x)
+        x = self.flatten(x)
+        if self.drop_rate > 0.:
+            x = F.dropout(x, p=self.drop_rate, training=self.training)
+        return x if pre_logits else self.head(x)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.forward_features(x)
+        x = self.forward_head(x)
+        return x
+
+
+def checkpoint_filter_fn(state_dict: Dict[str, torch.Tensor], model: nn.Module) -> Dict[str, torch.Tensor]:
+    if 'state_dict' in state_dict:
+        state_dict = state_dict['state_dict']
+    out_dict = state_dict
+    return out_dict
+
+
+def _cfg(url: str = '', **kwargs: Any) -> Dict[str, Any]:
+    return {
+        'url': url, 'num_classes': 1000, 'input_size': (3, 224, 224), 'pool_size': (7, 7),
+        'crop_pct': 0.875, 'interpolation': 'bicubic',
+        'mean': IMAGENET_DEFAULT_MEAN, 'std': IMAGENET_DEFAULT_STD,
+        'first_conv': 'stem.0.conv', 'classifier': 'head',
+        'paper_ids': 'arXiv:2403.19967',
+        'paper_name': 'Rewrite the Stars',
+        'origin_url': 'https://github.com/ma-xu/Rewrite-the-Stars',
+        **kwargs
+    }
+
+
+default_cfgs = generate_default_cfgs({
+    'starnet_s1.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s1.pth.tar',
+    ),
+    'starnet_s2.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s2.pth.tar',
+    ),
+    'starnet_s3.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s3.pth.tar',
+    ),
+    'starnet_s4.in1k': _cfg(
+        # hf_hub_id='timm/',
+        url='https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s4.pth.tar',
+    ),
+    'starnet_s050.untrained': _cfg(),
+    'starnet_s100.untrained': _cfg(),
+    'starnet_s150.untrained': _cfg(),
+})
+
+
+def _create_starnet(variant: str, pretrained: bool = False, **kwargs: Any) -> StarNet:
+    model = build_model_with_cfg(
+        StarNet, variant, pretrained,
+        pretrained_filter_fn=checkpoint_filter_fn,
+        feature_cfg=dict(out_indices=(0, 1, 2, 3), flatten_sequential=True),
+        **kwargs,
+    )
+    return model
+
+
+@register_model
+def starnet_s1(pretrained: bool = False, **kwargs: Any) -> StarNet:
+    model_args = dict(base_dim=24, depths=[2, 2, 8, 3])
+    return _create_starnet('starnet_s1', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def starnet_s2(pretrained: bool = False, **kwargs: Any) -> StarNet:
+    model_args = dict(base_dim=32, depths=[1, 2, 6, 2])
+    return _create_starnet('starnet_s2', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def starnet_s3(pretrained: bool = False, **kwargs: Any) -> StarNet:
+    model_args = dict(base_dim=32, depths=[2, 2, 8, 4])
+    return _create_starnet('starnet_s3', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def starnet_s4(pretrained: bool = False, **kwargs: Any) -> StarNet:
+    model_args = dict(base_dim=32, depths=[3, 3, 12, 5])
+    return _create_starnet('starnet_s4', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+# very small networks #
+@register_model
+def starnet_s050(pretrained: bool = False, **kwargs: Any) -> StarNet:
+    model_args = dict(base_dim=16, depths=[1, 1, 3, 1], mlp_ratio=3)
+    return _create_starnet('starnet_s050', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def starnet_s100(pretrained: bool = False, **kwargs: Any) -> StarNet:
+    model_args = dict(base_dim=20, depths=[1, 2, 4, 1], mlp_ratio=4)
+    return _create_starnet('starnet_s100', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def starnet_s150(pretrained: bool = False, **kwargs: Any) -> StarNet:
+    model_args = dict(base_dim=24, depths=[1, 2, 4, 2], mlp_ratio=3)
+    return _create_starnet('starnet_s150', pretrained=pretrained, **dict(model_args, **kwargs))

--- a/timm/models/starnet.py
+++ b/timm/models/starnet.py
@@ -34,7 +34,7 @@ class ConvBN(nn.Sequential):
             stride: int = 1,
             padding: int = 0,
             with_bn: bool = True,
-            **kwargs
+            **kwargs,
     ):
         super().__init__()
         self.add_module('conv', nn.Conv2d(
@@ -141,7 +141,10 @@ class StarNet(nn.Module):
     def group_matcher(self, coarse: bool = False) -> Dict[str, Any]:
         matcher = dict(
             stem=r'^stem\.\d+',
-            blocks=[(r'^stages\.(\d+)', None), (r'^norm', (99999,))]
+            blocks=[
+                (r'^stages\.(\d+)' if coarse else r'^stages\.(\d+)\.(\d+)', None),
+                (r'norm', (99999,))
+            ]
         )
         return matcher
 
@@ -206,7 +209,8 @@ class StarNet(nn.Module):
         if intermediates_only:
             return intermediates
 
-        x = self.norm(x)
+        if feat_idx == last_idx:
+            x = self.norm(x)
 
         return x, intermediates
 

--- a/timm/models/starnet.py
+++ b/timm/models/starnet.py
@@ -253,10 +253,7 @@ class StarNet(nn.Module):
 
 
 def checkpoint_filter_fn(state_dict: Dict[str, torch.Tensor], model: nn.Module) -> Dict[str, torch.Tensor]:
-    if 'state_dict' in state_dict:
-        state_dict = state_dict['state_dict']
-    out_dict = state_dict
-    return out_dict
+    return state_dict.get('state_dict', state_dict)
 
 
 def _cfg(url: str = '', **kwargs: Any) -> Dict[str, Any]:
@@ -274,20 +271,20 @@ def _cfg(url: str = '', **kwargs: Any) -> Dict[str, Any]:
 
 default_cfgs = generate_default_cfgs({
     'starnet_s1.in1k': _cfg(
-        # hf_hub_id='timm/',
-        url='https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s1.pth.tar',
+        hf_hub_id='timm/',
+        #url='https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s1.pth.tar',
     ),
     'starnet_s2.in1k': _cfg(
-        # hf_hub_id='timm/',
-        url='https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s2.pth.tar',
+        hf_hub_id='timm/',
+        #url='https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s2.pth.tar',
     ),
     'starnet_s3.in1k': _cfg(
-        # hf_hub_id='timm/',
-        url='https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s3.pth.tar',
+        hf_hub_id='timm/',
+        #url='https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s3.pth.tar',
     ),
     'starnet_s4.in1k': _cfg(
-        # hf_hub_id='timm/',
-        url='https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s4.pth.tar',
+        hf_hub_id='timm/',
+        #url='https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s4.pth.tar',
     ),
     'starnet_s050.untrained': _cfg(),
     'starnet_s100.untrained': _cfg(),

--- a/timm/models/swiftformer.py
+++ b/timm/models/swiftformer.py
@@ -480,7 +480,7 @@ class SwiftFormer(nn.Module):
             indices: Union[int, List[int]] = 1,
             prune_norm: bool = False,
             prune_head: bool = True,
-    ) -> List[int]:
+    ):
         """ Prune layers not required for specified intermediates.
         """
         take_indices, max_index = feature_take_indices(len(self.stages), indices)
@@ -561,10 +561,10 @@ def _cfg(url: str = '', **kwargs: Any) -> Dict[str, Any]:
 
 
 default_cfgs = generate_default_cfgs({
-    # 'swiftformer_xs.dist_in1k': _cfg(url=''),
-    # 'swiftformer_s.dist_in1k': _cfg(url=''),
-    # 'swiftformer_l1.dist_in1k': _cfg(url=''),
-    # 'swiftformer_l3.dist_in1k': _cfg(url=''),
+    # 'swiftformer_xs.dist_in1k': _cfg(hf_hub_id='timm/'),
+    # 'swiftformer_s.dist_in1k': _cfg(hf_hub_id='timm/'),
+    # 'swiftformer_l1.dist_in1k': _cfg(hf_hub_id='timm/'),
+    # 'swiftformer_l3.dist_in1k': _cfg(hf_hub_id='timm/'),
     'swiftformer_xs.untrained': _cfg(),
     'swiftformer_s.untrained': _cfg(),
     'swiftformer_l1.untrained': _cfg(),
@@ -588,18 +588,18 @@ def swiftformer_xs(pretrained: bool = False, **kwargs: Any) -> SwiftFormer:
     return _create_swiftformer('swiftformer_xs', pretrained=pretrained, **dict(model_args, **kwargs))
 
 
-# @register_model
-# def swiftformer_s(pretrained: bool = False, **kwargs: Any) -> SwiftFormer:
-#     model_args = dict(layers=[3, 3, 9, 6], embed_dims=[48, 64, 168, 224])
-#     return _create_swiftformer('swiftformer_s', pretrained=pretrained, **dict(model_args, **kwargs))
+@register_model
+def swiftformer_s(pretrained: bool = False, **kwargs: Any) -> SwiftFormer:
+    model_args = dict(layers=[3, 3, 9, 6], embed_dims=[48, 64, 168, 224])
+    return _create_swiftformer('swiftformer_s', pretrained=pretrained, **dict(model_args, **kwargs))
 
-# @register_model
-# def swiftformer_l1(pretrained: bool = False, **kwargs: Any) -> SwiftFormer:
-#     model_args = dict(layers=[4, 3, 10, 5], embed_dims=[48, 96, 192, 384])
-#     return _create_swiftformer('swiftformer_l1', pretrained=pretrained, **dict(model_args, **kwargs))
+@register_model
+def swiftformer_l1(pretrained: bool = False, **kwargs: Any) -> SwiftFormer:
+    model_args = dict(layers=[4, 3, 10, 5], embed_dims=[48, 96, 192, 384])
+    return _create_swiftformer('swiftformer_l1', pretrained=pretrained, **dict(model_args, **kwargs))
 
 
-# @register_model
-# def swiftformer_l3(pretrained: bool = False, **kwargs: Any) -> SwiftFormer:
-#     model_args = dict(layers=[4, 4, 12, 6], embed_dims=[64, 128, 320, 512])
-#     return _create_swiftformer('swiftformer_l3', pretrained=pretrained, **dict(model_args, **kwargs))
+@register_model
+def swiftformer_l3(pretrained: bool = False, **kwargs: Any) -> SwiftFormer:
+    model_args = dict(layers=[4, 4, 12, 6], embed_dims=[64, 128, 320, 512])
+    return _create_swiftformer('swiftformer_l3', pretrained=pretrained, **dict(model_args, **kwargs))

--- a/timm/models/swiftformer.py
+++ b/timm/models/swiftformer.py
@@ -1,0 +1,605 @@
+"""SwiftFormer
+SwiftFormer: Efficient Additive Attention for Transformer-based Real-time Mobile Vision Applications
+Code: https://github.com/Amshaker/SwiftFormer
+Paper: https://arxiv.org/pdf/2303.15446
+
+@InProceedings{Shaker_2023_ICCV,
+    author    = {Shaker, Abdelrahman and Maaz, Muhammad and Rasheed, Hanoona and Khan, Salman and Yang, Ming-Hsuan and Khan, Fahad Shahbaz},
+    title     = {SwiftFormer: Efficient Additive Attention for Transformer-based Real-time Mobile Vision Applications},
+    booktitle = {Proceedings of the IEEE/CVF International Conference on Computer Vision (ICCV)},
+    year      = {2023},
+}
+"""
+import re
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
+from timm.layers import DropPath, Linear, LayerType, to_2tuple, trunc_normal_
+from ._builder import build_model_with_cfg
+from ._features import feature_take_indices
+from ._manipulate import checkpoint_seq
+from ._registry import generate_default_cfgs, register_model
+
+__all__ = ['SwiftFormer']
+
+
+class LayerScale2d(nn.Module):
+    def __init__(self, dim: int, init_values: float = 1e-5, inplace: bool = False):
+        super().__init__()
+        self.inplace = inplace
+        self.gamma = nn.Parameter(
+            init_values * torch.ones(dim, 1, 1), requires_grad=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x.mul_(self.gamma) if self.inplace else x * self.gamma
+    
+
+class Embedding(nn.Module):
+    """
+    Patch Embedding that is implemented by a layer of conv.
+    Input: tensor in shape [B, C, H, W]
+    Output: tensor in shape [B, C, H/stride, W/stride]
+    """
+    def __init__(
+            self,
+            in_chans: int = 3,
+            embed_dim: int = 768,
+            patch_size: int = 16,
+            stride: int = 16,
+            padding: int = 0,
+            norm_layer: LayerType = nn.BatchNorm2d,
+    ):
+        super().__init__()
+        patch_size = to_2tuple(patch_size)
+        stride = to_2tuple(stride)
+        padding = to_2tuple(padding)
+        self.proj = nn.Conv2d(in_chans, embed_dim, patch_size, stride, padding)
+        self.norm = norm_layer(embed_dim) if norm_layer else nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.proj(x)
+        x = self.norm(x)
+        return x
+
+
+class ConvEncoder(nn.Module):
+    """
+    Implementation of ConvEncoder with 3*3 and 1*1 convolutions.
+    Input: tensor with shape [B, C, H, W]
+    Output: tensor with shape [B, C, H, W]
+    """
+    def __init__(
+            self, 
+            dim: int,
+            hidden_dim: int = 64,
+            kernel_size: int = 3,
+            drop_path: float = 0.,
+            act_layer: LayerType = nn.GELU,
+            norm_layer: LayerType = nn.BatchNorm2d,
+            use_layer_scale: bool = True,
+    ):
+        super().__init__()
+        self.dwconv = nn.Conv2d(dim, dim, kernel_size, padding=kernel_size // 2, groups=dim)
+        self.norm = norm_layer(dim)
+        self.pwconv1 = nn.Conv2d(dim, hidden_dim, 1)
+        self.act = act_layer()
+        self.pwconv2 = nn.Conv2d(hidden_dim, dim, 1)
+        self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
+        self.layer_scale = LayerScale2d(dim, 1) if use_layer_scale else nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        input = x
+        x = self.dwconv(x)
+        x = self.norm(x)
+        x = self.pwconv1(x)
+        x = self.act(x)
+        x = self.pwconv2(x)
+        x = self.layer_scale(x)
+        x = input + self.drop_path(x)
+        return x
+
+
+class Mlp(nn.Module):
+    """
+    Implementation of MLP layer with 1*1 convolutions.
+    Input: tensor with shape [B, C, H, W]
+    Output: tensor with shape [B, C, H, W]
+    """
+    def __init__(
+            self,
+            in_features: int,
+            hidden_features: Optional[int] = None,
+            out_features: Optional[int] = None,
+            act_layer: LayerType = nn.GELU,
+            norm_layer: LayerType = nn.BatchNorm2d,
+            drop: float = 0.,
+    ):
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.norm1 = norm_layer(in_features)
+        self.fc1 = nn.Conv2d(in_features, hidden_features, 1)
+        self.act = act_layer()
+        self.fc2 = nn.Conv2d(hidden_features, out_features, 1)
+        self.drop = nn.Dropout(drop)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.norm1(x)
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop(x)
+        x = self.fc2(x)
+        x = self.drop(x)
+        return x
+
+
+class EfficientAdditiveAttention(nn.Module):
+    """
+    Efficient Additive Attention module for SwiftFormer.
+    Input: tensor in shape [B, C, H, W]
+    Output: tensor in shape [B, C, H, W]
+    """
+    def __init__(self, in_dims: int = 512, token_dim: int = 256, num_heads: int = 1):
+        super().__init__()
+        self.scale_factor = token_dim ** -0.5
+        self.to_query = nn.Linear(in_dims, token_dim * num_heads)
+        self.to_key = nn.Linear(in_dims, token_dim * num_heads)
+
+        self.w_g = nn.Parameter(torch.randn(token_dim * num_heads, 1))
+        
+        self.proj = nn.Linear(token_dim * num_heads, token_dim * num_heads)
+        self.final = nn.Linear(token_dim * num_heads, token_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, _, H, W = x.shape
+        x = x.flatten(2).permute(0, 2, 1)
+
+        query = F.normalize(self.to_query(x), dim=-1)
+        key = F.normalize(self.to_key(x), dim=-1)
+
+        attn = F.normalize(query @ self.w_g * self.scale_factor, dim=1)
+        attn = torch.sum(attn * query, dim=1, keepdim=True)
+
+        out = self.proj(attn * key) + query
+        out = self.final(out).permute(0, 2, 1).reshape(B, -1, H, W)
+        return out
+
+
+class LocalRepresentation(nn.Module):
+    """
+    Local Representation module for SwiftFormer that is implemented by 3*3 depth-wise and point-wise convolutions.
+    Input: tensor in shape [B, C, H, W]
+    Output: tensor in shape [B, C, H, W]
+    """
+    def __init__(
+            self,
+            dim: int,
+            kernel_size: int = 3,
+            drop_path: float = 0.,
+            use_layer_scale: bool = True,
+            act_layer: LayerType = nn.GELU,
+            norm_layer: LayerType = nn.BatchNorm2d,
+    ):
+        super().__init__()
+        self.dwconv = nn.Conv2d(dim, dim, kernel_size, padding=kernel_size // 2, groups=dim)
+        self.norm = norm_layer(dim)
+        self.pwconv1 = nn.Conv2d(dim, dim, kernel_size=1)
+        self.act = act_layer()
+        self.pwconv2 = nn.Conv2d(dim, dim, kernel_size=1)
+        self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
+        self.layer_scale = LayerScale2d(dim, 1) if use_layer_scale else nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        skip = x
+        x = self.dwconv(x)
+        x = self.norm(x)
+        x = self.pwconv1(x)
+        x = self.act(x)
+        x = self.pwconv2(x)
+        x = self.layer_scale(x)
+        x = skip + self.drop_path(x)
+        return x
+    
+
+class Block(nn.Module):
+    """
+    SwiftFormer Encoder Block for SwiftFormer. It consists of :
+    (1) Local representation module, (2) EfficientAdditiveAttention, and (3) MLP block.
+    Input: tensor in shape [B, C, H, W]
+    Output: tensor in shape [B, C, H, W]
+    """
+    def __init__(
+            self,
+            dim: int,
+            mlp_ratio: float = 4.,
+            drop_rate: float = 0.,
+            drop_path: float = 0.,
+            act_layer: LayerType = nn.GELU,
+            norm_layer: LayerType = nn.BatchNorm2d,
+            use_layer_scale: bool = True,
+            layer_scale_init_value: float = 1e-5,
+    ):
+        super().__init__()
+        self.local_representation = LocalRepresentation(
+            dim=dim, 
+            use_layer_scale=use_layer_scale,
+            act_layer=act_layer,
+            norm_layer=norm_layer,
+        )
+        self.attn = EfficientAdditiveAttention(in_dims=dim, token_dim=dim)
+        self.linear = Mlp(
+            in_features=dim,
+            hidden_features=int(dim * mlp_ratio),
+            act_layer=act_layer,
+            norm_layer=norm_layer, 
+            drop=drop_rate,
+        )
+        self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
+        self.layer_scale_1 = LayerScale2d(dim, layer_scale_init_value) \
+            if use_layer_scale else nn.Identity()
+        self.layer_scale_2 = LayerScale2d(dim, layer_scale_init_value) \
+            if use_layer_scale else nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.local_representation(x)
+        x = x + self.drop_path(self.layer_scale_1(self.attn(x)))
+        x = x + self.drop_path(self.layer_scale_2(self.linear(x)))
+        return x
+
+
+class Stage(nn.Module):
+    """
+    Implementation of each SwiftFormer stages. Here, SwiftFormerEncoder used as the last block in all stages, while ConvEncoder used in the rest of the blocks.
+    Input: tensor in shape [B, C, H, W]
+    Output: tensor in shape [B, C, H, W]
+    """
+    def __init__(
+            self,
+            dim: int,
+            index: int,
+            layers: List[int],
+            mlp_ratio: float = 4.,
+            act_layer: LayerType = nn.GELU,
+            norm_layer: LayerType = nn.BatchNorm2d,
+            drop_rate: float = 0.,
+            drop_path_rate: float = 0.,
+            use_layer_scale: bool = True,
+            layer_scale_init_value: float = 1e-5,
+            downsample: Optional[LayerType] = None,
+    ):
+        super().__init__()
+        self.grad_checkpointing = False
+        self.downsample = downsample if downsample is not None else nn.Identity()
+
+        blocks = []
+        for block_idx in range(layers[index]):
+            block_dpr = drop_path_rate * (block_idx + sum(layers[:index])) / (sum(layers) - 1)
+            if layers[index] - block_idx <= 1:
+                blocks.append(Block(
+                    dim, 
+                    mlp_ratio=mlp_ratio,
+                    drop_rate=drop_rate,
+                    drop_path=block_dpr,
+                    act_layer=act_layer,
+                    norm_layer=norm_layer,
+                    use_layer_scale=use_layer_scale,
+                    layer_scale_init_value=layer_scale_init_value,
+                ))
+            else:
+                blocks.append(ConvEncoder(
+                    dim=dim, 
+                    hidden_dim=int(mlp_ratio * dim), 
+                    kernel_size=3,
+                    drop_path=block_dpr,
+                    act_layer=act_layer,
+                    norm_layer=norm_layer,
+                    use_layer_scale=use_layer_scale,
+                ))
+        self.blocks = nn.Sequential(*blocks)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.downsample(x)
+        if self.grad_checkpointing and not torch.jit.is_scripting():
+            x = checkpoint_seq(self.blocks, x, flatten=True)
+        else:
+            x = self.blocks(x)
+        return x
+
+
+class SwiftFormer(nn.Module):
+    def __init__(
+            self,
+            layers: List[int] = [3, 3, 6, 4],
+            embed_dims: List[int] = [48, 56, 112, 220],
+            mlp_ratios: int = 4,
+            downsamples: List[bool] = [False, True, True, True],
+            act_layer: LayerType = nn.GELU,
+            down_patch_size: int = 3,
+            down_stride: int = 2,
+            down_pad: int = 1,
+            num_classes: int = 1000,
+            drop_rate: float = 0.,
+            drop_path_rate: float = 0.,
+            use_layer_scale: bool = True,
+            layer_scale_init_value: float = 1e-5,
+            global_pool: str = 'avg',
+            output_stride: int = 32,
+            in_chans: int = 3,
+            **kwargs,
+    ):
+        super().__init__()
+        assert output_stride == 32
+        self.num_classes = num_classes
+        self.global_pool = global_pool
+        self.feature_info = []
+
+        self.stem = nn.Sequential(
+            nn.Conv2d(in_chans, embed_dims[0] // 2, 3, 2, 1),
+            nn.BatchNorm2d(embed_dims[0] // 2),
+            nn.ReLU(),
+            nn.Conv2d(embed_dims[0] // 2, embed_dims[0], 3, 2, 1),
+            nn.BatchNorm2d(embed_dims[0]),
+            nn.ReLU(),
+        )
+        prev_dim = embed_dims[0]
+
+        stages = []
+        for i in range(len(layers)):
+            downsample = Embedding(
+                in_chans=prev_dim,
+                embed_dim=embed_dims[i],
+                patch_size=down_patch_size,
+                stride=down_stride,
+                padding=down_pad,
+            ) if downsamples[i] else nn.Identity()
+            stage = Stage(
+                dim=embed_dims[i], 
+                index=i, 
+                layers=layers, 
+                mlp_ratio=mlp_ratios,
+                act_layer=act_layer,
+                drop_rate=drop_rate,
+                drop_path_rate=drop_path_rate,
+                use_layer_scale=use_layer_scale,
+                layer_scale_init_value=layer_scale_init_value,
+                downsample=downsample,
+            )
+            prev_dim = embed_dims[i]
+            stages.append(stage)
+            self.feature_info += [dict(num_chs=embed_dims[i], reduction=2**(i+2), module=f'stages.{i}')]
+        self.stages = nn.Sequential(*stages)
+
+        # Classifier head
+        self.num_features  = self.head_hidden_size = out_chs = embed_dims[-1]
+        self.norm = nn.BatchNorm2d(out_chs)
+        self.head_drop = nn.Dropout(drop_rate)
+        self.head = Linear(out_chs, num_classes) if num_classes > 0 else nn.Identity()
+        # assuming model is always distilled (valid for current checkpoints, will split def if that changes)
+        self.head_dist = Linear(out_chs, num_classes) if num_classes > 0 else nn.Identity()
+        self.distilled_training = False  # must set this True to train w/ distillation token
+        self._initialize_weights()
+
+    def _initialize_weights(self):
+        for name, m in self.named_modules():
+            if isinstance(m, nn.Linear):
+                trunc_normal_(m.weight, std=.02)
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.Conv2d):
+                trunc_normal_(m.weight, std=.02)
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+
+    @torch.jit.ignore
+    def no_weight_decay(self) -> Set:
+        return set()
+
+    @torch.jit.ignore
+    def group_matcher(self, coarse: bool = False) -> Dict[str, Any]:
+        matcher = dict(
+            stem=r'^stem',  # stem and embed
+            blocks=[(r'^stages\.(\d+)', None), (r'^norm', (99999,))]
+        )
+        return matcher
+
+    @torch.jit.ignore
+    def set_grad_checkpointing(self, enable: bool = True):
+        for s in self.stages:
+            s.grad_checkpointing = enable
+
+    @torch.jit.ignore
+    def get_classifier(self) -> Tuple[nn.Module, nn.Module]:
+        return self.head, self.head_dist
+
+    def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None):
+        self.num_classes = num_classes
+        if global_pool is not None:
+            self.global_pool = global_pool
+        self.head = Linear(self.num_features, num_classes) if num_classes > 0 else nn.Identity()
+        self.head_dist = Linear(self.num_features, num_classes) if num_classes > 0 else nn.Identity()
+
+    @torch.jit.ignore
+    def set_distilled_training(self, enable: bool = True):
+        self.distilled_training = enable
+    
+    def forward_intermediates(
+            self,
+            x: torch.Tensor,
+            indices: Optional[Union[int, List[int]]] = None,
+            norm: bool = False,
+            stop_early: bool = False,
+            output_fmt: str = 'NCHW',
+            intermediates_only: bool = False,
+    ) -> Union[List[torch.Tensor], Tuple[torch.Tensor, List[torch.Tensor]]]:
+        """ Forward features that returns intermediates.
+
+        Args:
+            x: Input image tensor
+            indices: Take last n blocks if int, all if None, select matching indices if sequence
+            norm: Apply norm layer to compatible intermediates
+            stop_early: Stop iterating over blocks when last desired intermediate hit
+            output_fmt: Shape of intermediate feature outputs
+            intermediates_only: Only return intermediate features
+        Returns:
+
+        """
+        assert output_fmt in ('NCHW',), 'Output shape must be NCHW.'
+        intermediates = []
+        take_indices, max_index = feature_take_indices(len(self.stages), indices)
+        last_idx = len(self.stages) - 1
+
+        # forward pass
+        x = self.stem(x)
+        if torch.jit.is_scripting() or not stop_early:  # can't slice blocks in torchscript
+            stages = self.stages
+        else:
+            stages = self.stages[:max_index + 1]
+
+        for feat_idx, stage in enumerate(stages):
+            x = stage(x)
+            if feat_idx in take_indices:
+                if norm and feat_idx == last_idx:
+                    x_inter = self.norm(x)  # applying final norm last intermediate
+                else:
+                    x_inter = x
+                intermediates.append(x_inter) 
+
+        if intermediates_only:
+            return intermediates
+
+        x = self.norm(x)
+
+        return x, intermediates
+
+    def prune_intermediate_layers(
+            self,
+            indices: Union[int, List[int]] = 1,
+            prune_norm: bool = False,
+            prune_head: bool = True,
+    ) -> List[int]:
+        """ Prune layers not required for specified intermediates.
+        """
+        take_indices, max_index = feature_take_indices(len(self.stages), indices)
+        self.stages = self.stages[:max_index + 1]  # truncate blocks w/ stem as idx 0
+        if prune_norm:
+            self.norm = nn.Identity()
+        if prune_head:
+            self.reset_classifier(0, '')
+        return take_indices
+
+    def forward_features(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.stem(x)
+        x = self.stages(x)
+        x = self.norm(x)
+        return x
+
+    def forward_head(
+            self,
+            x: torch.Tensor,
+            pre_logits: bool = False,
+    ) -> Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
+        if self.global_pool == 'avg':
+            x = x.mean(dim=(2, 3))
+        x = self.head_drop(x)
+        if pre_logits:
+            return x
+        x, x_dist = self.head(x), self.head_dist(x)
+        if self.distilled_training and self.training and not torch.jit.is_scripting():
+            # only return separate classification predictions when training in distilled mode
+            return x, x_dist
+        else:
+            # during standard train/finetune, inference average the classifier predictions
+            return (x + x_dist) / 2
+
+    def forward(self, x: torch.Tensor) -> Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
+        x = self.forward_features(x)
+        x = self.forward_head(x)
+        return x
+
+
+def checkpoint_filter_fn(state_dict: Dict[str, torch.Tensor], model: nn.Module) -> Dict[str, torch.Tensor]:
+    if 'model' in state_dict:
+        state_dict = state_dict['model']
+
+    out_dict = {}
+    for k, v in state_dict.items():
+        k = k.replace('patch_embed.', 'stem.')
+        k = k.replace('dist_head.', 'head_dist.')
+        k = k.replace('attn.Proj.', 'attn.proj.')
+        k = k.replace('.layer_scale_1', '.layer_scale_1.gamma')
+        k = k.replace('.layer_scale_2', '.layer_scale_2.gamma')
+        k = re.sub(r'\.layer_scale(?=$|\.)', '.layer_scale.gamma', k)
+        m = re.match(r'^network\.(\d+)\.(.*)', k)
+        if m:
+            n_idx, rest = int(m.group(1)), m.group(2)
+            stage_idx = n_idx // 2
+            if n_idx % 2 == 0:
+                k = f'stages.{stage_idx}.blocks.{rest}'
+            else:
+                k = f'stages.{stage_idx+1}.downsample.{rest}'
+
+        out_dict[k] = v
+    return out_dict
+
+
+def _cfg(url: str = '', **kwargs: Any) -> Dict[str, Any]:
+    return {
+        'url': url,
+        'num_classes': 1000, 'input_size': (3, 224, 224), 'pool_size': None, 'fixed_input_size': True,
+        'crop_pct': .95, 'interpolation': 'bicubic',
+        'mean': IMAGENET_DEFAULT_MEAN, 'std': IMAGENET_DEFAULT_STD,
+        'first_conv': 'stem.0', 'classifier': ('head', 'head_dist'),
+        'paper_ids': 'arXiv:2303.15446',
+        'paper_name': 'SwiftFormer: Efficient Additive Attention for Transformer-based Real-time Mobile Vision Applications',
+        'origin_url': 'https://github.com/Amshaker/SwiftFormer',
+        **kwargs
+    }
+
+
+default_cfgs = generate_default_cfgs({
+    # 'swiftformer_xs.dist_in1k': _cfg(url=''),
+    # 'swiftformer_s.dist_in1k': _cfg(url=''),
+    # 'swiftformer_l1.dist_in1k': _cfg(url=''),
+    # 'swiftformer_l3.dist_in1k': _cfg(url=''),
+    'swiftformer_xs.untrained': _cfg(),
+    'swiftformer_s.untrained': _cfg(),
+    'swiftformer_l1.untrained': _cfg(),
+    'swiftformer_l3.untrained': _cfg(),
+})
+
+
+def _create_swiftformer(variant: str, pretrained: bool = False, **kwargs: Any) -> SwiftFormer:
+    model = build_model_with_cfg(
+        SwiftFormer, variant, pretrained,
+        pretrained_filter_fn=checkpoint_filter_fn,
+        feature_cfg=dict(out_indices=(0, 1, 2, 3), flatten_sequential=True),
+        **kwargs,
+    )
+    return model
+
+
+@register_model
+def swiftformer_xs(pretrained: bool = False, **kwargs: Any) -> SwiftFormer:
+    model_args = dict(layers=[3, 3, 6, 4], embed_dims=[48, 56, 112, 220])
+    return _create_swiftformer('swiftformer_xs', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+# @register_model
+# def swiftformer_s(pretrained: bool = False, **kwargs: Any) -> SwiftFormer:
+#     model_args = dict(layers=[3, 3, 9, 6], embed_dims=[48, 64, 168, 224])
+#     return _create_swiftformer('swiftformer_s', pretrained=pretrained, **dict(model_args, **kwargs))
+
+# @register_model
+# def swiftformer_l1(pretrained: bool = False, **kwargs: Any) -> SwiftFormer:
+#     model_args = dict(layers=[4, 3, 10, 5], embed_dims=[48, 96, 192, 384])
+#     return _create_swiftformer('swiftformer_l1', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+# @register_model
+# def swiftformer_l3(pretrained: bool = False, **kwargs: Any) -> SwiftFormer:
+#     model_args = dict(layers=[4, 4, 12, 6], embed_dims=[64, 128, 320, 512])
+#     return _create_swiftformer('swiftformer_l3', pretrained=pretrained, **dict(model_args, **kwargs))

--- a/timm/models/swiftformer.py
+++ b/timm/models/swiftformer.py
@@ -497,11 +497,7 @@ class SwiftFormer(nn.Module):
         x = self.norm(x)
         return x
 
-    def forward_head(
-            self,
-            x: torch.Tensor,
-            pre_logits: bool = False,
-    ) -> Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
+    def forward_head(self, x: torch.Tensor, pre_logits: bool = False):
         if self.global_pool == 'avg':
             x = x.mean(dim=(2, 3))
         x = self.head_drop(x)
@@ -515,7 +511,7 @@ class SwiftFormer(nn.Module):
             # during standard train/finetune, inference average the classifier predictions
             return (x + x_dist) / 2
 
-    def forward(self, x: torch.Tensor) -> Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
+    def forward(self, x: torch.Tensor):
         x = self.forward_features(x)
         x = self.forward_head(x)
         return x

--- a/timm/models/swiftformer.py
+++ b/timm/models/swiftformer.py
@@ -523,8 +523,9 @@ class SwiftFormer(nn.Module):
 
 
 def checkpoint_filter_fn(state_dict: Dict[str, torch.Tensor], model: nn.Module) -> Dict[str, torch.Tensor]:
-    if 'model' in state_dict:
-        state_dict = state_dict['model']
+    state_dict = state_dict.get('model', state_dict)
+    if 'stem.0.weight' in state_dict:
+        return state_dict
 
     out_dict = {}
     for k, v in state_dict.items():
@@ -562,14 +563,18 @@ def _cfg(url: str = '', **kwargs: Any) -> Dict[str, Any]:
 
 
 default_cfgs = generate_default_cfgs({
-    # 'swiftformer_xs.dist_in1k': _cfg(hf_hub_id='timm/'),
-    # 'swiftformer_s.dist_in1k': _cfg(hf_hub_id='timm/'),
-    # 'swiftformer_l1.dist_in1k': _cfg(hf_hub_id='timm/'),
-    # 'swiftformer_l3.dist_in1k': _cfg(hf_hub_id='timm/'),
-    'swiftformer_xs.untrained': _cfg(),
-    'swiftformer_s.untrained': _cfg(),
-    'swiftformer_l1.untrained': _cfg(),
-    'swiftformer_l3.untrained': _cfg(),
+    'swiftformer_xs.dist_in1k': _cfg(
+        hf_hub_id='timm/',
+    ),
+    'swiftformer_s.dist_in1k': _cfg(
+        hf_hub_id='timm/'
+    ),
+    'swiftformer_l1.dist_in1k': _cfg(
+        hf_hub_id='timm/'
+    ),
+    'swiftformer_l3.dist_in1k': _cfg(
+        hf_hub_id='timm/'
+    ),
 })
 
 

--- a/timm/models/swiftformer.py
+++ b/timm/models/swiftformer.py
@@ -471,7 +471,8 @@ class SwiftFormer(nn.Module):
         if intermediates_only:
             return intermediates
 
-        x = self.norm(x)
+        if feat_idx == last_idx:
+            x = self.norm(x)
 
         return x, intermediates
 

--- a/timm/models/swiftformer.py
+++ b/timm/models/swiftformer.py
@@ -402,7 +402,11 @@ class SwiftFormer(nn.Module):
     def group_matcher(self, coarse: bool = False) -> Dict[str, Any]:
         matcher = dict(
             stem=r'^stem',  # stem and embed
-            blocks=[(r'^stages\.(\d+)', None), (r'^norm', (99999,))]
+            blocks=r'^stages\.(\d+)' if coarse else [
+                (r'^stages\.(\d+).downsample', (0,)),
+                (r'^stages\.(\d+)\.blocks\.(\d+)', None),
+                (r'^norm', (99999,)),
+            ]
         )
         return matcher
 


### PR DESCRIPTION
## New Model
- [(ICCV2023) SwiftFormer: Efficient Additive Attention for Transformer-based Real-time Mobile Vision Applications](https://github.com/Amshaker/SwiftFormer) 
- [(CVPR2023) Run, Don’t Walk: Chasing Higher FLOPS for Faster Neural Networks](https://github.com/JierunChen/FasterNet)
- [(CVPR2024) SHViT: Single-Head Vision Transformer with Memory Efficient](https://github.com/ysj9909/SHViT)
- [(CVPR2024) Rewrite the Stars](https://github.com/ma-xu/Rewrite-the-Stars)
- [GhostNetV3: Exploring the Training Strategies for Compact Models](https://github.com/huawei-noah/Efficient-AI-Backbones/tree/master/ghostnetv3_pytorch)

##  Model Request
resolve #2450 

## Result
| Model           | Acc@1  | MACs    | Params  | GPU Throughput | CPU Throughput | iOS NPU Latency | Android NPU Latency |
| --------------- | ------ | ------- | ------- | -------------- | -------------- | --------------- | ------------------- |
| [swiftformer_xs](https://drive.google.com/file/d/12RchxzyiJrtZS-2Bur9k4wcRQMItA43S/view?usp=sharing)  | 75.586 | 603.77M | 3.48M   | 3356.03        | 146.25         | 0.63            | 3.288               |
| [swiftformer_s](https://drive.google.com/file/d/1awpcXAaHH38WaHrOmUM8updxQazUZ3Nb/view?usp=sharing)   | 78.466 | 986.19M | 6.09M   | 2519.29        | 123.62         | 0.76            | 3.386               |
| [swiftformer_l1](https://drive.google.com/file/d/1SDzauVmpR5uExkOv3ajxdwFnP-Buj9Uo/view?usp=sharing)  | 80.902 | 1.60G   | 12.06M  | 1832.04        | 100.77         | 1.07            | 3.810               |
| [swiftformer_l3](https://drive.google.com/file/d/1DAxMe6FlnZBBIpR-HYIDfFLWJzIgiF0Y/view?usp=sharing)  | 83.000 | 4.01G   | 28.49M  | 969.61         | 43.39          | 1.88            | 4.700               |
| [fasternet_t0](https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_t0-epoch.281-val_acc1.71.9180.pth)    | 71.904 | 335.69M | 3.91M   | 8924.14        | 461.35         | 0.50            | 0.256               |
| [fasternet_t1](https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_t1-epoch.291-val_acc1.76.2180.pth)    | 76.210 | 850.94M | 7.60M   | 4939.89        | 262.55         | 0.67            | 0.384               |
| [fasternet_t2](https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_t2-epoch.289-val_acc1.78.8860.pth)    | 78.896 | 1.90G   | 14.98M  | 2548.34        | 133.69         | 1.04            | 0.641               |
| [fasternet_s](https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_s-epoch.299-val_acc1.81.2840.pth)     | 81.290 | 4.55G   | 31.18M  | 1219.00        | 62.62          | 1.88            | 1.257               |
| [fasternet_m](https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_m-epoch.291-val_acc1.82.9620.pth)     | 82.966 | 8.72G   | 53.52M  | 605.40         | 28.72          |    -             | 2.456               |
| [fasternet_l](https://github.com/JierunChen/FasterNet/releases/download/v1.0/fasternet_l-epoch.299-val_acc1.83.5060.pth)     | 83.506 | 15.50G  | 93.47M  | 381.80         | 17.43          |       -          | 4.505               |
| [shvit_s1](https://github.com/ysj9909/SHViT/releases/download/v1.0/shvit_s1.pth)        | 72.778 | 241.47M | 6.31M   | 13566.14       | 494.77         | 0.60            | 0.461               |
| [shvit_s2](https://github.com/ysj9909/SHViT/releases/download/v1.0/shvit_s2.pth)        | 75.192 | 365.58M | 11.45M  | 10214.81       | 413.26         | 0.81            | 0.523               |
| [shvit_s3](https://github.com/ysj9909/SHViT/releases/download/v1.0/shvit_s3.pth)        | 77.340 | 600.83M | 14.21M  | 6676.91        | 299.91         | 0.96            | 0.625               |
| [shvit_s4](https://github.com/ysj9909/SHViT/releases/download/v1.0/shvit_s4.pth)        | 79.378 | 986.63M | 16.55M  | 4149.87        | 177.38         | 1.09            | 0.798               |
| [starnet_s1](https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s1.pth.tar)      | 73.564 | 422.89M | 2.87M   | 3859.64        | 233.59         | 0.48            | 0.471               |
| [starnet_s2](https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s2.pth.tar)      | 74.660 | 545.05M | 3.68M   | 3888.33        | 203.43         | 0.51            | 0.438               |
| [starnet_s3](https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s3.pth.tar)      | 77.380 | 755.38M | 5.75M   | 2760.39        | 150.84         | 0.66            | 0.548               |
| [starnet_s4](https://github.com/ma-xu/Rewrite-the-Stars/releases/download/checkpoints_v1/starnet_s4.pth.tar)      | 78.838 | 1.05G   | 7.48M   | 1938.80        | 112.58         | 0.81            | 0.720               |
| [ghostnetv3_100](https://github.com/huawei-noah/Efficient-AI-Backbones/releases/download/GhostNetV3/ghostnetv3-1.0.pth.tar)    | 76.928   | 168.00M | 6.15M  | 3467.852       | 168.138      |  -  | 0.668               |

- Only SHViT S4 uses (256, 256) input image size
- SwiftFormer weight is on google drive

### Param / MACs / Throughput

![Figure_1](https://github.com/user-attachments/assets/182ca98d-9833-40ed-9a2f-0efd14f2a808)

### NPU  Latency
- iOS NPU: Apple iPhone 14 Pro Max / iOS 18.5 / A16
- Android NPU: Samsung S24 / Android 14 / Snapdragon® 8 Gen 3 | SM8650

![Figure_2](https://github.com/user-attachments/assets/62efcc07-802e-430a-944d-5476a990140a)

- iOS latency reported for iPhone 14 Pro Max (iOS 18.5) uses the benchmark tool from [Xcode 16.3](https://developer.apple.com/videos/play/wwdc2022/10027/)

- Android latency reported for Samsung Galaxy S24 (Android 14) uses the benchmark tool from [Qualcomm® AI Hub Models](https://github.com/quic/ai-hub-models)

<details>

<summary> Measure Android Latency </summary>

```python
import torch
import timm
from timm.utils.model import reparameterize_model
import qai_hub as hub


def latency_android(name, img_size=224):
    torch_model = timm.create_model(name)
    torch_model.eval()
    torch_model = reparameterize_model(torch_model)
    input_shape = (1, 3, img_size, img_size)
    example_input = torch.rand(input_shape)
    traced_model = torch.jit.trace(torch_model, example_input)
    compile_job = hub.submit_compile_job(
        model=traced_model,
        device=hub.Device("Samsung Galaxy S24 (Family)"),
        input_specs=dict(image=input_shape),
    )
    target_model = compile_job.get_target_model()
    profile_job = hub.submit_profile_job(
        model=target_model,
        device=hub.Device("Samsung Galaxy S24 (Family)"),
    )
    profile_result = profile_job.download_profile()
    latency_ms = profile_result["execution_summary"]["estimated_inference_time"] / 1000
    print(f"{name} 📊 Latency: {latency_ms:.3f} ms")


if __name__ == '__main__':
    name_list = timm.list_models('shvit*')
    print(name_list)
    for name in name_list:
        latency_android(name)
```

</details>
