### PR TITLE
filter kwargs before creating norm layer

### DIFF
--- a/timm/layers/create_norm.py
+++ b/timm/layers/create_norm.py
@@ -5,6 +5,7 @@ Create norm modules by string (to mirror create_act and creat_norm-act fns)
 Copyright 2022 Ross Wightman
 """
 import functools
+import inspect
 import types
 from typing import Type
 
@@ -48,12 +49,14 @@ _NORM_MAP = dict(
     simplenorm2dfp32=SimpleNorm2dFp32,
     frozenbatchnorm2d=FrozenBatchNorm2d,
 )
-_NORM_TYPES = {m for n, m in _NORM_MAP.items()}
 
 
-def create_norm_layer(layer_name, num_features, **kwargs):
+def create_norm_layer(layer_name, **kwargs):
     layer = get_norm_layer(layer_name)
-    layer_instance = layer(num_features, **kwargs)
+    # filter kwargs before creating layer
+    params = inspect.signature(layer).parameters
+    kwargs = {k: v for k, v in kwargs.items() if k in params}
+    layer_instance = layer(**kwargs)
     return layer_instance
 
 

--- a/timm/models/efficientformer_v2.py
+++ b/timm/models/efficientformer_v2.py
@@ -96,7 +96,14 @@ class ConvNorm(nn.Module):
             bias=bias,
             **dd,
         )
-        self.bn = create_norm_layer(norm_layer, out_channels, **norm_kwargs, **dd)
+        self.bn = create_norm_layer(
+            norm_layer,
+            num_channels=out_channels,
+            num_features=out_channels,
+            num_groups=groups,
+            **norm_kwargs,
+            **dd,
+        )
 
     def forward(self, x):
         x = self.conv(x)


### PR DESCRIPTION
Unlike other create_* functions, create_norm_layer can create normalization layers that have different parameters (such as BatchNorm2d and GroupNorm), which may trigger errors for missing required arguments or passes redundant arguments. So it's reasoning that delete them before create.

In short, I want the following code works correctly whether it's batch normalization or group normalization.

```python
create_norm_layer('GroupNorm', num_features=1, num_groups=2, num_channels=4)
```

Please notice that this is a breaking change that compromises backward compatibility (the removing of num_features). If it's necessary, I can add it back. Furthermore, it doesn't robustly handle unusual scenarios, though it suffices for all normalization layers in Pytorch and timm.