### PR TITLE
Update no_grad usage to inference_mode if possible

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -321,7 +321,7 @@ class InferenceBenchmarkRunner(BenchmarkRunner):
             f'Running inference benchmark on {self.model_name} for {self.num_bench_iter} steps w/ '
             f'input size {self.input_size} and batch size {self.batch_size}.')
 
-        with torch.no_grad():
+        with torch.inference_mode():
             self._init_input()
 
             for _ in range(self.num_warm_iter):

--- a/hfdocs/source/models/adversarial-inception-v3.mdx
+++ b/hfdocs/source/models/adversarial-inception-v3.mdx
@@ -37,7 +37,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/advprop.mdx
+++ b/hfdocs/source/models/advprop.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/big-transfer.mdx
+++ b/hfdocs/source/models/big-transfer.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/csp-darknet.mdx
+++ b/hfdocs/source/models/csp-darknet.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/csp-resnet.mdx
+++ b/hfdocs/source/models/csp-resnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/csp-resnext.mdx
+++ b/hfdocs/source/models/csp-resnext.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/densenet.mdx
+++ b/hfdocs/source/models/densenet.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/dla.mdx
+++ b/hfdocs/source/models/dla.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/dpn.mdx
+++ b/hfdocs/source/models/dpn.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/ecaresnet.mdx
+++ b/hfdocs/source/models/ecaresnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/efficientnet-pruned.mdx
+++ b/hfdocs/source/models/efficientnet-pruned.mdx
@@ -39,7 +39,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/efficientnet.mdx
+++ b/hfdocs/source/models/efficientnet.mdx
@@ -37,7 +37,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/ensemble-adversarial.mdx
+++ b/hfdocs/source/models/ensemble-adversarial.mdx
@@ -37,7 +37,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/ese-vovnet.mdx
+++ b/hfdocs/source/models/ese-vovnet.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/fbnet.mdx
+++ b/hfdocs/source/models/fbnet.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/gloun-inception-v3.mdx
+++ b/hfdocs/source/models/gloun-inception-v3.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/gloun-resnet.mdx
+++ b/hfdocs/source/models/gloun-resnet.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/gloun-resnext.mdx
+++ b/hfdocs/source/models/gloun-resnext.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/gloun-senet.mdx
+++ b/hfdocs/source/models/gloun-senet.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/gloun-seresnext.mdx
+++ b/hfdocs/source/models/gloun-seresnext.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/gloun-xception.mdx
+++ b/hfdocs/source/models/gloun-xception.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/hrnet.mdx
+++ b/hfdocs/source/models/hrnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/ig-resnext.mdx
+++ b/hfdocs/source/models/ig-resnext.mdx
@@ -37,7 +37,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/inception-resnet-v2.mdx
+++ b/hfdocs/source/models/inception-resnet-v2.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/inception-v3.mdx
+++ b/hfdocs/source/models/inception-v3.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/inception-v4.mdx
+++ b/hfdocs/source/models/inception-v4.mdx
@@ -32,7 +32,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/legacy-se-resnet.mdx
+++ b/hfdocs/source/models/legacy-se-resnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/legacy-se-resnext.mdx
+++ b/hfdocs/source/models/legacy-se-resnext.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/legacy-senet.mdx
+++ b/hfdocs/source/models/legacy-senet.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/mixnet.mdx
+++ b/hfdocs/source/models/mixnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/mnasnet.mdx
+++ b/hfdocs/source/models/mnasnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/mobilenet-v2.mdx
+++ b/hfdocs/source/models/mobilenet-v2.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/mobilenet-v3.mdx
+++ b/hfdocs/source/models/mobilenet-v3.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/nasnet.mdx
+++ b/hfdocs/source/models/nasnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/noisy-student.mdx
+++ b/hfdocs/source/models/noisy-student.mdx
@@ -42,7 +42,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/pnasnet.mdx
+++ b/hfdocs/source/models/pnasnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/regnetx.mdx
+++ b/hfdocs/source/models/regnetx.mdx
@@ -37,7 +37,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/regnety.mdx
+++ b/hfdocs/source/models/regnety.mdx
@@ -39,7 +39,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/res2net.mdx
+++ b/hfdocs/source/models/res2net.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/res2next.mdx
+++ b/hfdocs/source/models/res2next.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/resnest.mdx
+++ b/hfdocs/source/models/resnest.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/resnet-d.mdx
+++ b/hfdocs/source/models/resnet-d.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/resnet.mdx
+++ b/hfdocs/source/models/resnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/resnext.mdx
+++ b/hfdocs/source/models/resnext.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/rexnet.mdx
+++ b/hfdocs/source/models/rexnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/se-resnet.mdx
+++ b/hfdocs/source/models/se-resnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/selecsls.mdx
+++ b/hfdocs/source/models/selecsls.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/seresnext.mdx
+++ b/hfdocs/source/models/seresnext.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/skresnet.mdx
+++ b/hfdocs/source/models/skresnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/skresnext.mdx
+++ b/hfdocs/source/models/skresnext.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/spnasnet.mdx
+++ b/hfdocs/source/models/spnasnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/ssl-resnet.mdx
+++ b/hfdocs/source/models/ssl-resnet.mdx
@@ -37,7 +37,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/swsl-resnet.mdx
+++ b/hfdocs/source/models/swsl-resnet.mdx
@@ -37,7 +37,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/swsl-resnext.mdx
+++ b/hfdocs/source/models/swsl-resnext.mdx
@@ -37,7 +37,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/tf-efficientnet-condconv.mdx
+++ b/hfdocs/source/models/tf-efficientnet-condconv.mdx
@@ -41,7 +41,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/tf-efficientnet-lite.mdx
+++ b/hfdocs/source/models/tf-efficientnet-lite.mdx
@@ -41,7 +41,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/tf-efficientnet.mdx
+++ b/hfdocs/source/models/tf-efficientnet.mdx
@@ -39,7 +39,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/tf-inception-v3.mdx
+++ b/hfdocs/source/models/tf-inception-v3.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/tf-mixnet.mdx
+++ b/hfdocs/source/models/tf-mixnet.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/tf-mobilenet-v3.mdx
+++ b/hfdocs/source/models/tf-mobilenet-v3.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/tresnet.mdx
+++ b/hfdocs/source/models/tresnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/wide-resnet.mdx
+++ b/hfdocs/source/models/wide-resnet.mdx
@@ -33,7 +33,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/hfdocs/source/models/xception.mdx
+++ b/hfdocs/source/models/xception.mdx
@@ -35,7 +35,7 @@ To get the model predictions:
 
 ```py
 >>> import torch
->>> with torch.no_grad():
+>>> with torch.inference_mode():
 ...     out = model(tensor)
 >>> probabilities = torch.nn.functional.softmax(out[0], dim=0)
 >>> print(probabilities.shape)

--- a/inference.py
+++ b/inference.py
@@ -273,7 +273,7 @@ def main():
     all_labels = []
     all_outputs = []
     use_probs = args.output_type == 'prob'
-    with torch.no_grad():
+    with torch.inference_mode():
         for batch_idx, (input, _) in enumerate(loader):
 
             with amp_autocast():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -145,7 +145,7 @@ def test_model_inference(model_name, batch_size):
         owl_tensors = safetensors.torch.load_file(os.path.join(temp_dir, 'test', 'owl_tensors.safetensors'))
         test_owl = Image.open(os.path.join(temp_dir, 'test', 'test_owl.jpg'))
 
-    with torch.no_grad():
+    with torch.inference_mode():
         rand_output = model(rand_tensors['input'])
         rand_features = model.forward_features(rand_tensors['input'])
         rand_pre_logits = model.forward_head(rand_features, pre_logits=True)
@@ -631,7 +631,7 @@ def test_model_forward_fx(model_name, batch_size):
     input_size = _get_input_size(model=model, target=TARGET_FWD_FX_SIZE)
     if max(input_size) > MAX_FWD_FX_SIZE:
         pytest.skip("Fixed input size model > limit.")
-    with torch.no_grad():
+    with torch.inference_mode():
         inputs = torch.randn((batch_size, *input_size))
         outputs = model(inputs)
         if isinstance(outputs, tuple):
@@ -711,7 +711,7 @@ if 'GITHUB_ACTIONS' not in os.environ:
         model.eval()
 
         model = torch.jit.script(_create_fx_model(model))
-        with torch.no_grad():
+        with torch.inference_mode():
             outputs = tuple(model(torch.randn((batch_size, *input_size))).values())
             if isinstance(outputs, tuple):
                 outputs = torch.cat(outputs)
@@ -742,7 +742,7 @@ if 'GITHUB_ACTIONS' not in os.environ:
         model.eval()
 
         model = torch.jit.script(model)
-        with torch.no_grad():
+        with torch.inference_mode():
             outputs = model(torch.randn((batch_size, *input_size)))
 
         assert isinstance(outputs, list)

--- a/timm/utils/onnx.py
+++ b/timm/utils/onnx.py
@@ -54,7 +54,7 @@ def onnx_export(
     # Opset >= 11 should allow for dynamic padding, however I cannot get it to work due to
     # issues in the tracing of the dynamic padding or errors attempting to export the model after jit
     # scripting it (an approach that should work). Perhaps in a future PyTorch or ONNX versions...
-    with torch.no_grad():
+    with torch.inference_mode():
         original_out = model(example_input)
 
     input_names = input_names or ["input0"]

--- a/train.py
+++ b/train.py
@@ -512,7 +512,7 @@ def main():
         **args.model_kwargs,
     )
     if args.head_init_scale is not None:
-        with torch.inference_mode():
+        with torch.no_grad():
             model.get_classifier().weight.mul_(args.head_init_scale)
             model.get_classifier().bias.mul_(args.head_init_scale)
     if args.head_init_bias is not None:

--- a/train.py
+++ b/train.py
@@ -512,7 +512,7 @@ def main():
         **args.model_kwargs,
     )
     if args.head_init_scale is not None:
-        with torch.no_grad():
+        with torch.inference_mode():
             model.get_classifier().weight.mul_(args.head_init_scale)
             model.get_classifier().bias.mul_(args.head_init_scale)
     if args.head_init_bias is not None:
@@ -1310,7 +1310,7 @@ def validate(
 
     end = time.time()
     last_idx = len(loader) - 1
-    with torch.no_grad():
+    with torch.inference_mode():
         for batch_idx, (input, target) in enumerate(loader):
             last_batch = batch_idx == last_idx
             if not args.prefetcher:

--- a/validate.py
+++ b/validate.py
@@ -343,7 +343,7 @@ def validate(args):
     top5 = AverageMeter()
 
     model.eval()
-    with torch.no_grad():
+    with torch.inference_mode():
         # warmup, reduce variability of first batch time, especially for comparing torchscript vs non
         if not args.naflex_loader:
             input = torch.randn((args.batch_size,) + tuple(data_config['input_size'])).to(device=device, dtype=model_dtype)


### PR DESCRIPTION
I updated no_grad references in the repository to inference_mode for some slight performance gain.

References for no_grad / inference_mode difference:
https://discuss.pytorch.org/t/pytorch-torch-no-grad-vs-torch-inference-mode/134099/2?u=timgianitsos

https://stackoverflow.com/questions/74191070/why-are-there-two-different-flags-to-disable-gradient-computation-in-pytorch/74197846#74197846
