### PR TITLE
fix: correct date in README from 2025 to 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## What's New
 
-## Jan 5 & 6, 2025
+## Jan 5 & 6, 2026
 * Release 1.0.24
 * Add new benchmark result csv files for inference timing on all models w/ RTX Pro 6000, 5090, and 4090 cards w/ PyTorch 2.9.1
 * Fix moved module error in deprecated timm.models.layers import path that impacts legacy imports


### PR DESCRIPTION
## Description
Correct the incorrect year value (2025) to the accurate 2026 in the README.md file. This was a simple typo that needed to be fixed to ensure documentation accuracy.

## Type of change
Bug fix (non-breaking change which fixes an issue)

## Testing
- Checked the updated README.md file locally to confirm the year 2026 displays correctly
- Verified no other content in README was affected by the change