### PR TITLE
Fix inference.py labels for models fine-tuned on non-ImageNet datasets

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -18,7 +18,8 @@ import numpy as np
 import pandas as pd
 import torch
 
-from timm.data import create_dataset, create_loader, resolve_data_config, ImageNetInfo, infer_imagenet_subset
+from timm.data import create_dataset, create_loader, resolve_data_config, ImageNetInfo, infer_imagenet_subset, \
+    CustomDatasetInfo
 from timm.layers import apply_test_time_pool
 from timm.models import create_model
 from timm.utils import AverageMeter, setup_default_logging, set_jit_fuser, ParseKwargs
@@ -247,9 +248,22 @@ def main():
 
     to_label = None
     if args.label_type in ('name', 'description', 'detail'):
-        imagenet_subset = infer_imagenet_subset(model)
-        if imagenet_subset is not None:
-            dataset_info = ImageNetInfo(imagenet_subset)
+        dataset_info = None
+        label_names = model.pretrained_cfg.get('label_names', None)
+        label_descriptions = model.pretrained_cfg.get('label_descriptions', None)
+        if label_names is not None:
+            # custom labels pushed with the model (e.g. fine-tuned on a non-ImageNet dataset)
+            dataset_info = CustomDatasetInfo(
+                label_names=label_names,
+                label_descriptions=label_descriptions,
+            )
+        else:
+            imagenet_subset = infer_imagenet_subset(model)
+            if imagenet_subset is not None:
+                dataset_info = ImageNetInfo(imagenet_subset)
+            else:
+                _logger.error("Cannot deduce ImageNet subset from model, no labelling will be performed.")
+        if dataset_info is not None:
             if args.label_type == 'name':
                 to_label = lambda x: dataset_info.index_to_label_name(x)
             elif args.label_type == 'detail':
@@ -257,8 +271,6 @@ def main():
             else:
                 to_label = lambda x: dataset_info.index_to_description(x)
             to_label = np.vectorize(to_label)
-        else:
-            _logger.error("Cannot deduce ImageNet subset from model, no labelling will be performed.")
 
     top_k = min(args.topk, args.num_classes)
     batch_time = AverageMeter()


### PR DESCRIPTION
Fixes #2419.

When running `inference.py` with `--label-type name/description/detail`, labels are
only resolved by inferring an ImageNet subset (`infer_imagenet_subset` + `ImageNetInfo`).
For a model fine-tuned on a non-ImageNet dataset, subset inference returns `None` and no
labels are emitted, even though the correct labels ship with the model in its
`pretrained_cfg`.

This checks `model.pretrained_cfg` for `label_names` (and optional `label_descriptions`)
before falling back to the ImageNet subset path. When present, it builds a
`CustomDatasetInfo` and uses it for `index_to_label_name` / `index_to_description`.
ImageNet models are unaffected and still resolve through `ImageNetInfo`, and the
"cannot deduce ImageNet subset" error is preserved for models that have neither.

Verified locally: a model exposing `label_names` in `pretrained_cfg` now emits its own
labels, and an ImageNet model still resolves unchanged. No automated test added since
`inference.py` is a script.
