### PR TITLE
Add LingBot-Vision models

### DIFF
--- a/timm/models/eva.py
+++ b/timm/models/eva.py
@@ -8,6 +8,7 @@ This file contains a number of ViT variants the utilise ROPE position embeddings
  * Perception Encoder (PE) ViT from Meta (https://arxiv.org/abs/2504.13181)
  * ROPE-ViT from Naver AI (https://arxiv.org/abs/2403.13298)
  * DINOv3 from META AI Research (https://arxiv.org/abs/2508.10104)
+ * LingBot-Vision from Robbyant (https://arxiv.org/abs/2607.05247)
 
 @article{EVA,
   title={EVA: Exploring the Limits of Masked Visual Representation Learning at Scale},
@@ -55,8 +56,17 @@ EVA-02: A Visual Representation for Neon Genesis - https://arxiv.org/abs/2303.11
   url={https://arxiv.org/abs/2508.10104},
 }
 
+@article{lingbot-vision2026,
+  title={Vision Pretraining for Dense Spatial Perception},
+  author={Fu, Zelin and Tan, Bin and Sun, Changjiang and Liu, Shaohui and Zheng, Kecheng and Xu, Yinghao
+    and Zhu, Xing and Shen, Yujun and Xue, Nan},
+  journal={arXiv preprint arXiv:2607.05247},
+  year={2026}
+}
+
 DINOv3 code was a modification of existing EVA model and support modules, so licensed under Apache-2.0 like timm.
 Weights from META remain under DINOv3 License (https://ai.meta.com/resources/models-and-libraries/dinov3-license/).
+LingBot-Vision code and weights are released under Apache-2.0 (https://github.com/robbyant/lingbot-vision).
 
 Modifications by / Copyright 2023 Ross Wightman, original copyrights below
 """
@@ -1398,6 +1408,31 @@ def _eupe_cfg(url: str = '', **kwargs) -> Dict[str, Any]:
         'license': 'fair-noncommercial-research-license', **kwargs
     }
 
+
+def _lingbot_cfg(url: str = '', **kwargs) -> Dict[str, Any]:
+    """Generate default configuration for LingBot-Vision models.
+
+    Note: Original LingBot-Vision uses CLS-token pooling for representations. timm defaults to avg
+    pooling for the Eva architecture. Pass global_pool='token' at model creation to match
+    upstream behavior, which may be preferred for tasks like retrieval and few-shot classification.
+
+    Args:
+        url: Model weights URL.
+        **kwargs: Additional configuration parameters.
+
+    Returns:
+        Model configuration dictionary.
+    """
+    return {
+        'url': url,
+        'num_classes': 0, 'input_size': (3, 512, 512), 'pool_size': None,
+        'crop_pct': 1.0, 'crop_mode': 'squash', 'interpolation': 'bilinear', 'fixed_input_size': True,
+        'mean': IMAGENET_DEFAULT_MEAN, 'std': IMAGENET_DEFAULT_STD,
+        'first_conv': 'patch_embed.proj', 'classifier': 'head',
+        'license': 'apache-2.0', 'origin_url': 'https://github.com/robbyant/lingbot-vision',
+        'paper_ids': 'arXiv:2607.05247', **kwargs
+    }
+
 default_cfgs = generate_default_cfgs({
 
     # EVA 01 CLIP fine-tuned on imagenet-1k
@@ -1807,6 +1842,23 @@ default_cfgs = generate_default_cfgs({
     'vit_7b_patch16_dinov3.sat493m': _dinov3_cfg(
         hf_hub_id='timm/',
         mean=(0.430, 0.411, 0.296), std=(0.213, 0.156, 0.143),
+    ),
+
+    # LingBot-Vision weights are released under Apache-2.0, please see
+    # https://github.com/robbyant/lingbot-vision/blob/main/LICENSE
+    # NOTE: Original LingBot-Vision uses CLS-token pooling (global_pool='token') which may be better
+    # for some tasks. Default here is avg pooling inherited from the Eva base class.
+    'vit_small_patch16_lingbot.robbyant': _lingbot_cfg(
+        hf_hub_id='belfner/vit_small_patch16_lingbot.robbyant',
+    ),
+    'vit_base_patch16_lingbot.robbyant': _lingbot_cfg(
+        hf_hub_id='belfner/vit_base_patch16_lingbot.robbyant',
+    ),
+    'vit_large_patch16_lingbot.robbyant': _lingbot_cfg(
+        hf_hub_id='belfner/vit_large_patch16_lingbot.robbyant',
+    ),
+    'vit_giant_patch16_lingbot.robbyant': _lingbot_cfg(
+        hf_hub_id='belfner/vit_giant_patch16_lingbot.robbyant',
     ),
 
 })
@@ -3093,4 +3145,120 @@ def vit_7b_patch16_dinov3(pretrained: bool = False, **kwargs) -> Eva:
     )
 
     model = _create_eva('vit_7b_patch16_dinov3', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
+
+
+@register_model
+def vit_small_patch16_lingbot(pretrained: bool = False, **kwargs) -> Eva:
+    """LingBot-Vision S/16 https://arxiv.org/abs/2607.05247
+    NOTE: Pass global_pool='token' to use CLS-token pooling (matches upstream LingBot-Vision).
+    """
+    model_args = dict(
+        patch_size=16,
+        dynamic_img_size=True,
+        embed_dim=384,
+        depth=12,
+        num_heads=6,
+        qkv_bias=True,
+        # global_pool='token',  # upstream uses CLS token; default here is 'avg', pass via kwargs or --gp
+        init_values=1.0e-05, # layer-scale
+        rope_type='dinov3',
+        rope_temperature=100,
+        #rope_rescale_coords=2,  # haven't added to interface
+        rope_rotate_half=True,
+        use_rot_pos_emb=True,
+        use_abs_pos_emb=False,
+        num_reg_tokens=4,
+        use_fc_norm=False,
+        norm_layer=partial(LayerNorm, eps=1e-5),
+    )
+    model = _create_eva('vit_small_patch16_lingbot', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
+
+
+@register_model
+def vit_base_patch16_lingbot(pretrained: bool = False, **kwargs) -> Eva:
+    """LingBot-Vision B/16 https://arxiv.org/abs/2607.05247
+    NOTE: Pass global_pool='token' to use CLS-token pooling (matches upstream LingBot-Vision).
+    """
+    model_args = dict(
+        patch_size=16,
+        dynamic_img_size=True,
+        embed_dim=768,
+        depth=12,
+        num_heads=12,
+        qkv_bias=True,
+        # global_pool='token',  # upstream uses CLS token; default here is 'avg', pass via kwargs or --gp
+        init_values=1.0e-05, # layer-scale
+        rope_type='dinov3',
+        rope_temperature=100,
+        #rope_rescale_coords=2,  # haven't added to interface
+        rope_rotate_half=True,
+        use_rot_pos_emb=True,
+        use_abs_pos_emb=False,
+        num_reg_tokens=4,
+        use_fc_norm=False,
+        norm_layer=partial(LayerNorm, eps=1e-5),
+    )
+    model = _create_eva('vit_base_patch16_lingbot', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
+
+
+@register_model
+def vit_large_patch16_lingbot(pretrained: bool = False, **kwargs) -> Eva:
+    """LingBot-Vision L/16 https://arxiv.org/abs/2607.05247
+    NOTE: Pass global_pool='token' to use CLS-token pooling (matches upstream LingBot-Vision).
+    """
+    model_args = dict(
+        patch_size=16,
+        dynamic_img_size=True,
+        embed_dim=1024,
+        depth=24,
+        num_heads=16,
+        qkv_bias=True,
+        # global_pool='token',  # upstream uses CLS token; default here is 'avg', pass via kwargs or --gp
+        init_values=1.0e-05, # layer-scale
+        rope_type='dinov3',
+        rope_temperature=100,
+        #rope_rescale_coords=2,  # haven't added to interface
+        rope_rotate_half=True,
+        use_rot_pos_emb=True,
+        use_abs_pos_emb=False,
+        num_reg_tokens=4,
+        use_fc_norm=False,
+        norm_layer=partial(LayerNorm, eps=1e-5),
+    )
+    model = _create_eva('vit_large_patch16_lingbot', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
+
+
+@register_model
+def vit_giant_patch16_lingbot(pretrained: bool = False, **kwargs) -> Eva:
+    """LingBot-Vision G/16 https://arxiv.org/abs/2607.05247
+    NOTE: Pass global_pool='token' to use CLS-token pooling (matches upstream LingBot-Vision).
+    """
+    model_args = dict(
+        patch_size=16,
+        dynamic_img_size=True,
+        embed_dim=1536,
+        depth=40,
+        num_heads=24,
+        qkv_bias=False,
+        # global_pool='token',  # upstream uses CLS token; default here is 'avg', pass via kwargs or --gp
+        mlp_ratio=4 * 2 / 3,
+        init_values=1.0e-5, # layer-scale
+        rope_type='dinov3',
+        rope_temperature=100,
+        use_rot_pos_emb=True,
+        use_abs_pos_emb=False,
+        rope_rotate_half=True,
+        swiglu_mlp=True,
+        swiglu_align_to=8,
+        #rope_rescale_coords=2,  # haven't added to interface
+        num_reg_tokens=4,
+        use_fc_norm=False,
+        norm_layer=partial(LayerNorm, eps=1e-5),
+    )
+
+    model = _create_eva('vit_giant_patch16_lingbot', pretrained=pretrained, **dict(model_args, **kwargs))
     return model


### PR DESCRIPTION
## Summary

Add the LingBot-Vision family of self-supervised ViT backbones (Robbyant): Apache-2.0 weights for DINOv3-class dense-feature extraction, produced by masked-boundary pretraining (ViT-G) and distillation (S/B/L) on a ~161M image corpus ([paper](https://arxiv.org/abs/2607.05247), [code](https://github.com/robbyant/lingbot-vision)). **No new model code**: the checkpoints map onto the existing Eva/DINOv3 path through the existing `checkpoint_filter_fn` with zero filter changes. The diff is `timm/models/eva.py` only (+168: citation, `_lingbot_cfg` alongside `_dinov3_cfg`, 4 cfgs, 4 factories).

| Model | Embed Dim | Depth | Heads | QKV Bias | FFN | Params | Source |
|-------|-----------|-------|-------|----------|-----|--------|--------|
| `vit_small_patch16_lingbot.robbyant` | 384 | 12 | 6 | zero-K fused | GELU 4.0 | 21.6M | `robbyant/lingbot-vision-vit-small` |
| `vit_base_patch16_lingbot.robbyant` | 768 | 12 | 12 | zero-K fused | GELU 4.0 | 85.7M | `robbyant/lingbot-vision-vit-base` |
| `vit_large_patch16_lingbot.robbyant` | 1024 | 24 | 16 | zero-K fused | GELU 4.0 | 303.1M | `robbyant/lingbot-vision-vit-large` |
| `vit_giant_patch16_lingbot.robbyant` | 1536 | 40 | 24 | none | SwiGLU 4096 | 1134.5M | `robbyant/lingbot-vision-vit-giant` |

### Architecture

Per the reference configs/code, exactly the DINOv3 recipe already in `eva.py`: 4 register tokens, RoPE base 100 with rotate-half layout and separate-normalized coords, LayerScale 1e-5, `LinearKMaskedBias`-style fused QKV (learnable Q/V bias, zero K) on S/B/L, bias-free SwiGLU giant (`mlp_ratio=4 * 2 / 3`, aligned to 8 = 4096 wide — the DINOv2 giant2 1536/40/24 shape with DINOv3-style blocks). The 512px squash/bilinear input cfg matches the final high-resolution adaptation stage and the reference inference preprocessing. Pooling follows the Eva/DINOv3 convention: default `global_pool='avg'`, pass `global_pool='token'` to match the upstream CLS representation (documented in the factory docstrings).

### Numerical Equivalence

Verified **bit-exact** fp32 equivalence against the reference implementation for all four variants:

```
max abs diff = 0.0 for every partition (CLS / 4 registers / patches), every variant,
at 512x512 and 384x512, and on real images through the resolved pretrained transform;
CLS-pooled public forward also 0.0 (acceptance rule: assert_close rtol=1e-4 atol=1e-5)
```

Procedure:
1. Convert with the existing `eva.checkpoint_filter_fn` (pinned source revisions, SHA-256 verified); strict load, zero missing/unexpected keys.
2. Load reference model from the pinned upstream checkout; identical fp32 inputs on CPU.
3. Compare `forward_features()[:, :1] / [:, 1:5] / [:, 5:]` vs reference `x_norm_clstoken / x_storage_tokens / x_norm_patchtokens`, plus `model(x)` with `global_pool='token'` vs the reference public forward.
4. Serialize (`safetensors` + bin), strict-reload the serialized artifact, per-repo manifest with source/converter hashes.

Test environment: Python 3.14, PyTorch 2.13.0, timm @ this branch, safetensors 0.8.0.

Reproducible end-to-end from branch [`add_lingbot_vision_staging`](https://github.com/belfner/pytorch-image-models/tree/add_lingbot_vision_staging) (= this PR + one tooling commit; reference implementation pinned as a submodule):

```bash
git submodule update --init
pip install omegaconf Pillow safetensors fvcore
python convert_lingbot_vision.py --variants small base large giant  # auto-downloads pinned sources
# each variant verifies in its own subprocess: fresh empty cache + clean memory baseline
python verify_lingbot_vision.py
```

### Pretrained Weights

Converted weights (Apache-2.0 per the upstream repo LICENSE, ungated) hosted at [`belfner/vit_{small,base,large,giant}_patch16_lingbot.robbyant`](https://huggingface.co/collections/belfner/lingbot-vision-timm-6a6a8e6ad381409f95e820dd) — safetensors + bin + `config.json` + conversion manifest each; cfgs point there so the PR is testable as-is.

### Testing

`pytest -vv tests/test_models.py -k lingbot` (serial): 4 passed (tagged pretrained loads), 33 skipped (generic forward/JIT/FX capped below the fixed 512 cfg — covered by a construction/feature-API/pooling/grad-checkpoint/TorchScript smoke matrix, 33/33). `*giant*` falls under existing GHA exclusions; no test-file changes.

Naming note: the entrypoint names are suggestions — also happy to fold S/B/L in as tags on the shape-compatible `vit_{small,base,large}_patch16_dinov3_qkvb` entrypoints (EUPE-style) with only the giant as a new entrypoint.
