### PR TITLE
Update default naflexvit positional embedding interpolation mode to bilinear

### DIFF
--- a/timm/models/naflexvit.py
+++ b/timm/models/naflexvit.py
@@ -227,7 +227,7 @@ class NaFlexEmbeds(nn.Module):
             default_img_size: Optional[Union[int, Tuple[int, int]]] = None,
             pos_embed: str = 'learned',
             pos_embed_grid_size: Optional[Tuple[int, int]] = (14, 14),
-            pos_embed_interp_mode: str = 'bicubic',
+            pos_embed_interp_mode: str = 'bilinear',
             pos_embed_ar_preserving: bool = False,
             pos_embed_use_grid_sample: bool = False,
             input_norm_layer: Optional[Type[nn.Module]] = None,


### PR DESCRIPTION
The default positional embedding interpolation mode for the NaFlex SigLIP2 model doesn't match what is used for SigLIP2 in its official implementations. In fact, looking at the Transformers implementation, there's not even an option to have it as anything but bilinear: https://github.com/huggingface/transformers/blob/2781ad092dad77ff554cb70ec130b97e44cfba78/src/transformers/models/siglip2/modeling_siglip2.py#L174

Bilinear is probably the more appropriate default since it is what is used in official implementations of SigLIP 2. Having it on the wrong mode causes significant deviation in cosine similarity of outputs between the Transformers and TIMM implementations of SigLIP 2, but setting the mode to bilinear and using an input image that doesn't need resizing (to avoid preprocessing discrepancies) results in identical intermediate and final outputs between the two implementations.