### PR TITLE
Review `huggingface_hub` integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=1.7
 torchvision
 pyyaml
-huggingface_hub
+huggingface_hub>=0.17.0
 safetensors>=0.2
 numpy


### PR DESCRIPTION
**TL;DR:**
- `timm` is compatible with `huggingface_hub` v0.x and v1.x
- bump minimal version (still very lax)
- fix a bug when upload to private repo
- clean some stuff

---

At first I just wanted to check that the current implementation was compatible with the upcoming `huggingface_hub` v1.0 release (see https://github.com/huggingface/huggingface_hub/issues/3340). This is indeed the case (breaking changes should not affect timm). However I took the advantage to update the `huggingface_hub` integration, and especially:
- use `file_exists` instead of `get_hf_file_metadata` + `hf_hub_url` in order to check if the repo user is uploading to has a README
- bump minimal version to [`v0.17.0`](https://github.com/huggingface/huggingface_hub/releases/tag/v0.17.0) which has been release in Sept' 2023 and introduced `file_exists` utility. I don't think this bump is a major problem as it's 2 years old.
- do not recreate `repo_id` manually using `repo_type_and_id_from_hf_id` as this is already done by the `create_repo` return value ([since Dec' 2022](https://github.com/huggingface/huggingface_hub/pull/1268) so included in `v0.17+`)
- use `HfApi` instead of individual methods when uploading a model
  -  => allows to set custom user-agent for `timm` (only done for `hf_hub_download` so far)
  - => allow to pass `token` once and for all => previously the `get_hf_file_metadata(hf_hub_url(repo_id=repo_id, filename="README.md", revision=revision))` was necessarily failing in case of private repo since token was not forwarded 

---


