### PR TITLE
validate.py: add --seed for reproducible validation

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -22,6 +22,7 @@ import torch
 import torch.nn as nn
 import torch.nn.parallel
 
+from timm import utils
 from timm.data import create_dataset, create_loader, resolve_data_config, RealLabelsImagenet
 from timm.layers import apply_test_time_pool, set_fast_norm
 from timm.models import create_model, load_checkpoint, is_model, list_models
@@ -156,6 +157,8 @@ parser.add_argument('--valid-labels', default='', type=str, metavar='FILENAME',
                     help='Valid label indices txt file for validation of partial label space')
 parser.add_argument('--retry', default=False, action='store_true',
                     help='Enable batch size decay & retry for single model validation')
+parser.add_argument('--seed', type=int, default=42, metavar='S',
+                    help='random seed (default: 42)')
 
 parser.add_argument('--metrics-avg', type=str, default=None,
                     choices=['micro', 'macro', 'weighted'],
@@ -200,6 +203,8 @@ def validate(args):
         _logger.info('Validating in mixed precision with native PyTorch AMP.')
     else:
         _logger.info(f'Validating in {model_dtype or torch.float32}. AMP not enabled.')
+
+    utils.random_seed(args.seed)
 
     if args.fuser:
         set_jit_fuser(args.fuser)
@@ -282,6 +287,7 @@ def validate(args):
         input_img_mode=input_img_mode,
         target_key=args.target_key,
         trust_remote_code=args.dataset_trust_remote_code,
+        seed=args.seed,
     )
 
     if args.valid_labels:


### PR DESCRIPTION
## Summary

Adds `--seed` to `validate.py` and plumbs it through `utils.random_seed()` and `create_dataset(seed=...)`, mirroring what `train.py` already does. Currently `validate.py` has no way to fix Python/NumPy/PyTorch RNG state or the dataset reader's shuffle seed, so repeated runs against the same checkpoint can produce slightly different results when the dataset reader is stochastic (TFDS subsplits, `IterableDatasets`, partial-sample validation via `--num-samples`, etc.).

Default is `42`, matching `train.py`. No behavior change for users who don't pass `--seed`.

## Why

`train.py` already plumbs a seed end-to-end (`train.py:357` arg, `train.py:485` `utils.random_seed(args.seed, args.rank)`, `train.py:668` `create_dataset(..., seed=args.seed)`). `validate.py` has none of this, so anyone driving validation programmatically — CI, sweeps, performance benchmarks where validate doubles as a fixed-shape harness — currently has no way to reproduce a run.

## Test plan

- `python validate.py --help` shows `--seed` in the output.
- Two runs with the same `--seed` against a small in-memory dataset produce identical top-1/top-5; different seeds visibly differ for stochastic readers.

## Notes

`utils.random_seed(args.seed)` is called without a `rank` arg because `validate.py` uses DataParallel-style `--num-gpu` rather than DDP — there's no per-rank seed offset to apply, unlike `train.py`.