### PR TITLE
Fix layer decay to work as intended with optimizers

### DIFF
--- a/timm/optim/_param_groups.py
+++ b/timm/optim/_param_groups.py
@@ -92,7 +92,12 @@ def param_groups_layer_decay(
         layer_map = auto_group_layers(model)
     num_layers = max(layer_map.values()) + 1
     layer_max = num_layers - 1
-    layer_scales = list(layer_decay ** (layer_max - i) for i in range(num_layers))
+    
+    # no decay: layer_scale is zero
+    if layer_decay == 0:
+        layer_scales = [1.0] * num_layers
+    else:
+        layer_scales = [layer_decay ** (layer_max - i) for i in range(num_layers)]
 
     for name, param in model.named_parameters():
         if not param.requires_grad:

--- a/timm/optim/_param_groups.py
+++ b/timm/optim/_param_groups.py
@@ -68,6 +68,7 @@ _layer_map = auto_group_layers  # backward compat
 
 def param_groups_layer_decay(
         model: nn.Module,
+        lr: float,
         weight_decay: float = 0.05,
         no_weight_decay_list: Collection[str] = (),
         weight_decay_exclude_1d: bool = True,
@@ -111,12 +112,12 @@ def param_groups_layer_decay(
         if group_name not in param_groups:
             this_scale = layer_scales[layer_id]
             param_group_names[group_name] = {
-                "lr_scale": this_scale,
+                "lr": lr*this_scale,
                 "weight_decay": this_decay,
                 "param_names": [],
             }
             param_groups[group_name] = {
-                "lr_scale": this_scale,
+                "lr": lr*this_scale,
                 "weight_decay": this_decay,
                 "params": [],
             }


### PR DESCRIPTION
# Summary
In the current `create_optimizer` implementation, the `layer_decay` parameter does not have any effect. This pull request removes the unused `lr_scale` and instead directly sets the `lr` values of the parameter groups, scaled according to their layer depth. This change leads to significantly improved training performance, as the learning rate is now correctly applied per layer.
 
 ### What was changed
 - Removed the unused `lr_scale` parameter in param groups.
 - Applied the scaling directly to the lr of each param group.
 - Adjusted optimizer creation logic to ensure lr is resolved correctly (either explicitly or via default).
 
 ### Results
A simple CIFAR-10 test shows that the previous implementation had minimal effect when setting layer_decay, while the new version properly applies the decay and improves performance.

### Experimental Setup
Using AdamW optimizer from `create_optimizer_v2`, with PyTorch Lightning (deterministic=True)

- version_0 (gray): layer_decay = 0 (baseline )
- version_1 (cyan): layer_decay = 0.75 (old implementation)
- version_2 (pink): layer_decay = 0.75 (new implementation)

![layer_decay_test](https://github.com/user-attachments/assets/6ea80d5c-fe6d-43ba-81a1-a24b13929fec)

I chose to explicitly apply the `lr` values in the `param_groups_layer_decay` function, as relying on a `lr_scale` parameter would have required significantly more effort to propagate and support correctly across all relevant components.
 