### PR TITLE
Fix CutMix minmax border sampling

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,6 +1,25 @@
+import numpy as np
+import pytest
 import torch
 
 from timm.data import create_transform
+from timm.data.mixup import rand_bbox_minmax
+
+
+@pytest.mark.parametrize('count', [None, 4])
+def test_rand_bbox_minmax_can_reach_bottom_right_border(monkeypatch, count):
+    def sample_last(low, high, size=None):
+        result = np.asarray(high) - 1
+        return result if size is None else np.broadcast_to(result, size)
+
+    monkeypatch.setattr(np.random, 'randint', sample_last)
+
+    yl, yu, xl, xu = rand_bbox_minmax((3, 5, 7), (0.5, 0.75), count=count)
+
+    assert np.all(yl == 3)
+    assert np.all(yu == 5)
+    assert np.all(xl == 3)
+    assert np.all(xu == 7)
 
 
 def test_naflex_eval_patchify_can_preserve_spatial_patch_dimensions():

--- a/timm/data/mixup.py
+++ b/timm/data/mixup.py
@@ -67,8 +67,8 @@ def rand_bbox_minmax(img_shape, minmax, count=None):
     img_h, img_w = img_shape[-2:]
     cut_h = np.random.randint(int(img_h * minmax[0]), int(img_h * minmax[1]), size=count)
     cut_w = np.random.randint(int(img_w * minmax[0]), int(img_w * minmax[1]), size=count)
-    yl = np.random.randint(0, img_h - cut_h, size=count)
-    xl = np.random.randint(0, img_w - cut_w, size=count)
+    yl = np.random.randint(0, img_h - cut_h + 1, size=count)
+    xl = np.random.randint(0, img_w - cut_w + 1, size=count)
     yu = yl + cut_h
     xu = xl + cut_w
     return yl, yu, xl, xu
@@ -346,4 +346,3 @@ class FastCollateMixup(Mixup):
         target = mixup_target(target, self.num_classes, lam, self.label_smoothing)
         target = target[:batch_size]
         return output, target
-


### PR DESCRIPTION
## Summary

- allow min/max CutMix boxes to use the bottommost and rightmost valid origins
- cover both scalar and batched bounding-box generation with a deterministic regression test

## Problem

`numpy.random.randint` excludes its upper bound. `rand_bbox_minmax` passed `img_h - cut_h` and `img_w - cut_w` directly, so boxes could never start at those final valid coordinates. This biased sampling away from the bottom and right borders, with the strongest effect for boxes close to the image size.

Adding one to each exclusive upper bound samples every valid origin from zero through the final in-bounds coordinate without changing box dimensions or lambda correction.

## Validation

- regression test fails on `main` and passes with this change
- `pytest -q tests/test_data.py tests/test_scheduled_sampler.py --disable-warnings`: 30 passed
- `pytest -q --forked -k 'not test_models' tests --disable-warnings --maxfail=20`: 440 passed, 1 skipped, 15329 deselected
- 200,000 seeded samples across four valid origins were approximately uniform (maximum deviation: 0.162 percentage points)
