### PR TITLE
Fix NaFlexVit DINOv3 support: propagate rope_type and rotate_half

### DIFF
--- a/timm/models/naflexvit.py
+++ b/timm/models/naflexvit.py
@@ -103,6 +103,7 @@ class NaFlexVitCfg:
     rope_ref_feat_shape: Optional[Tuple[int, int]] = None
     rope_grid_offset: float = 0.  # Grid offset for non-pixel ROPE mode
     rope_grid_indexing: str = 'ij'  # Grid indexing mode for ROPE ('ij' or 'xy')
+    rope_rotate_half: bool = False  # Use rotate_half layout for ROPE (DINOv3 uses True)
 
     # Image processing
     dynamic_img_pad: bool = False  # Whether to enable dynamic padding for variable resolution
@@ -286,6 +287,7 @@ def get_block_fn(cfg: NaFlexVitCfg) -> Callable:
             scale_attn_inner=cfg.scale_attn_inner_norm,
             qkv_fused=cfg.qkv_fused,
             num_prefix_tokens=num_prefix_tokens,
+            rotate_half=cfg.rope_rotate_half,
         )
     else:
         # Standard ViT block
@@ -1179,7 +1181,7 @@ class NaFlexVit(nn.Module):
         self.rope: Optional[nn.Module] = None
         self.rope_is_mixed = False
         if cfg.rope_type and cfg.rope_type != 'none':
-            from timm.layers.pos_embed_sincos import RotaryEmbeddingCat, RotaryEmbeddingMixed
+            from timm.layers.pos_embed_sincos import RotaryEmbeddingCat, RotaryEmbeddingDinoV3, RotaryEmbeddingMixed
             if cfg.rope_type == 'mixed':
                 self.rope = RotaryEmbeddingMixed(
                     cfg.embed_dim,
@@ -1200,6 +1202,16 @@ class NaFlexVit(nn.Module):
                     ref_feat_shape=cfg.rope_ref_feat_shape,
                     grid_offset=cfg.rope_grid_offset,
                     grid_indexing=cfg.rope_grid_indexing,
+                    **dd,
+                )
+                self.rope_is_mixed = False
+            elif cfg.rope_type == 'dinov3':
+                self.rope = RotaryEmbeddingDinoV3(
+                    cfg.embed_dim // cfg.num_heads,
+                    temperature=cfg.rope_temperature,
+                    feat_shape=None,  # Dynamic shapes for NaFlex
+                    grid_indexing=cfg.rope_grid_indexing,
+                    rotate_half=cfg.rope_rotate_half,
                     **dd,
                 )
                 self.rope_is_mixed = False
