### PR TITLE
Add Patch Representation Refinement module

### DIFF
--- a/timm/layers/__init__.py
+++ b/timm/layers/__init__.py
@@ -139,6 +139,7 @@ from .pos_embed_sincos import (
     get_mixed_freqs,
     create_rope_embed,
 )
+from .prr import PRR
 from .squeeze_excite import SEModule, SqueezeExcite, EffectiveSEModule, EffectiveSqueezeExcite
 from .selective_kernel import SelectiveKernel
 from .separable_conv import SeparableConv2d, SeparableConvNormAct

--- a/timm/layers/prr.py
+++ b/timm/layers/prr.py
@@ -1,0 +1,73 @@
+""" Patch Representation Refinement (PRR)
+
+Parameter-free multi-head self-attention applied before the classification head to ensure diverse gradient flow across
+patch positions, improving representations for dense prediction tasks.
+
+Paper: 'Locality-Attending Vision Transformer' - https://arxiv.org/abs/2603.04892
+
+Reference impl: https://github.com/sinahmr/LocAtViT
+"""
+from typing import Type
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.jit import Final
+
+from .config import use_fused_attn
+
+
+class PRR(nn.Module):
+    """ Patch Representation Refinement (PRR) module
+
+    Parameter-free multi-head self-attention that refines patch representations before the classification head.
+    In standard ViT, only the [CLS] token receives direct supervision from the classification loss, leaving patch
+    representations at the final layer under-optimized for dense prediction. PRR addresses this issue by aggregating
+    information from all positions non-uniformly, ensuring better representations at spatial positions. This
+    module's output at the [CLS] position can then be passed to the head (other pooling methods can be used as well).
+
+    Supports both fused (scaled_dot_product_attention) and manual implementations.
+    """
+    fused_attn: Final[bool]
+
+    def __init__(
+            self, dim: int, num_heads: int, nchw: bool = False,
+            pre_norm: bool = False, post_norm: bool = False, norm_layer: Type[nn.Module] = nn.LayerNorm,
+    ):
+        """
+        Initialize the PRR module.
+
+        Args:
+            dim: Input dimension of the token embeddings.
+            num_heads: Number of attention heads.
+            nchw: Whether the input's shape is NCHW. NLC will be assumed otherwise.
+            pre_norm: Whether to apply normalization before PRR module.
+            post_norm: Whether to apply normalization after PRR module.
+            norm_layer: Normalization layer constructor for pre_norm and post_norm if enabled.
+        """
+        super().__init__()
+        self.fused_attn = use_fused_attn()
+        self.num_heads = num_heads
+        self.scale = (dim // num_heads) ** -0.5
+        self.nchw = nchw
+        self.pre_norm = norm_layer(dim) if pre_norm else nn.Identity()
+        self.post_norm = norm_layer(dim) if post_norm else nn.Identity()
+
+    def forward(self, x: torch.Tensor):
+        shape = x.shape
+        if self.nchw:
+            x = x.movedim(1, -1)
+        x = self.pre_norm(x)
+        x = x.flatten(1, -2)
+        x = x.view(x.shape[0], x.shape[1], self.num_heads, -1).permute(0, 2, 1, 3)
+        if self.fused_attn:
+            x = F.scaled_dot_product_attention(x, x, x)
+        else:
+            attn = (x * self.scale) @ x.transpose(-2, -1)
+            attn = torch.softmax(attn, dim=-1)
+            x = attn @ x
+        x = x.permute(0, 2, 1, 3).flatten(2, 3)
+        x = self.post_norm(x)
+        if self.nchw:
+            x = x.movedim(-1, 1)
+        return x.reshape(shape)

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -68,6 +68,7 @@ from timm.layers import (
     maybe_add_mask,
     LayerType,
     LayerScale,
+    PRR,
 )
 from ._builder import build_model_with_cfg
 from ._features import feature_take_indices
@@ -711,6 +712,7 @@ class VisionTransformer(nn.Module):
             final_norm: bool = True,
             fc_norm: Optional[bool] = None,
             pool_include_prefix: bool = False,
+            prr: bool = False,
             dynamic_img_size: bool = False,
             dynamic_img_pad: bool = False,
             drop_rate: float = 0.,
@@ -750,6 +752,7 @@ class VisionTransformer(nn.Module):
             pre_norm: Enable norm after embeddings, before transformer blocks (standard in CLIP ViT).
             final_norm: Enable norm after transformer blocks, before head (standard in most ViT).
             fc_norm: Move final norm after pool (instead of before), if None, enabled when global_pool == 'avg'.
+            prr: Whether to use Patch Representation Refinement before classification head.
             drop_rate: Head dropout rate.
             pos_drop_rate: Position embedding dropout rate.
             attn_drop_rate: Attention dropout rate.
@@ -849,6 +852,7 @@ class VisionTransformer(nn.Module):
         self.norm = norm_layer(embed_dim, **dd) if final_norm and not use_fc_norm else nn.Identity()
 
         # Classifier Head
+        self.prr = PRR(embed_dim, num_heads) if prr else nn.Identity()
         if global_pool == 'map':
             self.attn_pool = AttentionPoolLatent(
                 self.embed_dim,
@@ -1238,6 +1242,7 @@ class VisionTransformer(nn.Module):
         Returns:
             Output tensor.
         """
+        x = self.prr(x)
         x = self.pool(x)
         x = self.fc_norm(x)
         x = self.head_drop(x)


### PR DESCRIPTION
This branch adds the Patch Representation Refinement (PRR) module from Locality-Attending Vision Transformer (ICLR 2026), [paper](https://arxiv.org/abs/2603.04892), [code](https://github.com/sinahmr/LocAtViT).

PRR is a parameter-free multi-head self-attention applied before the classification head. In standard ViT, only the [CLS] token receives direct supervision from the classification loss, leaving patch representations at the final layer under-optimized for dense prediction. PRR addresses this by aggregating information from all positions non-uniformly, ensuring diverse gradient flow to spatial tokens.

Changes
- `timm/layers/prr.py` (new): PRR module with support for both fused (`scaled_dot_product_attention`) and manual attention paths.
- `timm/layers/__init__.py`: Export PRR.
- `timm/models/vision_transformer.py`: Add `prr` parameter to `VisionTransformer`. When enabled, PRR is applied in `forward_head` before pooling. Defaults to off, so no behavioral change for existing models.
