### PR TITLE
fix: replace 5 bare except clauses with except Exception

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -190,7 +190,7 @@ def test_model_forward(model_name, batch_size):
     # Test that grad-checkpointing, if supported, doesn't cause model failures or change in output
     try:
         model.set_grad_checkpointing()
-    except:
+    except Exception:
         # throws if not supported, that's fine
         pass
     else:
@@ -551,7 +551,7 @@ def test_model_forward_intermediates(model_name, batch_size):
     # Test that grad-checkpointing, if supported
     try:
         model.set_grad_checkpointing()
-    except:
+    except Exception:
         # throws if not supported, that's fine
         pass
     else:

--- a/timm/optim/adamw.py
+++ b/timm/optim/adamw.py
@@ -205,7 +205,7 @@ def adamw(
         try:
             # cannot do foreach if this overload doesn't exist when caution enabled
             foreach = not caution or 'Scalar' in torch.ops.aten._foreach_maximum_.overloads()
-        except:
+        except Exception:
             foreach = False
 
     if foreach and not torch.jit.is_scripting():

--- a/timm/optim/adan.py
+++ b/timm/optim/adan.py
@@ -124,7 +124,7 @@ class Adan(Optimizer):
 
         try:
             has_scalar_maximum = 'Scalar' in torch.ops.aten._foreach_maximum_.overloads()
-        except:
+        except Exception:
             has_scalar_maximum = False
 
         for group in self.param_groups:

--- a/timm/optim/nadamw.py
+++ b/timm/optim/nadamw.py
@@ -182,7 +182,7 @@ def nadamw(
         try:
             # cannot do foreach if this overload doesn't exist when caution enabled
             foreach = not caution or 'Scalar' in torch.ops.aten._foreach_maximum_.overloads()
-        except:
+        except Exception:
             foreach = False
 
     if foreach and not torch.jit.is_scripting():


### PR DESCRIPTION
## What
Replace 5 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors.