### PR TITLE
Cache NaFlex patch interpolation and expose variable-patch capabilities

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,23 @@
+import torch
+
+from timm.data import create_transform
+
+
+def test_naflex_eval_patchify_can_preserve_spatial_patch_dimensions():
+    common_kwargs = dict(
+        input_size=(3, 16, 16),
+        is_training=False,
+        naflex=True,
+        patch_size=(2, 2),
+        max_seq_len=16,
+        patchify=True,
+    )
+    image = torch.rand(3, 8, 8)
+
+    spatial = create_transform(**common_kwargs, patchify_flatten=False)(image)
+    flattened = create_transform(**common_kwargs)(image)
+
+    assert spatial['patches'].ndim == 4
+    assert spatial['patches'].shape[1:] == (2, 2, 3)
+    assert flattened['patches'].ndim == 2
+    assert flattened['patches'].shape[-1] == 2 * 2 * 3

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -2,7 +2,16 @@ import pytest
 import torch
 import torch.nn as nn
 
-from timm.layers import create_act_layer, set_layer_config, get_act_layer, get_act_fn, Attention2d, MultiQueryAttentionV2
+from timm.layers import (
+    Attention2d,
+    MultiQueryAttentionV2,
+    PatchEmbedInterpolator,
+    create_act_layer,
+    get_act_fn,
+    get_act_layer,
+    resample_patch_embed,
+    set_layer_config,
+)
 
 import importlib
 import os
@@ -11,6 +20,91 @@ torch_backend = os.environ.get('TORCH_BACKEND')
 if torch_backend is not None:
     importlib.import_module(torch_backend)
 torch_device = os.environ.get('TORCH_DEVICE', 'cpu')
