### PR TITLE
Fix custom input channels for pruned EfficientNet models

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -411,9 +411,8 @@ if 'GITHUB_ACTIONS' not in os.environ:
     @pytest.mark.parametrize('batch_size', [1])
     def test_model_load_pretrained(model_name, batch_size):
         """Create that pretrained weights load, verify support for in_chans != 3 while doing so."""
-        in_chans = 3 if 'pruned' in model_name else 1  # pruning not currently supported with in_chans change
-        create_model(model_name, pretrained=True, in_chans=in_chans, num_classes=5)
-        create_model(model_name, pretrained=True, in_chans=in_chans, num_classes=0)
+        create_model(model_name, pretrained=True, in_chans=1, num_classes=5)
+        create_model(model_name, pretrained=True, in_chans=1, num_classes=0)
 
     @pytest.mark.timeout(240)
     @pytest.mark.parametrize('model_name', list_models(pretrained=True, exclude_filters=NON_STD_FILTERS))
@@ -421,6 +420,19 @@ if 'GITHUB_ACTIONS' not in os.environ:
     def test_model_features_pretrained(model_name, batch_size):
         """Create that pretrained weights load when features_only==True."""
         create_model(model_name, pretrained=True, features_only=True)
+
+
+@pytest.mark.parametrize(
+    'model_name',
+    ['efficientnet_b1_pruned', 'efficientnet_b2_pruned', 'efficientnet_b3_pruned'],
+)
+def test_pruned_efficientnet_in_chans(model_name):
+    model = create_model(model_name, pretrained=False, in_chans=1)
+    model.eval()
+
+    assert model.conv_stem.in_channels == 1
+    with torch.no_grad():
+        assert model(torch.randn(1, 1, 32, 32)).shape == (1, 1000)
 
 
 @pytest.mark.torchscript

--- a/timm/models/_prune.py
+++ b/timm/models/_prune.py
@@ -92,6 +92,10 @@ def adapt_model_from_string(parent_module, model_string):
     dtype = next(parent_module.parameters()).dtype
     dd = {'device': device, 'dtype': dtype}
 
+    input_convs = getattr(parent_module, 'pretrained_cfg', {}).get('first_conv', ())
+    if isinstance(input_convs, str):
+        input_convs = (input_convs,)
+
     new_module = deepcopy(parent_module)
     for n, m in parent_module.named_modules():
         old_module = extract_layer(parent_module, n)
@@ -101,7 +105,7 @@ def adapt_model_from_string(parent_module, model_string):
             else:
                 conv = nn.Conv2d
             s = state_dict[n + '.weight']
-            in_channels = s[1]
+            in_channels = old_module.in_channels if n in input_convs else s[1]
             out_channels = s[0]
             g = 1
             if old_module.groups > 1:


### PR DESCRIPTION
## Summary

Fixes #1597.

Pruned EfficientNet variants rebuilt every convolution from the pruning specification after model construction. That restored the stem's recorded three-channel shape and discarded a caller's custom `in_chans` value.

This change preserves the configured input-channel count only for the model's declared input convolution. The pruning specification still controls its output channels and every internal pruned dimension.

The regression test covers `efficientnet_b1_pruned`, `efficientnet_b2_pruned`, and `efficientnet_b3_pruned` with a one-channel forward pass. The existing pretrained-loading test now exercises custom input channels for pruned models too.

## Validation

- `py -3.13 -m pytest tests/test_models.py -q -k pruned_efficientnet_in_chans`: 3 passed
- `py -3.13 -m pytest "tests/test_models.py::test_model_load_pretrained[1-efficientnet_b1_pruned.in1k]" -q`: 1 passed
- `py -3.13 -m py_compile timm/models/_prune.py tests/test_models.py`
- `git diff --check`

## AI assistance

OpenAI Codex was used to audit the code, reproduce the issue, prepare the patch and regression test, run validation, and draft this pull request description.