### PR TITLE
Add PP-LCNetV2 (lcnetv2_small / lcnetv2_base / lcnetv2_large)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ All model architecture families include variants with pretrained weights. There 
 * Inception-V3 - https://arxiv.org/abs/1512.00567
 * Inception-ResNet-V2 and Inception-V4 - https://arxiv.org/abs/1602.07261
 * Lambda Networks - https://arxiv.org/abs/2102.08602
+* LCNet-V2 - TBD
 * LeViT (Vision Transformer in ConvNet's Clothing) - https://arxiv.org/abs/2104.01136
 * MambaOut - https://arxiv.org/abs/2405.07992
 * MaxViT (Multi-Axis Vision Transformer) - https://arxiv.org/abs/2204.01697

--- a/convert/convert_lcnetv2_paddle.py
+++ b/convert/convert_lcnetv2_paddle.py
@@ -1,0 +1,74 @@
+""" Convert PP-LCNetV2 weights from PaddleClas to timm
+
+Checkpoints: https://github.com/PaddlePaddle/PaddleClas/blob/release/2.6/docs/en/models/PP-LCNetV2_en.md
+NOTE: `paddlepaddle` is required to unpickle the .pdparams files, it is not in requirements.txt
+
+Usage:
+    python convert/convert_lcnetv2_paddle.py PPLCNetV2_base_pretrained.pdparams \
+        --model lcnetv2_base --output lcnetv2_base.pth
+"""
+import argparse
+import re
+from typing import Any, Dict
+
+import torch
+
+import timm
+
+parser = argparse.ArgumentParser(description='Convert PaddleClas PP-LCNetV2 weights')
+parser.add_argument('checkpoint', metavar='PDPARAMS', help='path of the PaddleClas .pdparams checkpoint')
+parser.add_argument('--model', default='lcnetv2_base', help='name of the target timm model')
+parser.add_argument('--output', default='./converted.pth', help='output path of the converted checkpoint')
+parser.add_argument('--dropout-prob', type=float, default=0.2,
+                    help='dropout_prob the Paddle model was created with (see PPLCNetV2_* entrypoints)')
+
+
+def _remap_key(k: str) -> str:
+    k = k.replace('.pw_conv_1.', '.pw_conv.0.')
+    k = k.replace('.pw_conv_2.', '.pw_conv.1.')
+    k = k.replace('.se.conv1.', '.se.fc1.')
+    k = k.replace('.se.conv2.', '.se.fc2.')
+    k = k.replace('.bn._mean', '.bn.running_mean')
+    k = k.replace('.bn._variance', '.bn.running_var')
+    k = re.sub(r'^last_conv\.', 'conv_head.', k)
+    k = re.sub(r'^fc\.', 'classifier.', k)
+    return k
+
+
+def convert_state_dict(paddle_state_dict: Dict[str, Any], dropout_prob: float = 0.2) -> Dict[str, torch.Tensor]:
+    out_dict = {}
+    for k, v in paddle_state_dict.items():
+        # the released checkpoints carry the re-parameterized depthwise conv alongside the branches it was
+        # folded from, timm keeps the branches and folds on demand via timm.utils.reparameterize_model()
+        if re.fullmatch(r'(.*)\.dw_conv\.(weight|bias)', k) and f'{k.rsplit(".", 2)[0]}.dw_conv_list.0.conv.weight' \
+                in paddle_state_dict:
+            continue
+
+        v = torch.from_numpy(v)
+        if k == 'fc.weight':
+            v = v.transpose(0, 1)  # paddle Linear weights are [in_features, out_features]
+        elif k == 'last_conv.weight':
+            # Paddle applies dropout with mode='downscale_in_infer', which scales the pre-logits features by
+            # (1 - p) at inference. The 1x1 conv is bias free and followed by ReLU, so folding the scale into
+            # its weights is exact and lets timm keep a standard nn.Dropout / F.dropout head.
+            v = v * (1. - dropout_prob)
+
+        out_dict[_remap_key(k)] = v
+    return out_dict
+
+
+def main():
+    args = parser.parse_args()
+
+    import paddle  # noqa: only needed to read the checkpoint
+    paddle_state_dict = {k: v.numpy() for k, v in paddle.load(args.checkpoint).items()}
+
+    state_dict = convert_state_dict(paddle_state_dict, dropout_prob=args.dropout_prob)
+    model = timm.create_model(args.model, pretrained=False)
+    model.load_state_dict(state_dict)
+    torch.save(state_dict, args.output)
+    print(f'Converted {len(state_dict)} tensors from {args.checkpoint} to {args.output}')
+
+
+if __name__ == '__main__':
+    main()

--- a/convert/convert_lcnetv2_paddle.py
+++ b/convert/convert_lcnetv2_paddle.py
@@ -11,6 +11,7 @@ import argparse
 import re
 from typing import Any, Dict
 
+import numpy as np
 import torch
 
 import timm
@@ -36,6 +37,11 @@ def _remap_key(k: str) -> str:
 
 
 def convert_state_dict(paddle_state_dict: Dict[str, Any], dropout_prob: float = 0.2) -> Dict[str, torch.Tensor]:
+    # Paddle keeps the dropout probability as a float32 attribute, so the constant it multiplies by at
+    # inference is float32(1 - p). Rounding it here keeps the fold below exact for float32 checkpoints
+    # (where torch would round the scalar anyway) and for float64 ones alike.
+    keep_prob = float(np.float32(1. - dropout_prob))
+
     out_dict = {}
     for k, v in paddle_state_dict.items():
         # the released checkpoints carry the re-parameterized depthwise conv alongside the branches it was
@@ -51,7 +57,7 @@ def convert_state_dict(paddle_state_dict: Dict[str, Any], dropout_prob: float = 
             # Paddle applies dropout with mode='downscale_in_infer', which scales the pre-logits features by
             # (1 - p) at inference. The 1x1 conv is bias free and followed by ReLU, so folding the scale into
             # its weights is exact and lets timm keep a standard nn.Dropout / F.dropout head.
-            v = v * (1. - dropout_prob)
+            v = v * keep_prob
 
         out_dict[_remap_key(k)] = v
     return out_dict

--- a/convert/convert_lcnetv2_paddle.py
+++ b/convert/convert_lcnetv2_paddle.py
@@ -40,13 +40,13 @@ def convert_state_dict(paddle_state_dict: Dict[str, Any], dropout_prob: float = 
     for k, v in paddle_state_dict.items():
         # the released checkpoints carry the re-parameterized depthwise conv alongside the branches it was
         # folded from, timm keeps the branches and folds on demand via timm.utils.reparameterize_model()
-        if re.fullmatch(r'(.*)\.dw_conv\.(weight|bias)', k) and f'{k.rsplit(".", 2)[0]}.dw_conv_list.0.conv.weight' \
-                in paddle_state_dict:
+        repped = re.fullmatch(r'(.*)\.dw_conv\.(?:weight|bias)', k)
+        if repped and f'{repped.group(1)}.dw_conv_list.0.conv.weight' in paddle_state_dict:
             continue
 
         v = torch.from_numpy(v)
         if k == 'fc.weight':
-            v = v.transpose(0, 1)  # paddle Linear weights are [in_features, out_features]
+            v = v.transpose(0, 1).contiguous()  # paddle Linear weights are [in_features, out_features]
         elif k == 'last_conv.weight':
             # Paddle applies dropout with mode='downscale_in_infer', which scales the pre-logits features by
             # (1 - p) at inference. The 1x1 conv is bias free and followed by ReLU, so folding the scale into

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -57,7 +57,7 @@ FEAT_INTER_FILTERS = [
     'tiny_vit', 'vovnet', 'tresnet', 'rexnet', 'resnetv2', 'repghost', 'repvit', 'pvt_v2', 'nextvit', 'nest',
     'mambaout', 'inception_next', 'inception_v4', 'hgnet', 'gcvit', 'focalnet', 'efficientformer_v2', 'edgenext',
     'davit', 'rdnet', 'convnext', 'pit', 'starnet', 'shvit', 'fasternet', 'swiftformer', 'ghostnet', 'naflexvit',
-    'csatv2'
+    'csatv2', 'lcnetv2'
 ]
 
 # transformer / hybrid models don't support full set of spatial / feature APIs and/or have spatial output.

--- a/timm/models/__init__.py
+++ b/timm/models/__init__.py
@@ -36,6 +36,7 @@ from .inception_next import *
 from .inception_resnet_v2 import *
 from .inception_v3 import *
 from .inception_v4 import *
+from .lcnetv2 import *
 from .levit import *
 from .maxxvit import *
 from .mambaout import *

--- a/timm/models/lcnetv2.py
+++ b/timm/models/lcnetv2.py
@@ -447,7 +447,7 @@ def _cfg(url: str = '', **kwargs) -> Dict[str, Any]:
     return {
         'url': url,
         'num_classes': 1000, 'input_size': (3, 224, 224), 'pool_size': (7, 7),
-        'crop_pct': 0.875, 'interpolation': 'bilinear',
+        'crop_pct': 0.875, 'interpolation': 'bicubic',
         'mean': IMAGENET_DEFAULT_MEAN, 'std': IMAGENET_DEFAULT_STD,
         'first_conv': 'stem.0.conv', 'classifier': 'classifier',
         'origin_url': 'https://github.com/PaddlePaddle/PaddleClas',

--- a/timm/models/lcnetv2.py
+++ b/timm/models/lcnetv2.py
@@ -1,0 +1,482 @@
+""" PP-LCNetV2
+
+Reference:
+https://github.com/PaddlePaddle/PaddleClas/blob/release/2.6/docs/en/models/PP-LCNetV2_en.md
+The Paddle Implement of PP-LCNetV2 (https://github.com/PaddlePaddle/PaddleClas/blob/release/2.6/ppcls/arch/backbone/legendary_models/pp_lcnet_v2.py)
+
+PP-LCNetV2 is a CPU oriented network built on PP-LCNet (see `lcnet_*` models in mobilenetv3.py). The depthwise
+convs of the later stages are re-parameterizable multi-scale branches, SE and shortcuts are used sparingly to
+avoid latency penalties on CPU inference.
+
+Adapted from the Paddle implementation for timm by Yonghye Kwon
+"""
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
+from timm.layers import ConvNormAct, SelectAdaptivePool2d, SqueezeExcite, create_act_layer, create_conv2d, \
+    make_divisible
+from ._builder import build_model_with_cfg
+from ._features import feature_take_indices
+from ._manipulate import checkpoint_seq
+from ._registry import generate_default_cfgs, register_model
+
+__all__ = ['LCNetV2']
+
+
+class RepDepthwiseSeparable(nn.Module):
+    """Depthwise separable block with re-parameterizable multi-scale depthwise branches.
+
+    When `use_rep` is enabled the depthwise conv is trained as a set of parallel conv-bn branches with
+    decreasing kernel size (e.g. 5x5, 3x3, 1x1) that are folded into a single depthwise conv for inference.
+    """
+
+    def __init__(
+            self,
+            in_chs: int,
+            out_chs: int,
+            stride: int = 1,
+            dw_kernel_size: int = 3,
+            split_pw: bool = False,
+            use_rep: bool = False,
+            use_se: bool = False,
+            use_shortcut: bool = False,
+            pw_ratio: float = 0.5,
+            se_ratio: float = 0.25,
+            act_layer: Type[nn.Module] = nn.ReLU,
+            norm_layer: Type[nn.Module] = nn.BatchNorm2d,
+            inference_mode: bool = False,
+            device=None,
+            dtype=None,
+    ) -> None:
+        """
+        Args:
+            in_chs: Number of input channels.
+            out_chs: Number of output channels.
+            stride: Stride of the depthwise conv.
+            dw_kernel_size: Kernel size of the (largest) depthwise conv.
+            split_pw: Split the pointwise conv into a squeeze and an expand conv.
+            use_rep: Train the depthwise conv as re-parameterizable multi-scale branches.
+            use_se: Add a squeeze-excite module after the depthwise conv.
+            use_shortcut: Add a residual shortcut when input and output shapes match.
+            pw_ratio: Channel ratio of the first pointwise conv when `split_pw` is enabled.
+            se_ratio: Channel reduction ratio of the squeeze-excite module.
+            act_layer: Type of activation layer.
+            norm_layer: Type of normalization layer.
+            inference_mode: Instantiate the depthwise conv in its re-parameterized form.
+        """
+        dd = {'device': device, 'dtype': dtype}
+        super().__init__()
+        self.in_chs = in_chs
+        self.out_chs = out_chs
+        self.stride = stride
+        self.dw_kernel_size = dw_kernel_size
+        self.use_shortcut = use_shortcut and stride == 1 and in_chs == out_chs
+
+        if use_rep:
+            self.dw_conv_list = None
+            if inference_mode:
+                self.dw_conv = create_conv2d(
+                    in_chs,
+                    in_chs,
+                    kernel_size=dw_kernel_size,
+                    stride=stride,
+                    groups=in_chs,
+                    bias=True,
+                    **dd,
+                )
+            else:
+                # NOTE a 1x1 branch cannot be folded into a strided conv, it's skipped as in the original impl
+                self.dw_conv = None
+                self.dw_conv_list = nn.ModuleList([
+                    ConvNormAct(
+                        in_chs,
+                        in_chs,
+                        kernel_size=k,
+                        stride=stride,
+                        groups=in_chs,
+                        apply_act=False,
+                        norm_layer=norm_layer,
+                        **dd,
+                    ) for k in range(dw_kernel_size, 0, -2) if not (k == 1 and stride != 1)
+                ])
+            self.dw_act = create_act_layer(act_layer, inplace=True)
+        else:
+            self.dw_conv_list = None
+            self.dw_conv = ConvNormAct(
+                in_chs,
+                in_chs,
+                kernel_size=dw_kernel_size,
+                stride=stride,
+                groups=in_chs,
+                act_layer=act_layer,
+                norm_layer=norm_layer,
+                **dd,
+            )
+            self.dw_act = nn.Identity()
+
+        if use_se:
+            self.se = SqueezeExcite(
+                in_chs,
+                rd_channels=int(in_chs * se_ratio),
+                act_layer=act_layer,
+                gate_layer='sigmoid',
+                **dd,
+            )
+        else:
+            self.se = nn.Identity()
+
+        if split_pw:
+            mid_chs = int(out_chs * pw_ratio)
+            self.pw_conv = nn.Sequential(
+                ConvNormAct(in_chs, mid_chs, kernel_size=1, act_layer=act_layer, norm_layer=norm_layer, **dd),
+                ConvNormAct(mid_chs, out_chs, kernel_size=1, act_layer=act_layer, norm_layer=norm_layer, **dd),
+            )
+        else:
+            self.pw_conv = ConvNormAct(
+                in_chs,
+                out_chs,
+                kernel_size=1,
+                act_layer=act_layer,
+                norm_layer=norm_layer,
+                **dd,
+            )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        shortcut = x
+        if self.dw_conv is not None:
+            x = self.dw_act(self.dw_conv(x))
+        else:
+            out = self.dw_conv_list[0](x)
+            for i, dw_conv in enumerate(self.dw_conv_list):
+                if i > 0:
+                    out = out + dw_conv(x)
+            x = self.dw_act(out)
+        x = self.se(x)
+        x = self.pw_conv(x)
+        if self.use_shortcut:
+            x = x + shortcut
+        return x
+
+    def reparameterize(self) -> None:
+        """Fold the multi-scale depthwise branches into a single depthwise conv."""
+        if self.dw_conv_list is None:
+            return
+
+        kernel, bias = self._get_kernel_bias()
+        self.dw_conv = create_conv2d(
+            self.in_chs,
+            self.in_chs,
+            kernel_size=self.dw_kernel_size,
+            stride=self.stride,
+            groups=self.in_chs,
+            bias=True,
+            device=kernel.device,
+            dtype=kernel.dtype,
+        )
+        self.dw_conv.weight.data = kernel
+        self.dw_conv.bias.data = bias
+
+        # NOTE only the discarded branches are detached, the rest of the block stays trainable
+        for param in self.dw_conv_list.parameters():
+            param.detach_()
+
+        self.__delattr__('dw_conv_list')
+        self.dw_conv_list = None
+
+    def _get_kernel_bias(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Sum the bn folded branch kernels, zero padded to the largest kernel size."""
+        kernel_final = 0
+        bias_final = 0
+        for dw_conv in self.dw_conv_list:
+            kernel, bias = self._fuse_bn_tensor(dw_conv)
+            pad = (self.dw_kernel_size - kernel.shape[-1]) // 2
+            kernel_final = kernel_final + F.pad(kernel, [pad, pad, pad, pad])
+            bias_final = bias_final + bias
+        return kernel_final, bias_final
+
+    @staticmethod
+    def _fuse_bn_tensor(branch: ConvNormAct) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Fold a conv-bn branch into an equivalent conv weight and bias."""
+        kernel = branch.conv.weight
+        running_mean = branch.bn.running_mean
+        running_var = branch.bn.running_var
+        gamma = branch.bn.weight
+        beta = branch.bn.bias
+        eps = branch.bn.eps
+        std = (running_var + eps).sqrt()
+        t = (gamma / std).reshape(-1, 1, 1, 1)
+        return kernel * t, beta - running_mean * gamma / std
+
+
+# in_chs, dw_kernel_size, split_pw, use_rep, use_se, use_shortcut
+_STAGE_CFG = (
+    (64, 3, False, False, False, False),
+    (128, 3, False, False, False, False),
+    (256, 5, True, True, True, False),
+    (512, 5, False, True, False, True),
+)
+
+
+class LCNetV2(nn.Module):
+    """PP-LCNetV2"""
+
+    def __init__(
+            self,
+            scale: float = 1.0,
+            depths: Tuple[int, ...] = (2, 2, 6, 2),
+            in_chans: int = 3,
+            num_classes: int = 1000,
+            global_pool: str = 'avg',
+            head_hidden_size: Optional[int] = 1280,
+            act_layer: Type[nn.Module] = nn.ReLU,
+            norm_layer: Type[nn.Module] = nn.BatchNorm2d,
+            drop_rate: float = 0.,
+            inference_mode: bool = False,
+            device=None,
+            dtype=None,
+    ) -> None:
+        """
+        Args:
+            scale: Channel multiplier.
+            depths: Number of blocks per stage.
+            in_chans: Number of input image channels.
+            num_classes: Number of classes for the classification head.
+            global_pool: Type of pooling to use for global pooling features of the FC head.
+            head_hidden_size: Number of channels of the pre-logits conv, disabled if None.
+            act_layer: Type of activation layer.
+            norm_layer: Type of normalization layer.
+            drop_rate: Dropout rate.
+            inference_mode: Instantiate the re-parameterizable blocks in their re-parameterized form.
+        """
+        dd = {'device': device, 'dtype': dtype}
+        super().__init__()
+        self.num_classes = num_classes
+        self.drop_rate = drop_rate
+        self.grad_checkpointing = False
+
+        block_kwargs = dict(act_layer=act_layer, norm_layer=norm_layer, inference_mode=inference_mode, **dd)
+        stem_chs = make_divisible(32 * scale)
+        prev_chs = make_divisible(64 * scale)
+        self.stem = nn.Sequential(
+            ConvNormAct(
+                in_chans,
+                stem_chs,
+                kernel_size=3,
+                stride=2,
+                act_layer=act_layer,
+                norm_layer=norm_layer,
+                **dd,
+            ),
+            RepDepthwiseSeparable(stem_chs, prev_chs, stride=1, dw_kernel_size=3, **block_kwargs),
+        )
+
+        stages = []
+        self.feature_info = []
+        reduction = 2
+        for stage_idx, (chs, dw_kernel_size, split_pw, use_rep, use_se, use_shortcut) in enumerate(_STAGE_CFG):
+            out_chs = make_divisible(chs * 2 * scale)
+            blocks = []
+            for block_idx in range(depths[stage_idx]):
+                blocks += [RepDepthwiseSeparable(
+                    in_chs=prev_chs,
+                    out_chs=out_chs,
+                    stride=2 if block_idx == 0 else 1,
+                    dw_kernel_size=dw_kernel_size,
+                    split_pw=split_pw,
+                    use_rep=use_rep,
+                    use_se=use_se,
+                    use_shortcut=use_shortcut,
+                    **block_kwargs,
+                )]
+                prev_chs = out_chs
+            stages += [nn.Sequential(*blocks)]
+            reduction *= 2
+            self.feature_info += [dict(num_chs=out_chs, reduction=reduction, module=f'stages.{stage_idx}')]
+        self.stages = nn.Sequential(*stages)
+        self.num_features = prev_chs
+
+        # Head + Pooling
+        self.head_hidden_size = head_hidden_size or self.num_features
+        self.global_pool = SelectAdaptivePool2d(pool_type=global_pool)
+        if head_hidden_size:
+            self.conv_head = create_conv2d(self.num_features, self.head_hidden_size, 1, bias=False, **dd)
+            self.act2 = create_act_layer(act_layer, inplace=True)
+        else:
+            self.conv_head = nn.Identity()
+            self.act2 = nn.Identity()
+        self.flatten = nn.Flatten(1) if global_pool else nn.Identity()  # don't flatten if pooling disabled
+        self.classifier = nn.Linear(self.head_hidden_size, num_classes, **dd) if num_classes > 0 else nn.Identity()
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+            elif isinstance(m, nn.BatchNorm2d):
+                nn.init.ones_(m.weight)
+                nn.init.zeros_(m.bias)
+            elif isinstance(m, nn.Linear):
+                nn.init.zeros_(m.bias)
+
+    @torch.jit.ignore
+    def group_matcher(self, coarse: bool = False) -> Dict[str, Any]:
+        return dict(
+            stem=r'^stem',
+            blocks=r'^stages\.(\d+)' if coarse else r'^stages\.(\d+)\.(\d+)',
+        )
+
+    @torch.jit.ignore
+    def set_grad_checkpointing(self, enable: bool = True) -> None:
+        self.grad_checkpointing = enable
+
+    @torch.jit.ignore
+    def get_classifier(self) -> nn.Module:
+        return self.classifier
+
+    def reset_classifier(
+            self,
+            num_classes: int,
+            global_pool: Optional[str] = None,
+            device=None,
+            dtype=None,
+    ) -> None:
+        self.num_classes = num_classes
+        if global_pool is not None:
+            self.global_pool = SelectAdaptivePool2d(pool_type=global_pool)
+            self.flatten = nn.Flatten(1) if global_pool else nn.Identity()
+        self.classifier = nn.Linear(
+            self.head_hidden_size, num_classes, device=device, dtype=dtype) if num_classes > 0 else nn.Identity()
+
+    def forward_intermediates(
+            self,
+            x: torch.Tensor,
+            indices: Optional[Union[int, List[int]]] = None,
+            norm: bool = False,
+            stop_early: bool = False,
+            output_fmt: str = 'NCHW',
+            intermediates_only: bool = False,
+    ) -> Union[List[torch.Tensor], Tuple[torch.Tensor, List[torch.Tensor]]]:
+        """ Forward features that returns intermediates.
+
+        Args:
+            x: Input image tensor
+            indices: Take last n blocks if int, all if None, select matching indices if sequence
+            norm: Apply norm layer to compatible intermediates
+            stop_early: Stop iterating over blocks when last desired intermediate hit
+            output_fmt: Shape of intermediate feature outputs
+            intermediates_only: Only return intermediate features
+        Returns:
+
+        """
+        assert output_fmt in ('NCHW',), 'Output shape must be NCHW.'
+        intermediates = []
+        take_indices, max_index = feature_take_indices(len(self.stages), indices)
+
+        # forward pass
+        x = self.stem(x)
+        if torch.jit.is_scripting() or not stop_early:  # can't slice blocks in torchscript
+            stages = self.stages
+        else:
+            stages = self.stages[:max_index + 1]
+
+        for feat_idx, stage in enumerate(stages):
+            x = stage(x)
+            if feat_idx in take_indices:
+                intermediates.append(x)
+
+        if intermediates_only:
+            return intermediates
+
+        return x, intermediates
+
+    def prune_intermediate_layers(
+            self,
+            indices: Union[int, List[int]] = 1,
+            prune_norm: bool = False,
+            prune_head: bool = True,
+    ) -> List[int]:
+        """ Prune layers not required for specified intermediates.
+        """
+        take_indices, max_index = feature_take_indices(len(self.stages), indices)
+        self.stages = self.stages[:max_index + 1]  # truncate blocks
+        if prune_head:
+            self.reset_classifier(0, '')
+        return take_indices
+
+    def forward_features(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.stem(x)
+        if self.grad_checkpointing and not torch.jit.is_scripting():
+            x = checkpoint_seq(self.stages, x, flatten=True)
+        else:
+            x = self.stages(x)
+        return x
+
+    def forward_head(self, x: torch.Tensor, pre_logits: bool = False) -> torch.Tensor:
+        x = self.global_pool(x)
+        x = self.conv_head(x)
+        x = self.act2(x)
+        x = self.flatten(x)
+        if pre_logits:
+            return x
+        if self.drop_rate > 0.:
+            x = F.dropout(x, p=self.drop_rate, training=self.training)
+        return self.classifier(x)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.forward_features(x)
+        x = self.forward_head(x)
+        return x
+
+
+def _create_lcnetv2(variant: str, pretrained: bool = False, **kwargs) -> LCNetV2:
+    out_indices = kwargs.pop('out_indices', (0, 1, 2, 3))
+    return build_model_with_cfg(
+        LCNetV2,
+        variant,
+        pretrained,
+        feature_cfg=dict(flatten_sequential=True, out_indices=out_indices),
+        **kwargs,
+    )
+
+
+def _cfg(url: str = '', **kwargs) -> Dict[str, Any]:
+    return {
+        'url': url,
+        'num_classes': 1000, 'input_size': (3, 224, 224), 'pool_size': (7, 7),
+        'crop_pct': 0.875, 'interpolation': 'bilinear',
+        'mean': IMAGENET_DEFAULT_MEAN, 'std': IMAGENET_DEFAULT_STD,
+        'first_conv': 'stem.0.conv', 'classifier': 'classifier',
+        'origin_url': 'https://github.com/PaddlePaddle/PaddleClas',
+        'license': 'apache-2.0',
+        **kwargs,
+    }
+
+
+default_cfgs = generate_default_cfgs({
+    'lcnetv2_small.paddle_in1k': _cfg(hf_hub_id='timm/'),
+    'lcnetv2_base.paddle_in1k': _cfg(hf_hub_id='timm/'),
+    'lcnetv2_base.ssld_in1k': _cfg(hf_hub_id='timm/'),
+    'lcnetv2_large.paddle_in1k': _cfg(hf_hub_id='timm/'),
+})
+
+
+@register_model
+def lcnetv2_small(pretrained: bool = False, **kwargs) -> LCNetV2:
+    model_args = dict(scale=0.75, depths=(2, 2, 4, 2))
+    return _create_lcnetv2('lcnetv2_small', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def lcnetv2_base(pretrained: bool = False, **kwargs) -> LCNetV2:
+    model_args = dict(scale=1.0, depths=(2, 2, 6, 2))
+    return _create_lcnetv2('lcnetv2_base', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def lcnetv2_large(pretrained: bool = False, **kwargs) -> LCNetV2:
+    model_args = dict(scale=1.25, depths=(2, 2, 8, 2))
+    return _create_lcnetv2('lcnetv2_large', pretrained=pretrained, **dict(model_args, **kwargs))


### PR DESCRIPTION
## New Model
- [PP-LCNetV2](https://github.com/PaddlePaddle/PaddleClas/blob/release/2.6/docs/en/models/PP-LCNetV2_en.md) — PaddleClas' CPU oriented successor to PP-LCNet, which timm already carries as `lcnet_*` in `mobilenetv3.py`

Adds `lcnetv2_small`, `lcnetv2_base` and `lcnetv2_large` in a new `timm/models/lcnetv2.py`, covering all four released PaddleClas checkpoints. Naming follows the existing PP-HGNet port (`hgnet_*` / `hgnetv2_*`), so the `pp` prefix is dropped and the distilled checkpoint gets the `ssld_in1k` tag.

The depthwise convs of stage 3 and 4 train as parallel 5x5 / 3x3 / 1x1 conv-bn branches and fold into a single depthwise conv through `timm.utils.model.reparameterize_model()`, the same pattern FastViT and MobileOne use. SE sits only on the penultimate blocks and shortcuts only on the last stage, as in the original.

## Result

| Model | Params | MACs | IN-1k Acc@1 | IN-1k Acc@5 | IN-V2 Acc@1 | IN-V2 Acc@5 |
| --- | --- | --- | --- | --- | --- | --- |
| lcnetv2_small.paddle_in1k | 4.09M | 287.0M | – | – | 60.980 | 82.540 |
| lcnetv2_base.paddle_in1k | 6.62M | 603.4M | 77.04 | 93.27 | 65.050 | 85.340 |
| lcnetv2_base.ssld_in1k | 6.62M | 603.4M | 80.07 | 94.87 | 68.820 | 88.020 |
| lcnetv2_large.paddle_in1k | 10.44M | 1094.7M | – | – | 66.740 | 86.840 |

- Params / MACs measured with fvcore on the re-parameterized model at 224x224. `lcnetv2_base` lands at 6.62M / 603.4M against the 6.6M / 604M PaddleClas reports.
- IN-1k Acc@1 / Acc@5 are the numbers PaddleClas publishes. They only publish them for the base model, so small and large are left blank rather than guessed — the IN-V2 column covers all four.
- IN-V2 is ImageNet-V2 matched-frequency (10k images), measured with the `pretrained_cfg` in this PR. The base gap to IN-1k (77.04 → 65.05) sits in the usual 11–12 pt range.

`crop_pct=0.875` matches the PaddleClas eval transform (`ResizeImage(resize_short=256)` → `CropImage(224)`). For interpolation the faithful choice would be `bilinear`, since PaddleClas resizes with cv2 `INTER_LINEAR`, but cv2 does not anti-alias on downscale and PIL does, so PIL `bicubic` is the closer match in practice. Running the Paddle model through its own cv2 pipeline on the same 10k images:

| pipeline | IN-V2 Acc@1 | IN-V2 Acc@5 |
| --- | --- | --- |
| Paddle, cv2 `INTER_LINEAR` + center crop 224 | 65.050 | 85.390 |
| timm, PIL bicubic, `crop_pct=0.875` | 65.050 | 85.340 |
| timm, PIL bilinear, `crop_pct=0.875` | 64.670 | 84.850 |
| timm, PIL bicubic, `crop_pct=0.9` | 64.840 | 85.390 |
| timm, PIL bilinear, `crop_pct=0.9` | 64.550 | 85.160 |

so the cfg is set to `bicubic` / `0.875`. Happy to flip it if you would rather keep the literal Paddle interpolation.

## Equivalence with the Paddle reference

Every released checkpoint was run through the original Paddle implementation and this port on identical inputs (max abs diff, fp32). Every intermediate stage output matches to the same order as the logits:

| Checkpoint | logits | re-parameterized | pre-logits | top-1 agreement |
| --- | --- | --- | --- | --- |
| PPLCNetV2_small | 1.05e-05 | 7.15e-06 | 3.10e-06 | 100% |
| PPLCNetV2_base | 9.12e-06 | 6.44e-06 | 3.77e-06 | 100% |
| PPLCNetV2_base_ssld | 8.82e-06 | 1.09e-05 | 4.11e-06 | 100% |
| PPLCNetV2_large | 1.22e-05 | 1.10e-05 | 3.10e-06 | 100% |

To show that gap is fp32 rounding rather than a structural mismatch, `lcnetv2_base` was also run in fp64 and both frameworks' fp32 outputs measured against that ground truth (8 images, `|logit|max` 11.35, relative):

| | error vs fp64 ground truth |
| --- | --- |
| Paddle fp32 | 7.71e-07 |
| timm fp32 | 8.63e-07 |
| timm fp64 | 5.81e-10 |
| Paddle fp32 vs timm fp32 | 9.48e-07 |

timm's fp32 error is the same size as Paddle's own and the cross difference is just the two combined, so neither implementation is closer to the true answer — the fp32 gap is not reducible. Run in fp64 the port tracks the reference to 5.81e-10, which is fp64 conv noise.

On 1000 real ImageNet-V2 images handed to both frameworks as identical preprocessed tensors: top-1 65.70% on both, argmax agrees on 1000/1000, and the full top-5 list is identical for every single image.

## Note on the head dropout

Paddle builds the classifier dropout as `Dropout(p=0.2, mode='downscale_in_infer')`, which scales the pre-logits features by `1 - p` **at inference** instead of up-scaling during training. The 1x1 `conv_head` is bias free and followed by ReLU, so `convert/convert_lcnetv2_paddle.py` folds that constant into the conv weights. That keeps the timm model on a plain `drop_rate` head rather than carrying Paddle's dropout semantics into timm.

The fold rounds `1 - p` through float32, since that is what Paddle stores and multiplies by. For the released float32 checkpoints the converted `conv_head.weight` is then bit-identical to Paddle's own product; the explicit rounding only matters if the fold is ever done at higher precision, where the float64 `0.8` would drift by ~1.5e-08 relative.

## Weights

`convert/convert_lcnetv2_paddle.py` converts the PaddleClas `.pdparams` files. It also drops the fused depthwise convs that ship alongside the branches in the released checkpoints, since timm folds those on demand.

The four `default_cfgs` entries carry `hf_hub_id='timm/'` following the `hgnet` precedent, so `pretrained=True` will not resolve until the weights are on the hub — I have the converted checkpoints ready and can send them wherever is easiest, or you may prefer to run the conversion yourself. Equally happy to drop the convert script from this PR if you would rather keep it out of tree.
