### PR TITLE
(fix) timm: ROCm 7.0 compatibility for Attention2d modules

### DIFF
--- a/timm/layers/helpers.py
+++ b/timm/layers/helpers.py
@@ -4,6 +4,7 @@ Hacked together by / Copyright 2020 Ross Wightman
 """
 from itertools import repeat
 import collections.abc
+import torch
 
 
 # From PyTorch internals
@@ -41,3 +42,12 @@ def extend_tuple(x, n):
     if pad_n <= 0:
         return x[:n]
     return x + (x[-1],) * pad_n
+
+
+def is_contiguous(tensor: torch.Tensor) -> bool:
+    """Check tensor contiguity with proper handling for TorchScript compilation."""
+    # jit is oh so lovely :/
+    if torch.jit.is_scripting():
+        return tensor.is_contiguous()
+    else:
+        return tensor.is_contiguous(memory_format=torch.contiguous_format)


### PR DESCRIPTION
ROCm 7.0 enforces GEMM paths for 1x1 convolutions, requiring strict
memory contiguity. This change causes HIP error: invalid argument
when non-contiguous tensors (from reshape/permute/slice operations)
are passed to Attention2d and MultiQueryAttention2d modules.

Changes:
- Add contiguity checks in Attention2d.forward()
- Add contiguity checks in MultiQueryAttention2d.forward()
- Force .contiguous() only when tensor is non-contiguous

Fixes #2613
Signed-off-by: Emilien Macchi <emacchi@redhat.com>