+
+
+def test_patch_embed_interpolator_reuses_nonpersistent_cache(monkeypatch):
+    interpolator = PatchEmbedInterpolator((4, 4), in_chans=3, embed_dim=8)
+    linear_weight = torch.randn(8, 4 * 4 * 3, requires_grad=True)
+    conv_weight = torch.randn(8, 3, 4, 4)
+    expected_conv_weight = resample_patch_embed(conv_weight, [2, 2])
+
+    original_pinv = torch.linalg.pinv
+    pinv_calls = 0
+
+    def counted_pinv(*args, **kwargs):
+        nonlocal pinv_calls
+        pinv_calls += 1
+        return original_pinv(*args, **kwargs)
+
+    monkeypatch.setattr(torch.linalg, 'pinv', counted_pinv)
+    first = interpolator.resample_linear_weight(linear_weight, (2, 2))
+    second = interpolator.resample_linear_weight(linear_weight, (2, 2))
+    actual_conv_weight = interpolator.resample_conv_weight(conv_weight, (2, 2))
+
+    assert pinv_calls == 1
+    torch.testing.assert_close(first, second)
+    torch.testing.assert_close(actual_conv_weight, expected_conv_weight)
+    first.sum().backward()
+    assert linear_weight.grad is not None
+    assert (2, 2) in interpolator.resampler._pinv_cache_map
+    assert not any(name.endswith('pinv_2x2') for name, _ in interpolator.named_buffers())
+    assert not any('pinv_' in name for name in interpolator.state_dict())
+    interpolator.to(dtype=torch.float16)
+    assert not interpolator.resampler._pinv_cache_map
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='requires CUDA autocast')
+def test_patch_embed_interpolator_cache_survives_autocast(monkeypatch):
+    device = torch.device('cuda')
+    interpolator = PatchEmbedInterpolator(
+        (4, 4),
+        in_chans=3,
+        embed_dim=8,
+        device=device,
+    ).to(device)
+    weight = torch.randn(8, 4 * 4 * 3, device=device)
+
+    with torch.autocast(device_type='cuda', dtype=torch.bfloat16):
+        first = interpolator.resample_linear_weight(weight, (2, 2))
+
+    cached_matrix = interpolator.resampler._pinv_cache_map[(2, 2)]
+    assert cached_matrix.dtype == torch.float32
+
+    def unexpected_pinv(*args, **kwargs):
+        raise AssertionError('cache hit recomputed the pseudoinverse')
+
+    monkeypatch.setattr(torch.linalg, 'pinv', unexpected_pinv)
+    with torch.autocast(device_type='cuda', dtype=torch.bfloat16):
+        second = interpolator.resample_linear_weight(weight, (2, 2))
+
+    torch.testing.assert_close(first, second)
+
+
+@pytest.mark.skipif(not hasattr(torch, 'compile'), reason='requires torch.compile')
+def test_patch_embed_interpolator_prewarm_supports_fullgraph_compile():
+    class InterpolatingProjection(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.interpolator = PatchEmbedInterpolator((4, 4), in_chans=3, embed_dim=8)
+            self.weight = nn.Parameter(torch.randn(8, 4 * 4 * 3))
+            self.interpolator.prewarm([(2, 2)])
+
+        def forward(self, x):
+            return self.interpolator(
+                x,
+                self.weight,
+                patch_size=(2, 2),
+                is_linear=True,
+            )
+
+    module = InterpolatingProjection().eval()
+    patches = torch.randn(1, 3, 2, 2, 3)
+
+    with torch.inference_mode():
+        expected = module(patches)
+        actual = torch.compile(module, backend='eager', fullgraph=True)(patches)
+
+    torch.testing.assert_close(actual, expected)
 
 class MLP(nn.Module):
     def __init__(self, act_layer="relu", inplace=True):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -915,6 +915,39 @@ def test_naflexvit_forward_intermediates_dict_input():
 
 
 @pytest.mark.base
+def test_naflexvit_patch_interpolation_capability():
+    common_kwargs = dict(embed_dim=32, depth=1, num_heads=2)
+    fixed_model = create_model('naflexvit_base_patch16_gap', **common_kwargs)
+    variable_model = create_model(
+        'naflexvit_base_patch16_gap',
+        enable_patch_interpolator=True,
+        **common_kwargs,
+    )
+    conv_model = create_model(
+        'naflexvit_base_patch16_gap',
+        enable_patch_interpolator=True,
+        embed_proj_type='conv',
+        **common_kwargs,
+    )
+
+    assert not fixed_model.supports_patch_interpolation
+    assert variable_model.supports_patch_interpolation
+    assert not conv_model.supports_patch_interpolation
+    with pytest.raises(RuntimeError, match='not supported'):
+        fixed_model.prewarm_patch_interpolator([(8, 8)])
+
+    variable_model.prewarm_patch_interpolator([(8, 8)])
+    assert not any('pinv_' in name for name in variable_model.state_dict())
+
+    patches = torch.randn(1, 4, 8, 8, 3)
+    patch_coord = torch.tensor([[[0, 0], [0, 1], [1, 0], [1, 1]]])
+    patch_valid = torch.ones(1, 4, dtype=torch.bool)
+    output = variable_model(patches, patch_coord=patch_coord, patch_valid=patch_valid)
+    output.sum().backward()
+    assert variable_model.embeds.proj.weight.grad is not None
+
+
+@pytest.mark.base
 def test_naflexvit_key_only_attn_mask_is_opt_in_and_post_patch_dropout():
     batch_size, num_patches = 2, 8
     patches = torch.randn(batch_size, num_patches, 16 * 16 * 3)

--- a/timm/data/transforms_factory.py
+++ b/timm/data/transforms_factory.py
@@ -285,6 +285,7 @@ def transforms_imagenet_eval(
         max_seq_len: int = 576,  # 24x24 for 16x16 patch
         patchify: bool = False,
         patchify_channels_last: bool = True,
+        patchify_flatten: bool = True,
 ):
     """ ImageNet-oriented image transform for evaluation and inference.
 
@@ -302,6 +303,9 @@ def transforms_imagenet_eval(
         patch_size: Patch size for NaFlex mode.
         max_seq_len: Max sequence length for NaFlex mode.
         patchify: Patchify the output instead of relying on prefetcher
+        patchify_channels_last: Use channels-last layout within each patch.
+        patchify_flatten: Flatten each patch into a vector. Disable for variable
+            patch-size interpolation, which requires spatial patch dimensions.
 
     Returns:
         Composed transform pipeline
@@ -371,7 +375,11 @@ def transforms_imagenet_eval(
         ]
 
     if patchify:
-        tfl += [Patchify(patch_size=patch_size, channels_last=patchify_channels_last)]
+        tfl += [Patchify(
+            patch_size=patch_size,
+            flatten_patches=patchify_flatten,
+            channels_last=patchify_channels_last,
+        )]
 
     return transforms.Compose(tfl)
 
@@ -409,6 +417,7 @@ def create_transform(
         max_seq_len: int = 576,  # 24x24 for 16x16 patch
         patchify: bool = False,
         patchify_channels_last: bool = True,
+        patchify_flatten: bool = True,
 ):
     """
 
@@ -441,6 +450,8 @@ def create_transform(
         use_prefetcher: Pre-fetcher enabled. Do not convert image to tensor or normalize.
         normalize: Normalization tensor output w/ provided mean/std (if prefetcher not used).
         separate: Output transforms in 3-stage tuple.
+        patchify_flatten: Flatten eval patches into vectors. Disable when the
+            model needs their spatial dimensions for patch-size interpolation.
 
     Returns:
         Composed transforms or tuple thereof
@@ -515,6 +526,7 @@ def create_transform(
                 max_seq_len=max_seq_len,
                 patchify=patchify,
                 patchify_channels_last=patchify_channels_last,
+                patchify_flatten=patchify_flatten,
             )
 
     return transform

--- a/timm/layers/patch_embed.py
+++ b/timm/layers/patch_embed.py
@@ -10,7 +10,7 @@ Hacked together by / Copyright 2020 Ross Wightman
 """
 import logging
 import math
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
 from torch import nn as nn
@@ -347,13 +347,15 @@ class PatchEmbedResamplerFixedOrigSize(nn.Module):
             self,
             orig_size: Tuple[int, int],
             interpolation: str = 'bicubic',
-            antialias: bool = True
+            antialias: bool = True,
+            device=None,
     ):
         """
         Args:
             orig_size (Tuple[int, int]): The expected original (height, width) of input patch_embed tensors.
             interpolation (str): Interpolation mode.
             antialias (bool): Use anti-aliasing filter in resize.
+            device: Device used for cache prewarming before the first forward.
         """
         super().__init__()
         assert isinstance(orig_size, tuple) and len(orig_size) == 2, \
@@ -361,8 +363,17 @@ class PatchEmbedResamplerFixedOrigSize(nn.Module):
         self.orig_size = orig_size # expected original size
         self.interpolation = interpolation
         self.antialias = antialias
-        # Cache map key is the target new_size tuple
-        self._pinv_cache_map: Dict[Tuple[int, int], str] = {}
+        # Runtime-only cache. Keep matrices out of module buffers so DDP does
+        # not broadcast derived data on every forward.
+        self._pinv_cache_map: Dict[Tuple[int, int], torch.Tensor] = {}
+        # Tracks the module device before any matrices have been cached. The
+        # anchor and cached matrices are derived state and do not belong in a
+        # checkpoint.
+        self.register_buffer(
+            '_cache_device_anchor',
+            torch.empty(0, dtype=torch.uint8, device=device),
+            persistent=False,
+        )
 
     def _get_or_create_pinv_matrix(
             self,
@@ -371,28 +382,52 @@ class PatchEmbedResamplerFixedOrigSize(nn.Module):
             dtype: torch.dtype = DTYPE_INTERMEDIATE
     ) -> torch.Tensor:
         """Retrieves the cached pinv matrix or computes and caches it for the given new_size."""
-        cache_key = new_size
-        buffer_name = self._pinv_cache_map.get(cache_key)
-
-        if buffer_name and hasattr(self, buffer_name):
-            pinv_matrix = getattr(self, buffer_name)
+        pinv_matrix = self._pinv_cache_map.get(new_size)
+        if pinv_matrix is not None:
             if pinv_matrix.device == device and pinv_matrix.dtype == dtype:
-                 return pinv_matrix
+                return pinv_matrix
 
         # Calculate the matrix if not cached or needs update
-        resize_mat = _compute_resize_matrix(
-            self.orig_size, new_size, self.interpolation, self.antialias, device, dtype
-        )
-        pinv_matrix = torch.linalg.pinv(resize_mat)  # Calculates the pseudoinverse matrix used for resampling
+        # Always cache a regular float32 tensor so it remains usable if an
+        # inference forward is followed by training and backward, and so an
+        # autocast miss does not poison subsequent cache lookups with a lower
+        # precision matrix.
+        with torch.inference_mode(False), torch.autocast(device_type=device.type, enabled=False):
+            resize_mat = _compute_resize_matrix(
+                self.orig_size, new_size, self.interpolation, self.antialias, device, dtype
+            )
+            pinv_matrix = torch.linalg.pinv(resize_mat)  # Calculates the pseudoinverse matrix used for resampling
 
-        # Cache using register_buffer
-        buffer_name = f"pinv_{new_size[0]}x{new_size[1]}"
-        if hasattr(self, buffer_name):
-             delattr(self, buffer_name)
-        self.register_buffer(buffer_name, pinv_matrix)
-        self._pinv_cache_map[cache_key] = buffer_name # Map new_size key to buffer name
+        self._pinv_cache_map[new_size] = pinv_matrix
 
         return pinv_matrix
+
+    def _apply(self, fn):
+        # Cached tensors are not registered buffers. Drop them when the module
+        # moves device or dtype so stale allocations cannot be retained.
+        self._pinv_cache_map.clear()
+        return super()._apply(fn)
+
+    def prewarm(
+            self,
+            new_sizes: Iterable[Union[int, Tuple[int, int]]],
+            device: Optional[Union[str, torch.device]] = None,
+    ) -> None:
+        """Precompute resampling matrices for a collection of target sizes.
+
+        Prewarming is useful before ``torch.compile`` or other captured execution,
+        where creating a new cache entry during the first forward is undesirable.
+
+        Args:
+            new_sizes: Iterable of target patch sizes.
+            device: Device on which to build the cache. Defaults to this module's
+                current device.
+        """
+        device = torch.device(device) if device is not None else self._cache_device_anchor.device
+        for new_size in new_sizes:
+            new_size = to_2tuple(new_size)
+            if new_size != self.orig_size:
+                self._get_or_create_pinv_matrix(new_size, device)
 
     def forward(self, patch_embed: torch.Tensor, new_size: List[int]) -> torch.Tensor:
         """ Resamples the patch embedding weights to new_size.
@@ -446,6 +481,7 @@ class PatchEmbedInterpolator(nn.Module):
         antialias: Whether to use antialiasing during interpolation
         channels_last: Per-patch flat layout of the linear weight / patches:
             True -> (ph, pw, C) [NaFlex default], False -> (C, ph, pw).
+        device: Device used for cache prewarming before the first forward.
     """
 
     def __init__(
@@ -456,6 +492,7 @@ class PatchEmbedInterpolator(nn.Module):
             interpolation: str = 'bicubic',
             antialias: bool = True,
             channels_last: bool = True,
+            device=None,
     ):
         super().__init__()
         self.base_patch_size = base_patch_size
@@ -464,6 +501,20 @@ class PatchEmbedInterpolator(nn.Module):
         self.interpolation = interpolation
         self.antialias = antialias
         self.channels_last = channels_last
+        self.resampler = PatchEmbedResamplerFixedOrigSize(
+            orig_size=base_patch_size,
+            interpolation=interpolation,
+            antialias=antialias,
+            device=device,
+        )
+
+    def prewarm(
+            self,
+            target_patch_sizes: Iterable[Union[int, Tuple[int, int]]],
+            device: Optional[Union[str, torch.device]] = None,
+    ) -> None:
+        """Precompute interpolation matrices for target patch sizes."""
+        self.resampler.prewarm(target_patch_sizes, device=device)
 
     def resample_linear_weight(
             self,
@@ -493,14 +544,8 @@ class PatchEmbedInterpolator(nn.Module):
         else:
             weight_conv = weight.reshape(embed_dim, self.in_chans, base_ph, base_pw)
 
-        # Resample using existing function (operates on [out, in, h, w], layout-agnostic)
-        weight_conv_resampled = resample_patch_embed(
-            weight_conv,
-            new_size=[target_ph, target_pw],
-            interpolation=self.interpolation,
-            antialias=self.antialias,
-            verbose=False,
-        )
+        # Resample spatial dimensions with the shared pseudoinverse cache.
+        weight_conv_resampled = self.resampler(weight_conv, [target_ph, target_pw])
 
         # Reshape back to linear format [embed_dim, ph*pw*C] in the same channel order.
         if self.channels_last:
@@ -527,14 +572,7 @@ class PatchEmbedInterpolator(nn.Module):
         if target_patch_size == self.base_patch_size:
             return weight
 
-        # Resample using existing function
-        weight_resampled = resample_patch_embed(
-            weight,
-            new_size=list(target_patch_size),
-            interpolation=self.interpolation,
-            antialias=self.antialias,
-            verbose=False,
-        )
+        weight_resampled = self.resampler(weight, list(target_patch_size))
 
         return weight_resampled
 

--- a/timm/models/naflexvit.py
+++ b/timm/models/naflexvit.py
@@ -20,7 +20,7 @@ import logging
 import math
 from dataclasses import dataclass, fields, replace
 from functools import partial
-from typing import Callable, Dict, List, Optional, Set, Tuple, Type, Union, Any
+from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, Union, Any
 
 import torch
 import torch.nn as nn
@@ -494,9 +494,16 @@ class NaFlexEmbeds(nn.Module):
                 interpolation=pos_embed_interp_mode,
                 antialias=True,
                 channels_last=channels_last,
+                device=device,
             )
         else:
             self.patch_interpolator = None
+
+        self.supports_patch_interpolation = bool(
+            self.is_linear
+            and self.patch_interpolator is not None
+            and self.norm_input is None
+        )
 
         # Create normalization layer after the projection
         assert not (proj_norm_layer is True and norm_layer is None), \
@@ -543,6 +550,16 @@ class NaFlexEmbeds(nn.Module):
             nn.init.normal_(self.pos_embed_y, std=.02)
         if self.pos_embed_x is not None:
             nn.init.normal_(self.pos_embed_x, std=.02)
+
+    @torch.jit.ignore
+    def prewarm_patch_interpolator(
+            self,
+            patch_sizes: Iterable[Union[int, Tuple[int, int]]],
+    ) -> None:
+        """Precompute patch interpolation matrices on the projection device."""
+        if not self.supports_patch_interpolation:
+            raise RuntimeError('Patch interpolation is not supported by this embedding configuration.')
+        self.patch_interpolator.prewarm(patch_sizes, device=self.proj.weight.device)
 
     def feature_info(self, location) -> Dict[str, Any]:
         """Get feature information for feature extraction.
@@ -1198,6 +1215,7 @@ class NaFlexVit(nn.Module):
             channels_last=getattr(cfg, 'patchify_channels_last', True),
             **dd,
         )
+        self.supports_patch_interpolation = self.embeds.supports_patch_interpolation
         self.norm_pre = norm_layer(cfg.embed_dim, **dd) if cfg.pre_norm else nn.Identity()
 
         # ROPE position embeddings at model level
@@ -1398,6 +1416,14 @@ class NaFlexVit(nn.Module):
     def get_patch_size(self) -> Tuple[int, int]:
         """Return the 2-tuple patch size. For NaFlex dataloader / transform wiring."""
         return self.embeds.patch_size
+
+    @torch.jit.ignore
+    def prewarm_patch_interpolator(
+            self,
+            patch_sizes: Iterable[Union[int, Tuple[int, int]]],
+    ) -> None:
+        """Precompute patch interpolation matrices before captured execution."""
+        self.embeds.prewarm_patch_interpolator(patch_sizes)
 
     @torch.jit.ignore
     def group_matcher(self, coarse: bool = False) -> Dict:


### PR DESCRIPTION
## Motivation

While fixing variable patch-size integration in [mlfoundations/open_clip#1195](https://github.com/mlfoundations/open_clip/pull/1195), I noticed a few generic improvements that belong in timm. In particular, every non-base patch-size forward rebuilt the resize basis and ran `torch.linalg.pinv`, even though training usually cycles through a small fixed set of patch sizes.

The existing `PatchEmbedResamplerFixedOrigSize` already had most of the required caching logic, but `PatchEmbedInterpolator` did not use it and the cached matrices were persistent buffers. Downstream integrations also had no reliable way to discover whether a NaFlex model supports variable patches, while eval transforms always flattened patches before the model could infer their spatial size.

## Changes

### Cached interpolation and prewarming

`PatchEmbedInterpolator` now shares a `PatchEmbedResamplerFixedOrigSize` between linear and convolutional weight resampling. Each matrix is computed once per target patch size and device, then kept in a runtime-only cache. Cache misses produce regular float32 tensors even under inference mode or autocast; device or dtype conversion clears stale entries. The cache adds no parameters or persistent buffers, so checkpoint keys remain unchanged; the standalone `resample_patch_embed` function and both linear patch layouts continue to behave as before.

The cache can be populated before `torch.compile` or another captured execution path:

```python
model = timm.create_model(
    'naflexvit_base_patch16_gap',
    enable_patch_interpolator=True,
).to(device)
model.prewarm_patch_interpolator([(8, 8), (12, 12), (16, 16)])
model = torch.compile(model)
```

Prewarming should happen after moving the model to its execution device. The base patch size is a no-op. Each unique non-base patch size retains one float32 resampling matrix; there is intentionally no eviction policy because NaFlex training normally uses a small configured set of patch sizes.

### Capability discovery and evaluation layout

`NaFlexVit.supports_patch_interpolation` reports the resolved capability: a linear projection with an enabled interpolator and no incompatible input normalization.

`create_transform` and `transforms_imagenet_eval` now accept `patchify_flatten=False`, returning spatial patches such as `[N, Ph, Pw, C]`. The default remains `True`, so existing transform calls retain their flattened output.

## Benchmark

Both benchmarks ran on an NVIDIA A10 with PyTorch 2.11.0+cu128.

### Patch-resampling cache

[benchmark_patch_interpolator_cache.py](https://github.com/user-attachments/files/30010581/benchmark_patch_interpolator_cache.py) compares a float32 channels-last projection (`embed_dim=768`, `in_chans=3`, base patch 16x16). Values are median latency per call.

| Target patch | Previous uncached | Cache miss | Cache hit | Hit speedup | Cache size |
| --- | ---: | ---: | ---: | ---: | ---: |
| 8x8 | 2.319 ms | 2.337 ms | 0.428 ms | 5.41x | 64 KiB |
| 12x12 | 5.986 ms | 5.998 ms | 0.857 ms | 6.98x | 144 KiB |
| 32x32 | 12.973 ms | 12.994 ms | 3.442 ms | 3.77x | 1024 KiB |

Cache misses match the previous path, while repeated sizes avoid resize-matrix construction and `torch.linalg.pinv`.

### Synthetic OpenCLIP training step

[benchmark_open_clip_patch_interpolation_e2e.py](https://github.com/user-attachments/files/30010601/benchmark_open_clip_patch_interpolation_e2e.py) compares forced misses and cache hits over a full single-GPU OpenCLIP training step. The run used `naflex_ViT-B-16`, BF16 autocast, batch size 32, sequence length 196, and 32x32 patches; ten pairs were measured after warmup.

| Mode | Median step | IQR | Samples/s |
| --- | ---: | ---: | ---: |
| Previous behavior / forced miss | 150.732 ms | 0.264 ms | 212.30 |
| Cache hit | 139.797 ms | 0.943 ms | 228.90 |

This synthetic workload shows a **7.25% latency reduction** and **7.82% throughput increase** with a 1 MiB cache. End-to-end gains will vary with workload and patch-size distribution.

## Tests

**46 targeted tests passed**, covering cache reuse and dtype, gradients and checkpoint state, prewarming with `torch.compile`, capability reporting, non-base patch forwards, and spatial eval patchification.

