### PR TITLE
Fix CLS and Reg tokens usage when pos_embed is disabled

### DIFF
--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -996,8 +996,14 @@ class VisionTransformer(nn.Module):
 
     def _pos_embed(self, x: torch.Tensor) -> torch.Tensor:
         """Apply positional embedding to input."""
+        to_cat = []
+        if self.cls_token is not None:
+            to_cat.append(self.cls_token.expand(x.shape[0], -1, -1))
+        if self.reg_token is not None:
+            to_cat.append(self.reg_token.expand(x.shape[0], -1, -1))
+
         if self.pos_embed is None:
-            return x.view(x.shape[0], -1, x.shape[-1])
+            return torch.cat(to_cat + [x.view(x.shape[0], -1, x.shape[-1])], dim=1)
 
         if self.dynamic_img_size:
             B, H, W, C = x.shape
@@ -1011,12 +1017,6 @@ class VisionTransformer(nn.Module):
             x = x.view(B, -1, C)
         else:
             pos_embed = self.pos_embed
-
-        to_cat = []
-        if self.cls_token is not None:
-            to_cat.append(self.cls_token.expand(x.shape[0], -1, -1))
-        if self.reg_token is not None:
-            to_cat.append(self.reg_token.expand(x.shape[0], -1, -1))
 
         if self.no_embed_class:
             # deit-3, updated JAX (big vision)


### PR DESCRIPTION
In the curernt implementation of `vision_transformer.py`, if you set `pos_embed='none'`, the CLS and Reg tokens are not used, which is undesirable in my opinion. One can disable absolute positional embedding and still use those prefix tokens. I believe this commit fixes that issue.