### PR TITLE
Make NaFlex position embedding sampling compile-friendly and memory-efficient

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -763,6 +763,120 @@ if 'GITHUB_ACTIONS' not in os.environ:
             assert tensor.shape[0] == batch_size
             assert not torch.isnan(tensor).any(), 'Output included NaNs'
 
+def _create_naflex_pos_embed_test_module(ar_preserving):
+    from timm.models.naflexvit import NaFlexEmbeds
+
+    return NaFlexEmbeds(
+        patch_size=2,
+        in_chans=3,
+        embed_dim=8,
+        proj_type='linear',
+        class_token=False,
+        pos_embed='learned',
+        pos_embed_grid_size=(5, 7),
+        pos_embed_ar_preserving=ar_preserving,
+        pos_embed_use_grid_sample=True,
+    )
+
+
+def _create_naflex_pos_embed_test_inputs():
+    patch_coord = torch.zeros(2, 12, 2, dtype=torch.long)
+    patch_coord[0, :6] = torch.cartesian_prod(torch.arange(2), torch.arange(3))
+    patch_coord[1] = torch.cartesian_prod(torch.arange(3), torch.arange(4))
+    patch_valid = torch.zeros(2, 12, dtype=torch.bool)
+    patch_valid[0, :6] = True
+    patch_valid[1] = True
+    patches = torch.randn(2, 12, 2 * 2 * 3)
+    return patches, patch_coord, patch_valid
+
+
+def _naflex_dense_grid_sample_reference(module, x, patch_coord):
+    """Previous dense-grid implementation used as a numerical and gradient reference."""
+    batch_size, _, channels = x.shape
+    shapes = patch_coord.amax(dim=1) + 1
+    if module.pos_embed_ar_preserving:
+        sample_lengths = shapes.amax(dim=1)
+        grid_height = grid_width = int(sample_lengths.amax())
+        scale_x = scale_y = sample_lengths.amax() / sample_lengths
+    else:
+        grid_height, grid_width = (int(v) for v in shapes.amax(dim=0))
+        scale_y = shapes[:, 0].amax() / shapes[:, 0]
+        scale_x = shapes[:, 1].amax() / shapes[:, 1]
+
+    theta = torch.zeros(batch_size, 2, 3, device=x.device, dtype=torch.float32)
+    theta[:, 0, 0] = scale_x
+    theta[:, 1, 1] = scale_y
+    theta[:, 0, 2] = scale_x - 1
+    theta[:, 1, 2] = scale_y - 1
+    grid = torch.nn.functional.affine_grid(
+        theta,
+        (batch_size, channels, grid_height, grid_width),
+        align_corners=False,
+    )
+    pos_embed = torch.nn.functional.grid_sample(
+        module.pos_embed.permute(0, 3, 1, 2).expand(batch_size, -1, -1, -1).float(),
+        grid,
+        mode=module.pos_embed_interp_mode,
+        align_corners=False,
+        padding_mode='border',
+    ).to(dtype=x.dtype)
+    batch_indices = torch.arange(batch_size, device=x.device, dtype=torch.long).unsqueeze(1)
+    return x + pos_embed[batch_indices, :, patch_coord[..., 0], patch_coord[..., 1]]
+
+
+@pytest.mark.base
+@pytest.mark.parametrize('ar_preserving', [False, True])
+def test_naflexvit_direct_grid_sample_parity(ar_preserving):
+    module = _create_naflex_pos_embed_test_module(ar_preserving)
+    _, patch_coord, _ = _create_naflex_pos_embed_test_inputs()
+    x_actual = torch.randn(2, 12, 8, requires_grad=True)
+    x_reference = x_actual.detach().clone().requires_grad_()
+
+    actual = x_actual + 0.0  # make non-leaf for the in-place embedding method
+    module._apply_learned_naflex_pos_embed_grid_sample(actual, patch_coord)
+    reference = _naflex_dense_grid_sample_reference(module, x_reference, patch_coord)
+
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    actual_grads = torch.autograd.grad(actual.square().mean(), (x_actual, module.pos_embed))
+    reference_grads = torch.autograd.grad(reference.square().mean(), (x_reference, module.pos_embed))
+    for actual_grad, reference_grad in zip(actual_grads, reference_grads):
+        torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.base
+@pytest.mark.skipif(not hasattr(torch, 'compile'), reason='requires torch.compile')
+@pytest.mark.parametrize('ar_preserving', [False, True])
+def test_naflexvit_direct_grid_sample_fullgraph(ar_preserving):
+    module = _create_naflex_pos_embed_test_module(ar_preserving).eval()
+    inputs = _create_naflex_pos_embed_test_inputs()
+
+    with torch.inference_mode():
+        expected = module(*inputs)
+        actual = torch.compile(module, backend='eager', fullgraph=True)(*inputs)
+
+    torch.testing.assert_close(actual[0], expected[0])
+    assert actual[1] == expected[1]
+
+
+@pytest.mark.base
+@pytest.mark.skipif(
+    not hasattr(torch, 'export') or not hasattr(torch.export, 'export'),
+    reason='requires torch.export.export',
+)
+@pytest.mark.parametrize('ar_preserving', [False, True])
+def test_naflexvit_direct_grid_sample_export(ar_preserving):
+    module = _create_naflex_pos_embed_test_module(ar_preserving).eval()
+    inputs = _create_naflex_pos_embed_test_inputs()
+
+    with torch.inference_mode():
+        expected = module(*inputs)
+        exported = torch.export.export(module, inputs).module()
+        actual = exported(*inputs)
+
+    torch.testing.assert_close(actual[0], expected[0])
+    assert actual[1] == expected[1]
+
+
 def test_naflexvit_forward_intermediates_dict_input():
     """NaFlex (pre-patchified dict) inputs through forward_intermediates: NLC-only, final-feature
     parity with forward_features, patch_valid surfaced for downstream masking/scatter."""

