### PR TITLE
Fix Swin relative_position_index not initialized via TimmBackbone

### DIFF
--- a/timm/models/swin_transformer.py
+++ b/timm/models/swin_transformer.py
@@ -146,10 +146,10 @@ class WindowAttention(nn.Module):
         self.relative_position_bias_table = nn.Parameter(
             torch.empty((2 * win_h - 1) * (2 * win_w - 1), num_heads, **dd))
 
-        # register empty buffer for relative position index
+        # get pair-wise relative position index for each token inside the window
         self.register_buffer(
             "relative_position_index",
-            torch.empty(win_h * win_w, win_h * win_w, device=device, dtype=torch.long),
+            get_relative_position_index(win_h, win_w, device=device),
             persistent=False,
         )
 


### PR DESCRIPTION
## Description

Initialize `relative_position_index` buffer directly in `WindowAttention.__init__()` instead of deferring to `reset_parameters()`.

## Problem

When Swin models are loaded via transformers' `TimmBackbone`, the deferred buffer initialization doesn't trigger, leaving `relative_position_index` with uninitialized values. This causes `IndexError` during inference:

```
IndexError: index 1841 is out of bounds for dimension 0 with size 169
```

## Root Cause

PR #2632 changed buffer registration to use `torch.empty()` with deferred initialization in `reset_parameters()`. However, `reset_parameters()` is only called when `not self.proj.weight.is_meta`, which doesn't trigger in all loading scenarios.

## Solution

Compute the buffer directly during `__init__()` using `get_relative_position_index()`, restoring the pre-#2632 behavior for this buffer while keeping the `init_non_persistent_buffers()` API intact.

## Testing

- Verified buffer values are correct (max=168 vs garbage values)
- Inference succeeds with `omlab/omdet-turbo-swin-tiny-hf` via transformers

Fixes #2661