### PR TITLE
refactor(scheduler): add type hints to CosineLRScheduler

### DIFF
--- a/timm/scheduler/cosine_lr.py
+++ b/timm/scheduler/cosine_lr.py
@@ -8,7 +8,7 @@ import logging
 import math
 import numpy as np
 import torch
-from typing import List
+from typing import Tuple, List, Union
 
 from .scheduler import Scheduler
 
@@ -35,16 +35,16 @@ class CosineLRScheduler(Scheduler):
             cycle_mul: float = 1.,
             cycle_decay: float = 1.,
             cycle_limit: int = 1,
-            warmup_t=0,
-            warmup_lr_init=0,
-            warmup_prefix=False,
-            t_in_epochs=True,
-            noise_range_t=None,
-            noise_pct=0.67,
-            noise_std=1.0,
-            noise_seed=42,
-            k_decay=1.0,
-            initialize=True,
+            warmup_t: int=0,
+            warmup_lr_init: float=0.,
+            warmup_prefix: bool=False,
+            t_in_epochs: bool=True,
+            noise_range_t: Union[List[int], Tuple[int, int], int, None]=None,
+            noise_pct: float=0.67,
+            noise_std: float=1.0,
+            noise_seed: int=42,
+            k_decay: float=1.0,
+            initialize: bool=True,
     ) -> None:
         super().__init__(
             optimizer,


### PR DESCRIPTION
## Description

This PR adds explicit type hints to the `__init__` arguments of `CosineLRScheduler`.

## Motivation and Context

Currently, the `warmup_lr_init` argument defaults to `0` (integer). As a result, static analysis tools like Pylance (based on Pyright) and linters like Ruff infer the type as `int`.

When a user passes a `float` value (e.g., `1e-6`) to `warmup_lr_init`, it triggers a type mismatch error/warning, even though the code handles floats correctly at runtime.

**Example error in Pylance:**
> "Argument of type 'float' cannot be assigned to parameter 'warmup_lr_init' of type 'int'"

<img width="1173" height="265" alt="image" src="https://github.com/user-attachments/assets/a2f2a137-679d-483f-a0ce-bcf38f9ccf46" />


## Changes

- Imported `Tuple`, `List`, and `Union` from `typing`.
- Added explicit type annotations to `__init__` arguments in `timm/scheduler/cosine_lr.py`.
- Specifically, `warmup_lr_init` is now typed as `float` (defaulting to `0`), which resolves the linting error.

## Notes
I noticed similar issues in other schedulers, but I am addressing `CosineLRScheduler` in this PR as a first step.