@@ -2072,7 +2084,11 @@ def _create_naflexvit_from_eva(
     rope_temperature = kwargs.pop('rope_temperature', 10000.)
     rope_grid_offset = kwargs.pop('rope_grid_offset', 0.)
     rope_grid_indexing = kwargs.pop('rope_grid_indexing', 'ij')
-    if use_rot_pos_emb:
+    # Preserve explicit rope_type from model config (e.g. 'dinov3') if present
+    explicit_rope_type = kwargs.pop('rope_type', None)
+    if explicit_rope_type and explicit_rope_type != 'none':
+        rope_type = explicit_rope_type
+    elif use_rot_pos_emb:
         rope_type = 'mixed' if rope_mixed_mode else 'axial'
     else:
         rope_type = 'none'
@@ -2099,6 +2115,7 @@ def _create_naflexvit_from_eva(
         'rope_temperature': rope_temperature,
         'rope_grid_offset': rope_grid_offset,
         'rope_grid_indexing': rope_grid_indexing,
+        'rope_rotate_half': kwargs.pop('rope_rotate_half', False),
         'rope_ref_feat_shape': kwargs.get('ref_feat_shape', None),
         'attn_type': kwargs.pop('attn_type', 'eva'),
         'swiglu_mlp': kwargs.pop('swiglu_mlp', False),


### PR DESCRIPTION
## Problem

When creating a NaFlexVit model from DINOv3 pretrained weights via `use_naflex=True`, the model produces severely degraded features compared to the standard Eva wrapper.

## Root Cause

Two bugs in the NaFlexVit - Eva bridge:

1. **Missing `rope_type='dinov3'` support.** `NaFlexVit.__init__` only handled `'axial'` and `'mixed'` rope types. DINOv3 models specify `rope_type='dinov3'` which uses `RotaryEmbeddingDinoV3` with a different coordinate system (0.5-centered, normalized coords). This type was silently overridden to `'axial'` by `_create_naflexvit_from_eva()`, producing incorrect positional encodings.

2. **Missing `rotate_half` propagation to `EvaBlock`.** DINOv3 uses `rope_rotate_half=True`, which generates RoPE embeddings in a tiled (half) layout and requires `rope_rotate_half()` for rotation. However, `get_block_fn()` did not pass `rotate_half` to `EvaBlock`, so attention layers defaulted to `rotate_half=False` and used the interleaved `rot()` function instead -- applying rotations to wrong dimension pairs.

## Fix

- Add `rope_type='dinov3'` branch in `NaFlexVit.__init__` using `RotaryEmbeddingDinoV3`
- Add `rope_rotate_half` field to `NaFlexVitCfg`
- Pass `rotate_half=cfg.rope_rotate_half` to `EvaBlock` in `get_block_fn()`
- Preserve explicit `rope_type` from model configs in `_create_naflexvit_from_eva()` instead of always re-deriving it

## Verification

### Feature parity (DINOv3-S, same 256x256 input, Eva vs NaFlexVit)

| | Cosine Similarity | L2 Distance |
|---|---|---|
| Before fix (rope_type forced to 'axial') | 0.442 | 10.52 |
| Before fix (rope_type='dinov3' added, no rotate_half) | 0.749 | 7.12 |
| **After fix** | **1.000** | **0.000** |

### Linear probe on ImageNette (DINOv3-S/16 frozen backbone, 20 epochs)

| | Before fix | After fix |
|---|---|---|
| Square 256x256 | 98.93% | 98.98% |
| NaFlex AR-preserving | 73.45% to 95.11% | **99.08%** |

### Compatibility

EVA02 and standard ViT models with `use_naflex=True` remain unaffected (rotate_half correctly stays False for non-DINOv3 models, cosine similarity = 1.0).

## Reproduce

<details>
<summary>Feature parity check</summary>

```python
import timm
import torch
from timm.data.naflex_transforms import patchify_image

device = 'cuda'
x = torch.randn(1, 3, 256, 256, device=device)

# Standard Eva model
m_eva = timm.create_model(
    'vit_small_patch16_dinov3.lvd1689m',
    pretrained=True, num_classes=0, global_pool='token',
).to(device).eval()

# NaFlexVit wrapper
m_nfx = timm.create_model(
    'vit_small_patch16_dinov3.lvd1689m',
    pretrained=True, use_naflex=True, num_classes=0, global_pool='token',
).to(device).eval()

with torch.no_grad():
    f_eva = m_eva(x)
    patches, coord, valid = patchify_image(x[0].cpu(), (16, 16))
    f_nfx = m_nfx({
        'patches': patches.unsqueeze(0).to(device),
        'patch_coord': coord.unsqueeze(0).to(device),
        'patch_valid': valid.unsqueeze(0).to(device),
    })

cos = torch.nn.functional.cosine_similarity(f_eva, f_nfx, dim=-1)
print(f'Cosine similarity: {cos.item():.6f}')  # Expected: 1.000000
```

</details>

<details>
<summary>Variable aspect ratio test</summary>

```python
import timm
import torch
from timm.data.naflex_transforms import patchify_image

device = 'cuda'
model = timm.create_model(
    'vit_small_patch16_dinov3.lvd1689m',
    pretrained=True, use_naflex=True, num_classes=0, global_pool='token',
).to(device).eval()

for h, w in [(256, 256), (224, 336), (336, 224), (160, 480)]:
    x = torch.randn(1, 3, h, w, device=device)
    patches, coord, valid = patchify_image(x[0].cpu(), (16, 16))
    inp = {
        'patches': patches.unsqueeze(0).to(device),
        'patch_coord': coord.unsqueeze(0).to(device),
        'patch_valid': valid.unsqueeze(0).to(device),
    }
    with torch.no_grad():
        out = model(inp)
    print(f'{h}x{w} -> {out.shape}')  # All should be (1, 384)
```

</details>

<details>
<summary>Download ImageNette dataset</summary>

```bash
# ImageNette 320px (~130MB, 10 classes from ImageNet, ~9.5K train / ~3.9K val)
curl -L -o imagenette2-320.tgz https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-320.tgz
tar xzf imagenette2-320.tgz
# Update DATA_DIR in the benchmark script below to point to imagenette2-320/
```

</details>

<details>
<summary>Linear probe benchmark (ImageNette, Square vs NaFlex)</summary>

```python
"""DINOv3 + NaFlex linear probe: Square vs AR-preserving on ImageNette."""
import os
import time

import torch
import torch.nn as nn
from torch.utils.data import DataLoader
from torchvision import transforms
from torchvision.datasets import ImageFolder
from tqdm.auto import tqdm

import timm
from timm.data.naflex_transforms import ResizeToSequence, Patchify
from timm.data.naflex_dataset import NaFlexCollator

DEVICE = "cuda"
DATA_DIR = "path/to/imagenette2-320"  # https://github.com/fastai/imagenette
PATCH_SIZE = 16
MAX_DIM = 256
NUM_CLASSES = 10
LR = 0.01
EPOCHS = 20
BATCH_SIZE = 64


def get_square_dataloaders():
    normalize = transforms.Normalize(
        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225],
    )
    train_tf = transforms.Compose([
        transforms.RandomResizedCrop(MAX_DIM),
        transforms.RandomHorizontalFlip(),
        transforms.ToTensor(),
        normalize,
    ])
    val_tf = transforms.Compose([
        transforms.Resize(MAX_DIM),
        transforms.CenterCrop(MAX_DIM),
        transforms.ToTensor(),
        normalize,
    ])
    train_ds = ImageFolder(os.path.join(DATA_DIR, "train"), train_tf)
    val_ds = ImageFolder(os.path.join(DATA_DIR, "val"), val_tf)
    return (
        DataLoader(
            train_ds, batch_size=BATCH_SIZE, shuffle=True,
            num_workers=4, pin_memory=True,
        ),
        DataLoader(
            val_ds, batch_size=BATCH_SIZE, shuffle=False,
            num_workers=4, pin_memory=True,
        ),
    )


class NaFlexImageFolder(ImageFolder):
    def __init__(self, root, patch_size, max_seq_len, is_train=False):
        normalize = transforms.Normalize(
            mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225],
        )
        base_tf = transforms.Compose([
            *([transforms.RandomHorizontalFlip()] if is_train else []),
            transforms.ToTensor(),
            normalize,
        ])
        super().__init__(root, base_tf)
        self.resize_to_seq = ResizeToSequence(patch_size, max_seq_len)
        self.patchify = Patchify(patch_size)

    def __getitem__(self, index):
        path, target = self.samples[index]
        img = self.loader(path)
        img = self.resize_to_seq(img)
        img = self.transform(img)
        return self.patchify(img), target


def get_naflex_dataloaders():
    max_seq_len = (MAX_DIM // PATCH_SIZE) ** 2
    collator = NaFlexCollator(max_seq_len=max_seq_len)
    train_ds = NaFlexImageFolder(
        os.path.join(DATA_DIR, "train"), PATCH_SIZE, max_seq_len, is_train=True,
    )
    val_ds = NaFlexImageFolder(
        os.path.join(DATA_DIR, "val"), PATCH_SIZE, max_seq_len, is_train=False,
    )
    return (
        DataLoader(
            train_ds, batch_size=BATCH_SIZE, shuffle=True,
            num_workers=4, pin_memory=True, collate_fn=collator,
        ),
        DataLoader(
            val_ds, batch_size=BATCH_SIZE, shuffle=False,
            num_workers=4, pin_memory=True, collate_fn=collator,
        ),
    )


@torch.no_grad()
def extract_features(model, dataloader, is_naflex=False):
    model.eval()
    all_features, all_labels = [], []
    for inputs, labels in tqdm(dataloader, desc="Extracting features"):
        if is_naflex:
            inputs = {
                k: v.to(DEVICE) if isinstance(v, torch.Tensor) else v
                for k, v in inputs.items()
            }
        else:
            inputs = inputs.to(DEVICE)
        all_features.append(model(inputs).cpu())
        all_labels.append(labels)
    return torch.cat(all_features), torch.cat(all_labels)


def train_linear_probe(train_feat, train_labels, val_feat, val_labels, embed_dim):
    classifier = nn.Linear(embed_dim, NUM_CLASSES).to(DEVICE)
    optimizer = torch.optim.SGD(
        classifier.parameters(), lr=LR, momentum=0.9, weight_decay=1e-4,
    )
    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, EPOCHS)
    criterion = nn.CrossEntropyLoss()

    train_feat = train_feat.to(DEVICE)
    train_labels = train_labels.to(DEVICE)
    val_feat = val_feat.to(DEVICE)
    val_labels = val_labels.to(DEVICE)

    best_acc = 0.0
    for epoch in range(EPOCHS):
        classifier.train()
        perm = torch.randperm(len(train_feat))
        for i in range(0, len(train_feat), BATCH_SIZE):
            idx = perm[i : i + BATCH_SIZE]
            loss = criterion(classifier(train_feat[idx]), train_labels[idx])
            optimizer.zero_grad()
            loss.backward()
            optimizer.step()
        scheduler.step()

        classifier.eval()
        with torch.no_grad():
            acc = (
                (classifier(val_feat).argmax(1) == val_labels).float().mean().item()
            )
        best_acc = max(best_acc, acc)
    return best_acc


if __name__ == "__main__":
    # Square
    model = timm.create_model(
        'vit_small_patch16_dinov3.lvd1689m',
        pretrained=True, num_classes=0, global_pool='token',
    ).to(DEVICE).eval()
    train_dl, val_dl = get_square_dataloaders()
    tf, tl = extract_features(model, train_dl)
    vf, vl = extract_features(model, val_dl)
    sq = train_linear_probe(tf, tl, vf, vl, model.num_features)
    print(f"Square:  {sq * 100:.2f}%")

    # NaFlex
    model = timm.create_model(
        'vit_small_patch16_dinov3.lvd1689m',
        pretrained=True, use_naflex=True, num_classes=0, global_pool='token',
    ).to(DEVICE).eval()
    train_dl, val_dl = get_naflex_dataloaders()
    tf, tl = extract_features(model, train_dl, is_naflex=True)
    vf, vl = extract_features(model, val_dl, is_naflex=True)
    nf = train_linear_probe(tf, tl, vf, vl, model.num_features)
    print(f"NaFlex:  {nf * 100:.2f}%")
    print(f"Diff:    {(nf - sq) * 100:+.2f}%")
```

</details>
