### PR TITLE
Fix AttributeError in auto-augment factories when hparams is None

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,6 +3,15 @@ import pytest
 import torch
 
 from timm.data import create_loader, create_naflex_loader, create_transform
+from timm.data.auto_augment import (
+    _HPARAMS_DEFAULT,
+    AugMixAugment,
+    AutoAugment,
+    RandAugment,
+    augment_and_mix_transform,
+    auto_augment_transform,
+    rand_augment_transform,
+)
 from timm.data.mixup import rand_bbox_minmax
 
 
@@ -77,3 +86,25 @@ def test_create_naflex_loader_disables_persistent_workers_without_workers(is_tra
 
     assert loader.num_workers == 0
     assert not loader.persistent_workers
+
+
+@pytest.mark.parametrize('factory, config_str, expected_type', [
+    # each config string is taken verbatim from the corresponding factory's own docstring
+    (auto_augment_transform, 'original-mstd0.5', AutoAugment),
+    (auto_augment_transform, 'original', AutoAugment),
+    (rand_augment_transform, 'rand-m9-n3-mstd0.5', RandAugment),
+    (rand_augment_transform, 'rand-m9-n3-mmax8', RandAugment),
+    (rand_augment_transform, 'rand-mstd1-tweights', RandAugment),
+    (augment_and_mix_transform, 'augmix-m5-w4-d2', AugMixAugment),
+    (augment_and_mix_transform, 'augmix', AugMixAugment),
+])
+def test_auto_augment_factory_accepts_default_none_hparams(factory, config_str, expected_type):
+    # hparams defaults to None on all three public factories, but the mstd/mmax config sections
+    # (and augmix's unconditional magnitude_std default) call hparams.setdefault(...) before it is
+    # normalized, so the documented default used to raise AttributeError on a None hparams.
+    before = dict(_HPARAMS_DEFAULT)
+    transform = factory(config_str)
+    assert isinstance(transform, expected_type)
+    # the setdefault() calls must not leak magnitude_std into the shared module-level default,
+    # which would otherwise pin the value for every later call that relies on the defaults.
+    assert _HPARAMS_DEFAULT == before

--- a/timm/data/auto_augment.py
+++ b/timm/data/auto_augment.py
@@ -601,6 +601,7 @@ def auto_augment_transform(config_str: str, hparams: Optional[Dict] = None):
 
         'original-mstd0.5' results in AutoAugment with original policy, magnitude_std 0.5
     """
+    hparams = hparams or dict(_HPARAMS_DEFAULT)  # copy so setdefault() below doesn't mutate the shared default
     config = config_str.split('-')
     policy_name = config[0]
     config = config[1:]
@@ -789,6 +790,7 @@ def rand_augment_transform(
         'rand-mstd1-tweights' results in mag std 1.0, weighted transforms, default mag of 10 and num_layers 2
 
     """
+    hparams = hparams or dict(_HPARAMS_DEFAULT)  # copy so setdefault() below doesn't mutate the shared default
     magnitude = _LEVEL_DENOM  # default to _LEVEL_DENOM for magnitude (currently 10)
     num_layers = 2  # default to 2 ops per image
     increasing = False
@@ -967,6 +969,7 @@ def augment_and_mix_transform(config_str: str, hparams: Optional[Dict] = None):
     Returns:
          A PyTorch compatible Transform
     """
+    hparams = hparams or dict(_HPARAMS_DEFAULT)  # copy so setdefault() below doesn't mutate the shared default
     magnitude = 3
     width = 3
     depth = -1


### PR DESCRIPTION
### What

The three public auto-augment factory functions crash on their own documented default `hparams=None`:

```python
from timm.data.auto_augment import (
    auto_augment_transform, rand_augment_transform, augment_and_mix_transform,
)

augment_and_mix_transform('augmix-m5-w4-d2')   # AttributeError: 'NoneType' object has no attribute 'setdefault'
rand_augment_transform('rand-m9-n3-mstd0.5')   # AttributeError
auto_augment_transform('original-mstd0.5')     # AttributeError
```

Each of those config strings is copied verbatim from the corresponding function's own docstring example.

### Why

All three functions declare `hparams: Optional[Dict] = None`, but parse the `mstd`/`mmax` config sections by calling `hparams.setdefault(...)` *before* `hparams` is normalized:

- `auto_augment_transform` — `hparams.setdefault('magnitude_std', ...)` (mstd path)
- `rand_augment_transform` — `hparams.setdefault('magnitude_std'/'magnitude_max', ...)` (mstd/mmax paths)
- `augment_and_mix_transform` — same for mstd, **plus an unconditional** `hparams.setdefault('magnitude_std', float('inf'))`, so it raises on *any* config string, not just ones containing `mstd`.

The ops helpers these factories call (`auto_augment_policy`, `rand_augment_ops`, `augmix_ops`, `AugmentOp`) already guard with `hparams = hparams or _HPARAMS_DEFAULT`, but the factories dereference `hparams` before delegating, so that guard is never reached. The internal `transforms_factory.py` path always passes a real dict, which is why this wasn't caught in normal training runs — it only bites callers who use the factories directly with the documented default.

### Fix

Normalize `hparams` at the top of each factory, mirroring the existing `hparams = hparams or _HPARAMS_DEFAULT` idiom — but using a **copy** (`dict(_HPARAMS_DEFAULT)`). The factories mutate `hparams` via `setdefault`, and `_HPARAMS_DEFAULT` has no `magnitude_std` key, so reusing the shared module-level dict directly would leak `magnitude_std` into it and pin that value for every later call that relies on the defaults. Passing a real `hparams` dict is unchanged.

### Tests

Added a parametrized regression test in `tests/test_data.py` covering every factory and each affected path (the mstd/mmax sections and augmix's unconditional default), asserting the transforms build and that the shared `_HPARAMS_DEFAULT` is never mutated. It fails on `main` (6 cases) and passes with the fix; `tests/test_data.py` + `tests/test_factory.py` stay green (52 passed).