### PR TITLE
Preserve classifier head device and dtype on reset

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -5,7 +5,10 @@ import torch.nn as nn
 import timm.layers.fast_norm as fast_norm
 from timm.layers import (
     Attention2d,
+    ClassifierHead,
+    ClNormMlpClassifierHead,
     MultiQueryAttentionV2,
+    NormMlpClassifierHead,
     PatchEmbedInterpolator,
     create_act_layer,
     get_act_fn,
@@ -42,6 +45,22 @@ def test_fast_rms_norm2d_returns_apex_result(monkeypatch):
     actual = fast_norm.fast_rms_norm2d(x, normalized_shape, weight, eps)
 
     torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize(
+    'head_cls,head_kwargs,input_shape,pool_type',
+    [
+        (ClassifierHead, {}, (2, 4, 3, 3), 'avgmax'),
+        (NormMlpClassifierHead, {'hidden_size': 3}, (2, 4, 3, 3), ''),
+        (ClNormMlpClassifierHead, {'hidden_size': 3}, (2, 3, 3, 4), 'avgmax'),
+    ],
+)
+def test_classifier_head_reset_preserves_dtype(head_cls, head_kwargs, input_shape, pool_type):
+    head = head_cls(4, 3, **head_kwargs).to(dtype=torch.float64)
+    head.reset(2, pool_type)
+
+    assert all(parameter.dtype == torch.float64 for parameter in head.parameters())
+    assert head(torch.randn(input_shape, dtype=torch.float64)).dtype == torch.float64
 
 
 def test_resample_abs_pos_embed_same_token_count_different_grid():

--- a/timm/layers/classifier.py
+++ b/timm/layers/classifier.py
@@ -44,6 +44,11 @@ def _create_fc(num_features, num_classes, use_conv=False, device=None, dtype=Non
     return fc
 
 
+def _get_device_dtype(module):
+    parameter = next(module.parameters(), None)
+    return {} if parameter is None else {'device': parameter.device, 'dtype': parameter.dtype}
+
+
 def create_classifier(
         num_features: int,
         num_classes: int,
@@ -115,7 +120,7 @@ class ClassifierHead(nn.Module):
         self.flatten = nn.Flatten(1) if use_conv and pool_type else nn.Identity()
 
     def reset(self, num_classes: int, pool_type: Optional[str] = None):
-        # FIXME get current device/dtype for reset?
+        dd = _get_device_dtype(self)
         if pool_type is not None and pool_type != self.global_pool.pool_type:
             self.global_pool, self.fc = create_classifier(
                 self.in_features,
@@ -123,6 +128,7 @@ class ClassifierHead(nn.Module):
                 pool_type=pool_type,
                 use_conv=self.use_conv,
                 input_fmt=self.input_fmt,
+                **dd,
             )
             self.flatten = nn.Flatten(1) if self.use_conv and pool_type else nn.Identity()
         else:
@@ -131,6 +137,7 @@ class ClassifierHead(nn.Module):
                 num_pooled_features,
                 num_classes,
                 use_conv=self.use_conv,
+                **dd,
             )
 
     def forward(self, x, pre_logits: bool = False):
@@ -192,7 +199,7 @@ class NormMlpClassifierHead(nn.Module):
         self.fc = linear_layer(self.num_features, num_classes, **dd) if num_classes > 0 else nn.Identity()
 
     def reset(self, num_classes: int, pool_type: Optional[str] = None):
-        # FIXME handle device/dtype on reset
+        dd = _get_device_dtype(self)
         if pool_type is not None:
             self.global_pool = SelectAdaptivePool2d(pool_type=pool_type)
             self.flatten = nn.Flatten(1) if pool_type else nn.Identity()
@@ -202,11 +209,11 @@ class NormMlpClassifierHead(nn.Module):
             if ((isinstance(self.pre_logits.fc, nn.Conv2d) and not self.use_conv) or
                     (isinstance(self.pre_logits.fc, nn.Linear) and self.use_conv)):
                 with torch.no_grad():
-                    new_fc = linear_layer(self.in_features, self.hidden_size)
+                    new_fc = linear_layer(self.in_features, self.hidden_size, **dd)
                     new_fc.weight.copy_(self.pre_logits.fc.weight.reshape(new_fc.weight.shape))
                     new_fc.bias.copy_(self.pre_logits.fc.bias)
                     self.pre_logits.fc = new_fc
-        self.fc = linear_layer(self.num_features, num_classes) if num_classes > 0 else nn.Identity()
+        self.fc = linear_layer(self.num_features, num_classes, **dd) if num_classes > 0 else nn.Identity()
 
     def forward(self, x, pre_logits: bool = False):
         x = self.global_pool(x)
@@ -271,13 +278,13 @@ class ClNormMlpClassifierHead(nn.Module):
         self.fc = nn.Linear(self.num_features, num_classes, **dd) if num_classes > 0 else nn.Identity()
 
     def reset(self, num_classes: int, pool_type: Optional[str] = None, reset_other: bool = False):
-        # FIXME extract dd on reset
+        dd = _get_device_dtype(self)
         if pool_type is not None:
             self.pool_type = pool_type
         if reset_other:
             self.pre_logits = nn.Identity()
             self.norm = nn.Identity()
-        self.fc = nn.Linear(self.num_features, num_classes) if num_classes > 0 else nn.Identity()
+        self.fc = nn.Linear(self.num_features, num_classes, **dd) if num_classes > 0 else nn.Identity()
 
     def _global_pool(self, x):
         if self.pool_type:


### PR DESCRIPTION
## Summary

Preserve the current device and dtype when resetting timm's three shared classifier-head implementations.

`ClassifierHead.reset`, `NormMlpClassifierHead.reset`, and `ClNormMlpClassifierHead.reset` created replacement linear or convolution layers with PyTorch's CPU and float32 defaults. Resetting a head after moving the model to another dtype therefore produced mixed-dtype modules and made the next forward pass fail.

The reset path now derives factory arguments from the existing head parameters before replacing any layers. This also covers the Linear-to-Conv2d conversion in `NormMlpClassifierHead` when the pooling mode changes.

Tests exercise all three head types, including pooling changes and the MLP layer conversion. Before this change, each case rebuilt float32 parameters and failed on float64 input.

## Validation

- `py -3.13 -m pytest tests/test_layers.py -q`: 40 passed
- `py -3.13 -m py_compile timm/layers/classifier.py tests/test_layers.py`
- `git diff --check`

## AI assistance

OpenAI Codex was used to audit the code, reproduce the issue, prepare the patch and regression tests, run validation, and draft this pull request description.