### PR TITLE
fix: fix ImportError of RotaryEmbedding from `timm.models.layers`

### DIFF
--- a/timm/models/layers/__init__.py
+++ b/timm/models/layers/__init__.py
@@ -1,8 +1,9 @@
 # NOTE timm.models.layers is DEPRECATED, please use timm.layers, this is here to reduce breakages in transition
 from timm.layers.activations import *
+from timm.layers import RotaryEmbedding
 from timm.layers.adaptive_avgmax_pool import \
     adaptive_avgmax_pool2d, select_adaptive_pool2d, AdaptiveAvgMaxPool2d, SelectAdaptivePool2d
-from timm.layers.attention_pool2d import AttentionPool2d, RotAttentionPool2d, RotaryEmbedding
+from timm.layers.attention_pool2d import AttentionPool2d, RotAttentionPool2d
 from timm.layers.blur_pool import BlurPool2d
 from timm.layers.classifier import ClassifierHead, create_classifier
 from timm.layers.cond_conv2d import CondConv2d, get_condconv_initializer


### PR DESCRIPTION
## Motivation
Following a recent refactoring in v1.0.23 that restructured internal layer modules, `RotaryEmbedding` is no longer exported from `timm.layers.attention_pool2d`. However, the backward compatibility shim in `timm.models.layers` continued to import it from that deprecated location, causing `ImportError` for downstream code using the legacy import path.

## Modification
Update the compatibility layer to import `RotaryEmbedding` directly from the top-level `timm.layers` package instead of `timm.layers.attention_pool2d`. This preserves the deprecated `timm.models.layers` API while ensuring compatibility with the current module structure, preventing import failures without requiring changes to user code.

Closes: #2644 