### PR TITLE
Add timmx model export tool to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,9 @@ One of the greatest assets of PyTorch is the community and their contributions. 
 * fastai - https://github.com/fastai/fastai
 * lightly_train - https://github.com/lightly-ai/lightly-train
 
+### Deployment
+* timmx (Export timm models to ONNX, CoreML, LiteRT, TensorRT, and more) - https://github.com/Boulaouaney/timmx
+
 ## Licenses
 
 ### Code


### PR DESCRIPTION
Adds timmx to the README under a new "Deployment" subsection in Awesome PyTorch Resources.

timmx is a CLI tool for exporting timm models to multiple deployment formats (ONNX, CoreML, LiteRT, TensorRT, ncnn, ExecuTorch, TorchScript) with a simple CLI.

Ref: #2671 