### PR TITLE
Decay at the milestone epoch in MultiStepLRScheduler

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -252,6 +252,32 @@ class TestStepScheduler:
 class TestMultiStepScheduler:
     """Test MultiStepLRScheduler specific behavior."""
 
+    def test_multistep_decay_boundary(self):
+        """The decay happens at the milestone epoch, not the one before it."""
+        base_lr = 0.1
+        decay_rate = 0.5
+
+        optimizer = _create_optimizer(lr=base_lr)
+        scheduler = MultiStepLRScheduler(
+            optimizer,
+            decay_t=[10, 20],
+            decay_rate=decay_rate,
+        )
+
+        # the epoch before the milestone still runs at the undecayed rate
+        scheduler.step(9)
+        assert optimizer.param_groups[0]['lr'] == pytest.approx(base_lr, rel=1e-5)
+
+        # the milestone epoch itself is the first decayed one
+        scheduler.step(10)
+        assert optimizer.param_groups[0]['lr'] == pytest.approx(base_lr * decay_rate, rel=1e-5)
+
+        scheduler.step(19)
+        assert optimizer.param_groups[0]['lr'] == pytest.approx(base_lr * decay_rate, rel=1e-5)
+
+        scheduler.step(20)
+        assert optimizer.param_groups[0]['lr'] == pytest.approx(base_lr * decay_rate**2, rel=1e-5)
+
     def test_multistep_decay(self):
         """Test decay at specified milestones."""
         base_lr = 0.1

--- a/timm/scheduler/multistep_lr.py
+++ b/timm/scheduler/multistep_lr.py
@@ -51,7 +51,7 @@ class MultiStepLRScheduler(Scheduler):
     def get_curr_decay_steps(self, t):
         # find where in the array t goes,
         # assumes self.decay_t is sorted
-        return bisect.bisect_right(self.decay_t, t + 1)
+        return bisect.bisect_right(self.decay_t, t)
 
     def _get_lr(self, t: int) -> List[float]:
         if t < self.warmup_t:


### PR DESCRIPTION
`MultiStepLRScheduler.get_curr_decay_steps` looks up `t + 1` rather than `t`:

```python
def get_curr_decay_steps(self, t):
    # find where in the array t goes,
    # assumes self.decay_t is sorted
    return bisect.bisect_right(self.decay_t, t + 1)
```

so the learning rate drops one epoch before each milestone. With `--decay-milestones 10 20` the rate is already decayed when epoch 9 runs.

Comparing against `torch.optim.lr_scheduler.MultiStepLR` with the same milestones and gamma:

```
 epoch |  timm  |  torch  |
     8 |  0.100 |  0.100  |
     9 |  0.010 |  0.100  |  <== mismatch
    10 |  0.010 |  0.010  |
    18 |  0.010 |  0.010  |
    19 |  0.001 |  0.010  |  <== mismatch
    20 |  0.001 |  0.001  |
```

With this PR there are no mismatches across epochs 0-22.

Three references agree that the milestone epoch itself should be the first decayed one:

- `StepLRScheduler` in this package uses `decay_rate ** (t // decay_t)`, which first decays at `t == decay_t`. Before this change the two schedulers disagree at epoch 9 for equivalent settings; after it they agree.
- `torch.optim.lr_scheduler.MultiStepLR` uses `bisect_right(milestones, last_epoch)`.
- `train.py` describes `--decay-milestones` as a "list of decay epoch indices for multistep lr".

`train.py` calls `lr_scheduler.step(epoch + 1)`, so `t` is the epoch that is about to run, which is the value the milestone should be compared against.

The existing `test_multistep_decay` steps at 8, 11 and 21, so it crosses the boundary without landing on it and passes either way. The added `test_multistep_decay_boundary` pins epochs 9/10 and 19/20; it fails on `main` and passes here. `tests/test_scheduler.py` goes 51 -> 52 passing.

This does change the epoch at which existing multistep runs decay, so it will shift results for anyone using `--sched multistep`. Happy to gate it behind a flag instead if you would rather not change the default.
