### PR TITLE
Enhance the numerical stability of the Cautious Optimizer

### DIFF
--- a/timm/optim/adamp.py
+++ b/timm/optim/adamp.py
@@ -47,7 +47,8 @@ def projection(p, grad, perturb, delta: float, wd_ratio: float, eps: float, caut
                 mask = (perturb * grad_perp > 0).to(grad.dtype)
                 mask.div_(mask.mean().clamp_(min=1e-3))
                 perturb.mul_(mask)
-
+                # Enhance the numerical stability of the Cautious Optimizer
+                perturb -= p_n * view_func(p_n * perturb).sum(dim=1).reshape(expand_size)
             wd = wd_ratio
             return perturb, wd
 


### PR DESCRIPTION
Hi rwightman, this PR aims to fix potential numerical errors.

**Motivation:**
Applying a coordinate-wise mask in the tangent space may cause the masked tangent vector to slightly deviate from the tangent space. Here, we follow AdamP’s design philosophy by keeping the masked update strictly within the tangent space, which avoids potential numerical instability. Since
$\langle \xi, g^\bot \rangle = \langle \xi^\bot, g^\bot \rangle$,
where $\xi$ denotes the masked update, this approach always guarantees that the update direction is descending, which is consistent with the design philosophy of cautious optimizers.

**Modifications:**
Only one additional line of code is introduced, reusing an existing operation:
`perturb -= p_n * view_func(p_n * perturb).sum(dim=1).reshape(expand_size)`
This is simply an extra reprojection step, but it helps prevent numerical instability.
