### PR TITLE
fix: create results_dir if missing before saving results

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -345,6 +345,7 @@ def main():
         results_filename = f'{args.model}-{img_size}'
 
     if args.results_dir:
+        os.makedirs(args.results_dir, exist_ok=True)
         results_filename = os.path.join(args.results_dir, results_filename)
 
     for fmt in args.results_format:


### PR DESCRIPTION
Problem:
- The inference script crashes when saving results if the specified `results_dir` does not exist.

Solution:
- Automatically create `results_dir` if it doesn't exist using os.makedirs.
- Ensures results are saved successfully without manual directory creation.

Test:
- Verified local inference runs and results are correctly saved to a new directory.