### PR TITLE
Fix Hiera global attention to use 4D tensors for efficient SDPA dispatch

### DIFF
--- a/timm/models/hiera.py
+++ b/timm/models/hiera.py
@@ -299,13 +299,31 @@ class MaskUnitAttention(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """ Input should be of shape [batch, tokens, channels]. """
         B, N, _ = x.shape
-        num_windows = (N // (self.q_stride * self.window_size)) if self.use_mask_unit_attn else 1
-        qkv = self.qkv(x).reshape(B, -1, num_windows, 3, self.heads, self.head_dim).permute(3, 0, 4, 2, 1, 5)
-        q, k, v = qkv.unbind(0)
 
-        if self.q_stride > 1:
-            # Refer to Unroll to see how this performs a maxpool-Nd
-            q = q.view(B, self.heads, num_windows, self.q_stride, -1, self.head_dim).amax(dim=3)
+        if self.use_mask_unit_attn:
+            # Windowed attention: 5D path [B, heads, num_windows, tokens_per_window, head_dim]
+            num_windows = N // (self.q_stride * self.window_size)
+            qkv = self.qkv(x).reshape(
+                B, -1, num_windows, 3, self.heads, self.head_dim,
+            ).permute(3, 0, 4, 2, 1, 5)
+            q, k, v = qkv.unbind(0)
+
+            if self.q_stride > 1:
+                # Refer to Unroll to see how this performs a maxpool-Nd
+                q = q.view(B, self.heads, num_windows, self.q_stride, -1, self.head_dim).amax(dim=3)
+        else:
+            # Global attention: 4D path [B, heads, N, head_dim]
+            # Avoids the dummy num_windows=1 dimension that prevents FlashAttention dispatch.
+            qkv = self.qkv(x).reshape(B, N, 3, self.heads, self.head_dim).permute(2, 0, 3, 1, 4)
+            q, k, v = qkv.unbind(0)
+
+            if self.q_stride > 1:
+                # dim=2 instead of dim=3 because num_windows dimension is absent
+                q = q.view(B, self.heads, self.q_stride, -1, self.head_dim).amax(dim=2)
+
+            # Enforce contiguous memory layout so SDPA dispatches to FlashAttention
+            # instead of silently falling back to the O(N^2) math backend.
+            q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
 
         if self.fused_attn:
             # Note: the original paper did *not* use SDPA, it's a free boost!
@@ -315,7 +333,12 @@ class MaskUnitAttention(nn.Module):
             attn = attn.softmax(dim=-1)
             x = attn @ v
 
-        x = x.transpose(1, 3).reshape(B, -1, self.dim_out)
+        # Output transpose adapts to 5D (windowed) vs 4D (global) layout
+        if self.use_mask_unit_attn:
+            x = x.transpose(1, 3).reshape(B, -1, self.dim_out)
+        else:
+            x = x.transpose(1, 2).reshape(B, -1, self.dim_out)
+
         x = self.proj(x)
         return x
 


### PR DESCRIPTION
## Problem

Hiera's `MaskUnitAttention.forward()` takes a shortcut for global attention by setting `num_windows=1` and funneling everything through the same 5D reshape as windowed attention. This produces Q/K/V tensors shaped `[B, heads, 1, N, head_dim]` (5D, non-contiguous after permute).

PyTorch's `F.scaled_dot_product_attention` silently rejects these for all efficient backends (FlashAttention, Memory-Efficient, CuDNN) and falls back to the math backend, which materializes the full N x N attention matrix. At high resolutions (e.g. 2048x2048, 16384 tokens), this allocates several GB of VRAM per layer and OOMs on consumer GPUs.

## Fix

Branch the forward pass so that:

- **Windowed attention** (`use_mask_unit_attn=True`): Unchanged 5D path.
- **Global attention** (`use_mask_unit_attn=False`): Reshapes directly to 4D `[B, heads, N, head_dim]`, calls `.contiguous()` on Q/K/V, and adjusts downstream indexing (`amax` dim, output transpose) accordingly.

This is a minimal, non-breaking change. The mathematical output is identical to the original implementation, but SDPA can now dispatch to efficient O(N) kernels instead of the O(N^2) fallback.

## Changes

- Branch [forward()](cci:1://file:///c:/Users/raide/Music/tim/pytorch-image-models/timm/models/hiera.py:201:4-251:16) into windowed (5D) and global (4D) paths
- Reshape global QKV directly to `[B, N, 3, heads, head_dim]` and permute to 4D
- Adjust `q_stride` pooling from `amax(dim=3)` to `amax(dim=2)` on the global path
- Enforce `.contiguous()` on Q, K, V for the global path
- Adapt output transpose: `transpose(1, 3)` for windowed, `transpose(1, 2)` for global
