### PR TITLE
Return the fused RMSNorm2d result directly

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -29,14 +29,13 @@ def test_fast_rms_norm2d_returns_apex_result(monkeypatch):
     weight = torch.tensor([0.5, 1.5, 3.0])
     normalized_shape = [3]
     eps = 1e-5
-    expected = fast_norm.rms_norm2d(x, normalized_shape, weight, eps)
+    expected = torch.tensor([[[[10.0]], [[20.0]], [[30.0]]]])
 
     monkeypatch.setattr(fast_norm, 'has_apex_rmsnorm', True)
     monkeypatch.setattr(
         fast_norm,
         'fused_rms_norm_affine',
-        lambda x, weight, normalized_shape, eps:
-            torch.nn.functional.rms_norm(x, normalized_shape, weight, eps),
+        lambda x, weight, normalized_shape, eps: expected.permute(0, 2, 3, 1),
         raising=False,
     )
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 import torch.nn as nn
 
+import timm.layers.fast_norm as fast_norm
 from timm.layers import (
     Attention2d,
     MultiQueryAttentionV2,
@@ -21,6 +22,27 @@ torch_backend = os.environ.get('TORCH_BACKEND')
 if torch_backend is not None:
     importlib.import_module(torch_backend)
 torch_device = os.environ.get('TORCH_DEVICE', 'cpu')
+
+
+def test_fast_rms_norm2d_returns_apex_result(monkeypatch):
+    x = torch.tensor([[[[1.0]], [[2.0]], [[4.0]]]])
+    weight = torch.tensor([0.5, 1.5, 3.0])
+    normalized_shape = [3]
+    eps = 1e-5
+    expected = fast_norm.rms_norm2d(x, normalized_shape, weight, eps)
+
+    monkeypatch.setattr(fast_norm, 'has_apex_rmsnorm', True)
+    monkeypatch.setattr(
+        fast_norm,
+        'fused_rms_norm_affine',
+        lambda x, weight, normalized_shape, eps:
+            torch.nn.functional.rms_norm(x, normalized_shape, weight, eps),
+        raising=False,
+    )
+
+    actual = fast_norm.fast_rms_norm2d(x, normalized_shape, weight, eps)
+
+    torch.testing.assert_close(actual, expected)
 
 
 def test_resample_abs_pos_embed_same_token_count_different_grid():

--- a/timm/layers/fast_norm.py
+++ b/timm/layers/fast_norm.py
@@ -202,6 +202,7 @@ def fast_rms_norm2d(
         else:
             x = fused_rms_norm_affine(x, weight, normalized_shape, eps)
         x = x.permute(0, 3, 1, 2)
+        return x
 
     if is_autocast_enabled(x.device.type):
         # normally native AMP casts norm inputs to float32 and leaves the output as float32


### PR DESCRIPTION
I was looking at the fast RMSNorm2d path and noticed that the Apex result falls through into the fallback implementation, so the normalization and affine weight get applied a second time.

This returns the fused result directly, matching the existing 1D fast RMSNorm path. I added a CPU regression test with a small mocked Apex implementation, so the behavior is covered without requiring Apex locally : )

Tests: `pytest -q tests/test_layers.py` (`38 passed`)

I can also attach the corresponding TorchLean formalization showing why applying affine RMSNorm twice is not equivalent if that would be useful.