--- a/timm/models/naflexvit.py
+++ b/timm/models/naflexvit.py
@@ -211,6 +211,18 @@ def calculate_naflex_grid_sizes(_coord: torch.Tensor):
     return [(int(h.item()), int(w.item())) for h, w in zip(max_y, max_x)]
 
 
+def _normalize_naflex_grid_sample_coords(
+        patch_coord: torch.Tensor,
+        ar_preserving: bool = False,
+) -> torch.Tensor:
+    """Normalize NaFlex patch coordinates for ``grid_sample`` with ``align_corners=False``."""
+    shapes = patch_coord.amax(dim=1) + 1
+    if ar_preserving:
+        shapes = shapes.amax(dim=1, keepdim=True).expand_as(shapes)
+
+    return (2.0 * patch_coord.to(dtype=torch.float32) + 1.0) / shapes[:, None, :] - 1.0
+
+
 class NaFlexRopeIterator:
     """Iterator for generating batched ROPE embeddings for mixed mode with multiple grid sizes."""
 
@@ -629,7 +641,6 @@ class NaFlexEmbeds(nn.Module):
                 pos_embed_flat[:, :seq_len].expand(len(batch_indices), -1, -1)
             )
 
-    @disable_compiler
     def _apply_learned_naflex_pos_embed_grid_sample(
             self,
             x: torch.Tensor,
@@ -637,44 +648,28 @@ class NaFlexEmbeds(nn.Module):
     ) -> None:
         """Apply learned position embeddings to NaFlex batch using grid_sample.
 
-        Uses F.grid_sample for efficient interpolation of learned 2D position embeddings
-        based on patch coordinates. Based on proposal by https://github.com/stas-sl
+        Directly samples the learned 2D position embeddings at each patch coordinate,
+        avoiding a dense grid sized by the largest height and width in the batch.
+        Based on proposal by https://github.com/stas-sl
 
         Args:
             x: Input tensor to add position embeddings to [B, N, C]
             patch_coord: Patch coordinates [B, N, 2] with (y, x) values
         """
