### PR TITLE
Fix NaFlexVit.load_pretrained crashing on every checkpoint it is given

### DIFF
--- a/tests/test_checkpoint_loading.py
+++ b/tests/test_checkpoint_loading.py
@@ -109,3 +109,37 @@ def test_resume_checkpoint_weights_only_false_allows_custom_globals(tmp_path):
     assert resume_epoch == 4
     assert torch.equal(dst_model.weight, src_model.weight)
     assert torch.equal(dst_model.bias, src_model.bias)
+
+
+def test_naflexvit_load_pretrained_torch_checkpoint(tmp_path):
+    import timm
+
+    src_model = timm.create_model('naflexvit_base_patch16_gap', embed_dim=64, depth=2, num_heads=2, num_classes=10)
+    checkpoint_path = tmp_path / 'naflex_ckpt.pth'
+    torch.save(src_model.state_dict(), checkpoint_path)
+
+    dst_model = timm.create_model('naflexvit_base_patch16_gap', embed_dim=64, depth=2, num_heads=2, num_classes=10)
+    dst_model.load_pretrained(str(checkpoint_path))
+    for k, v in src_model.state_dict().items():
+        assert torch.equal(dst_model.state_dict()[k], v), k
+
+
+def test_naflexvit_load_pretrained_train_checkpoint(tmp_path):
+    import timm
+
+    src_model = timm.create_model('naflexvit_base_patch16_gap', embed_dim=64, depth=2, num_heads=2, num_classes=10)
+    checkpoint_path = tmp_path / 'naflex_train_ckpt.pth'
+    torch.save({'state_dict': src_model.state_dict(), 'epoch': 1}, checkpoint_path)
+
+    dst_model = timm.create_model('naflexvit_base_patch16_gap', embed_dim=64, depth=2, num_heads=2, num_classes=10)
+    dst_model.load_pretrained(str(checkpoint_path))
+    for k, v in src_model.state_dict().items():
+        assert torch.equal(dst_model.state_dict()[k], v), k
+
+
+def test_naflexvit_load_pretrained_npz_unsupported(tmp_path):
+    import timm
+
+    model = timm.create_model('naflexvit_base_patch16_gap', embed_dim=64, depth=2, num_heads=2, num_classes=10)
+    with pytest.raises(NotImplementedError):
+        model.load_pretrained(str(tmp_path / 'weights.npz'))

--- a/timm/models/naflexvit.py
+++ b/timm/models/naflexvit.py
@@ -1382,30 +1382,26 @@ class NaFlexVit(nn.Module):
 
     @torch.jit.ignore()
     def load_pretrained(self, checkpoint_path: str, prefix: str = '') -> None:
-        # Custom loading for the new model structure
-        from .vision_transformer import _load_weights as _orig_load_weights
+        """Load weights from a torch checkpoint, remapping original ViT keys to the NaFlexVit structure.
+
+        Args:
+            checkpoint_path: Path to a torch checkpoint (.npz JAX checkpoints are not supported).
+            prefix: Optional prefix to strip from checkpoint keys before remapping.
+        """
         from ._helpers import _torch_load
 
-        def _load_weights_adapter(model, checkpoint_path, prefix=''):
-            """Adapter function to handle the different model structure"""
-            state_dict = _torch_load(checkpoint_path, map_location='cpu', weights_only=True)
-            if isinstance(state_dict, dict) and 'state_dict' in state_dict:
-                state_dict = state_dict['state_dict']
+        if checkpoint_path.endswith('.npz') or checkpoint_path.endswith('.npy'):
+            raise NotImplementedError(
+                'Loading .npz / .npy (JAX) checkpoints is not currently supported for NaFlexVit, '
+                'please convert to a torch checkpoint first.'
+            )
 
-            # Map original keys to new structure
-            for k in list(state_dict.keys()):
-                if k.startswith('cls_token'):
-                    state_dict['embeds.' + k] = state_dict.pop(k)
-                elif k.startswith('reg_token'):
-                    state_dict['embeds.' + k] = state_dict.pop(k)
-                elif k.startswith('pos_embed'):
-                    state_dict['embeds.' + k] = state_dict.pop(k)
-                elif k.startswith('patch_embed'):
-                    state_dict['embeds.' + k[12:]] = state_dict.pop(k)
-
-            return _orig_load_weights(model, state_dict, prefix)
-
-        _load_weights_adapter(self, checkpoint_path, prefix)
+        state_dict = _torch_load(checkpoint_path, map_location='cpu', weights_only=True)
+        if isinstance(state_dict, dict) and 'state_dict' in state_dict:
+            state_dict = state_dict['state_dict']
+        if prefix:
+            state_dict = {k[len(prefix):]: v for k, v in state_dict.items() if k.startswith(prefix)}
+        self.load_state_dict(checkpoint_filter_fn(state_dict, self))
 
     @torch.jit.ignore
     def no_weight_decay(self) -> Set:


### PR DESCRIPTION
`NaFlexVit.load_pretrained` (timm/models/naflexvit.py:1384) could not succeed on any input:

- A torch checkpoint: the internal adapter loaded and remapped the state dict, then passed the resulting **dict** to `vision_transformer._load_weights` (naflexvit.py:1406), whose signature takes a **path** (vision_transformer.py:1422) and immediately calls `np.load(checkpoint_path)` (vision_transformer.py:1454). Result: `TypeError: expected str, bytes or os.PathLike object, not OrderedDict`.
- An `.npz`/`.npy` checkpoint: `timm.models.load_checkpoint` routes these extensions to `model.load_pretrained` (timm/models/_helpers.py:161-164), reachable from `train.py --initial-checkpoint` and `validate.py --checkpoint`, but the first thing the method did was `torch.load` the file, which cannot read numpy archives.

Even if the delegation had worked, `_load_weights` assigns to the `VisionTransformer` attribute layout (`model.patch_embed`, `model.cls_token`) that `NaFlexVit` does not have (`embeds.*`).

This PR replaces the adapter with a direct torch-checkpoint load through `_torch_load` plus the module's own `checkpoint_filter_fn` (naflexvit.py:1989), which already performs the complete key remap including the `pos_embed` `(1, N, C)` to `(1, H, W, C)` reshape and the `proj.weight` permute, mirroring how `VisionTransformer.load_pretrained` (vision_transformer.py:949) delegates to its own loader. A `prefix` argument now strips a key prefix before remapping. `.npz`/`.npy` paths raise a clear `NotImplementedError` with a conversion hint.

What this deliberately does not do: implement true JAX `.npz` loading for NaFlexVit. That needs a NaFlexVit-aware port of `_load_weights`, and the path was equally broken before this change, so it now fails loudly and clearly instead of cryptically.

Tests added in `tests/test_checkpoint_loading.py` cover a raw state dict, a train-style checkpoint with a `state_dict` key, and the npz error path. Without the fix they fail with the exact `TypeError` above; with it, `tests/test_checkpoint_loading.py` and `tests/test_factory.py` pass 47/47 locally (torch 2.13 / torchvision 0.28, Python 3.11).