### PR TITLE
fix(optim): replace bare except with Exception in Lion optimizer

### DIFF
--- a/timm/optim/lion.py
+++ b/timm/optim/lion.py
@@ -154,7 +154,7 @@ def lion(
         try:
             # cannot do foreach if this overload doesn't exist when caution enabled
             foreach = not caution or 'Scalar' in torch.ops.aten._foreach_maximum_.overloads()
-        except:
+        except Exception:
             foreach = False
 
     if foreach and torch.jit.is_scripting():


### PR DESCRIPTION
## Description
This PR replaces a bare `except:` clause with `except Exception:` in `timm/optim/lion.py`.

The previous implementation caught `BaseException`, which includes `SystemExit` and `KeyboardInterrupt`. This prevented the user from interrupting the process (Ctrl+C) during the `foreach` capability check.

## Verification
Verified via code inspection. This ensures standard runtime errors (like `AttributeError` or `RuntimeError` from `torch.ops`) are caught, while allowing system control signals to propagate correctly.