-        device = x.device
-        B, N, C = x.shape
-        shapes = patch_coord.max(dim=1).values + 1  # (B, 2) containing [h_i, w_i]
-
-        if self.pos_embed_ar_preserving:
-            L_i = shapes.amax(dim=1)  # (B,) max(h_i, w_i)
-            L_global = L_i.amax()
-            grid_size_y = grid_size_x = L_global
-            scale_x = scale_y = L_global / L_i  # uniform zoom (B,)
-        else:
-            grid_size_y, grid_size_x = shapes.amax(dim=0)  # (2,)
-            scale_y = grid_size_y / shapes[:, 0]  # vertical zoom (B,)
-            scale_x = grid_size_x / shapes[:, 1]  # horizontal zoom (B,)
-
-        theta = torch.zeros(B, 2, 3, device=device, dtype=torch.float32)
-        theta[:, 0, 0] = scale_x
-        theta[:, 1, 1] = scale_y
-        theta[:, 0, 2] = scale_x - 1  # translate x
-        theta[:, 1, 2] = scale_y - 1  # translate y
-
-        grid = F.affine_grid(theta, (B, C, grid_size_y, grid_size_x), align_corners=False)
+        B = x.shape[0]
+        grid = _normalize_naflex_grid_sample_coords(
+            patch_coord,
+            ar_preserving=self.pos_embed_ar_preserving,
+        ).flip(-1).unsqueeze(2)  # (B, N, 1, 2), grid_sample coordinate order is (x, y)
         pos_embed = F.grid_sample(
             self.pos_embed.permute(0, 3, 1, 2).expand(B, -1, -1, -1).float(),
             grid,
             mode=self.pos_embed_interp_mode,
             align_corners=False,
             padding_mode='border',
-        ).to(dtype=x.dtype)  # (B, C, H_out, W_out)
+        ).to(dtype=x.dtype)  # (B, C, N, 1)
 
-        bi = torch.arange(B, device=device, dtype=torch.long).unsqueeze(1)
-        x += pos_embed[bi, :, patch_coord[..., 0], patch_coord[..., 1]]  # NOTE leave as '+='
+        x += pos_embed.squeeze(-1).transpose(1, 2)  # NOTE leave as '+='
 
     def _apply_learned_pos_embed(
             self,


### PR DESCRIPTION
## Motivation

NaFlex's opt-in `grid_sample` path builds an intermediate grid from the largest height and width in the batch. Its data-dependent shape prevents `torch.compile`/`torch.export` capture and can do substantially more work than the `N` input tokens, especially for batches mixing tall and wide grids.

## Approach

Sample learned 2D positional embeddings directly at the supplied patch coordinates using a `[B, N, 1, 2]` grid. This also supports aspect-ratio-preserving mode. Factorized embeddings keep their existing row/column interpolation path.

## Expected value

- Enables `torch.compile(fullgraph=True)` and `torch.export` for the opt-in learned position embedding path.
- Reduces positional-embedding intermediates from `O(B * C * max_h * max_w)` to `O(B * C * N)`.
- Avoids pathological dense grids for heterogeneous aspect ratios.
- Keeps the existing grid-sample numerical behavior and gradient flow.

The default remains `pos_embed_use_grid_sample=False`, and the legacy antialiased interpolation and factorized paths are unchanged.

An A10 microbenchmark (`B=32`, `N=576`, `C=768`) measured 1.06x speedup for square grids, 2.76x for mixed `12x48`/`48x12`, and 5.97x for mixed `8x72`/`72x8`. In the mixed cases, forward peak memory fell from 325/731 MB to 82 MB. These are position-embedding results, not end-to-end model measurements.
[benchmark_naflex_pos_embed.py](https://github.com/user-attachments/files/29969821/benchmark_naflex_pos_embed.py)

## Tests

Added forward and gradient parity coverage for both aspect-ratio modes with mixed grids and padded sequences, plus `torch.compile(fullgraph=True)` and `torch.export` capture tests. Targeted result: `7 passed`.
