### PR TITLE
Fix positional embedding resampling for equal-token grid changes

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -9,6 +9,7 @@ from timm.layers import (
     create_act_layer,
     get_act_fn,
     get_act_layer,
+    resample_abs_pos_embed,
     resample_patch_embed,
     set_layer_config,
 )
@@ -20,6 +21,30 @@ torch_backend = os.environ.get('TORCH_BACKEND')
 if torch_backend is not None:
     importlib.import_module(torch_backend)
 torch_device = os.environ.get('TORCH_DEVICE', 'cpu')
+
+
+def test_resample_abs_pos_embed_same_token_count_different_grid():
+    old_size = (2, 8)
+    new_size = (4, 4)
+    prefix = torch.tensor([[[-1.0]]])
+    spatial = torch.arange(16.0).reshape(1, -1, 1)
+    pos_embed = torch.cat((prefix, spatial), dim=1)
+
+    actual = resample_abs_pos_embed(
+        pos_embed,
+        new_size=new_size,
+        old_size=old_size,
+        num_prefix_tokens=1,
+    )
+    expected_spatial = torch.nn.functional.interpolate(
+        spatial.reshape(1, *old_size, 1).permute(0, 3, 1, 2),
+        size=new_size,
+        mode='bicubic',
+        antialias=True,
+    ).permute(0, 2, 3, 1).reshape(1, -1, 1)
+    expected = torch.cat((prefix, expected_spatial), dim=1)
+
+    torch.testing.assert_close(actual, expected)
 
 
 def test_patch_embed_interpolator_reuses_nonpersistent_cache(monkeypatch):

--- a/timm/layers/pos_embed.py
+++ b/timm/layers/pos_embed.py
@@ -28,8 +28,11 @@ def resample_abs_pos_embed(
     # sort out sizes, assume square if old size not provided
     num_pos_tokens = posemb.shape[1]
     num_new_tokens = new_size[0] * new_size[1] + num_prefix_tokens
-    if num_new_tokens == num_pos_tokens and new_size[0] == new_size[1]:
-        return posemb
+    if num_new_tokens == num_pos_tokens:
+        if old_size is not None and old_size[0] == new_size[0] and old_size[1] == new_size[1]:
+            return posemb
+        if old_size is None and new_size[0] == new_size[1]:
+            return posemb
 
     if old_size is None:
         hw = int(math.sqrt(num_pos_tokens - num_prefix_tokens))


### PR DESCRIPTION
## Summary

- resample absolute positional embeddings when an explicit source grid differs from the target grid, even if both grids contain the same number of patches
- add a regression test for a `(2, 8)` source grid resampled to `(4, 4)`

## Problem

`resample_abs_pos_embed` returned early whenever the token count was unchanged and the target grid was square. That shortcut assumes the source grid is also square, but callers can provide an explicit rectangular `old_size`.

For example, changing a 16-patch grid from `(2, 8)` to `(4, 4)` returned the original positional embeddings unchanged. The output shape remained valid, but its spatial positions were incorrect. This affects dynamic image-size paths in ViT, distilled DeiT, and EVA models.

Related context: #2190 and #2317 added explicit source-grid tracking for rectangular dynamic inputs. This change handles the remaining equal-token-count case in the shared resampling helper. It intentionally does not alter the separate `set_input_size` caller guards.

## Fix

Keep the no-op fast path only when:

- an explicit `old_size` exactly matches `new_size`, or
- no `old_size` is supplied and the unchanged square grid can be inferred safely

The regression test compares the helper output with an independent `torch.nn.functional.interpolate` reference and verifies the prefix token and spatial interpolation together.

## Validation

- `CUDA_VISIBLE_DEVICES='' python -m pytest tests/test_layers.py -q` — 37 passed
- `python -m py_compile timm/layers/pos_embed.py tests/test_layers.py`
- `git diff --check`

## AI assistance

OpenAI Codex was used to audit the code, reproduce the issue, prepare the patch and regression test, run validation, and draft this pull request description.
