### PR TITLE
Fix ZeroDivisionError in AverageMeter.update when count is 0

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,14 @@ from timm.utils.model import _freeze_unfreeze
 from timm.utils.model import avg_sq_ch_mean, avg_ch_var, avg_ch_var_residual
 from timm.utils.model import reparameterize_model
 from timm.utils.model import get_state_dict
+from timm.utils.metrics import AverageMeter
+
+def test_average_meter_zero_count():
+    # update with n=0 on a fresh meter (count == 0) must not raise ZeroDivisionError
+    meter = AverageMeter()
+    meter.update(1.0, n=0)
+    assert meter.avg == 0
+
 
 def test_freeze_unfreeze():
     model = timm.create_model('resnet18')

--- a/timm/utils/metrics.py
+++ b/timm/utils/metrics.py
@@ -19,7 +19,7 @@ class AverageMeter:
         self.val = val
         self.sum += val * n
         self.count += n
-        self.avg = self.sum / self.count
+        self.avg = self.sum / self.count if self.count else 0
 
 
 def accuracy(output, target, topk=(1,)):


### PR DESCRIPTION
`AverageMeter.update(val, n=0)` on a fresh meter raises `ZeroDivisionError`:

```python
from timm.utils import AverageMeter

m = AverageMeter()
m.update(0.0, n=0)   # ZeroDivisionError: division by zero
```

`update` computes `self.avg = self.sum / self.count`, and on the first update with `n == 0` the count is still `0`. This is reachable from real averaging code that weights by a per-batch sample count, e.g. `meter.update(metric, n=num_valid_in_batch)` where a batch contributes zero valid samples — the first such batch (or the first batch of an epoch after `reset()`) crashes. Once any non-zero update has happened, `n=0` is harmless.

This guards the zero count so the average stays `0` instead of raising; behavior for all non-zero counts is unchanged. A regression test is added in `tests/test_utils.py`.