### PR TITLE
Fix auto-augment 'inc' and 'b' config flags ignoring the documented 0 value

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 
 from timm.data import create_loader, create_naflex_loader, create_transform
+from timm.data.auto_augment import augment_and_mix_transform, rand_augment_transform
 from timm.data.mixup import rand_bbox_minmax
 
 
@@ -77,3 +78,28 @@ def test_create_naflex_loader_disables_persistent_workers_without_workers(is_tra
 
     assert loader.num_workers == 0
     assert not loader.persistent_workers
+
+
+@pytest.mark.parametrize('config_str, expected_increasing', [
+    ('rand-m9-n3', False),       # flag omitted -> default off
+    ('rand-m9-n3-inc0', False),  # documented off value
+    ('rand-m9-n3-inc1', True),   # documented on value
+])
+def test_rand_augment_inc_flag_respects_zero(config_str, expected_increasing):
+    # 'inc' is documented as integer(bool) with default 0 and must toggle the increasing-severity
+    # transform set. val is the raw config string, and bool('0') is True, so 'inc0' used to enable it.
+    transform = rand_augment_transform(config_str, hparams={})
+    uses_increasing = any('Increasing' in op.name for op in transform.ops)
+    assert uses_increasing == expected_increasing
+
+
+@pytest.mark.parametrize('config_str, expected_blended', [
+    ('augmix-m5-w4', False),     # flag omitted -> default off
+    ('augmix-m5-w4-b0', False),  # documented off value
+    ('augmix-m5-w4-b1', True),   # documented on value
+])
+def test_augmix_blended_flag_respects_zero(config_str, expected_blended):
+    # 'b' (blended) is documented as integer(bool) with default 0; bool('0') is True, so 'b0' used
+    # to select the blended code path instead of disabling it.
+    transform = augment_and_mix_transform(config_str, hparams={})
+    assert transform.blended == expected_blended

--- a/timm/data/auto_augment.py
+++ b/timm/data/auto_augment.py
@@ -819,8 +819,7 @@ def rand_augment_transform(
                 # clip magnitude between [0, mmax] instead of default [0, _LEVEL_DENOM]
                 hparams.setdefault('magnitude_max', int(val))
             elif key == 'inc':
-                if bool(val):
-                    increasing = True
+                increasing = bool(int(val))
             elif key == 'm':
                 magnitude = int(val)
             elif key == 'n':
@@ -992,7 +991,7 @@ def augment_and_mix_transform(config_str: str, hparams: Optional[Dict] = None):
         elif key == 'a':
             alpha = float(val)
         elif key == 'b':
-            blended = bool(val)
+            blended = bool(int(val))
         else:
             assert False, 'Unknown AugMix config section'
     hparams.setdefault('magnitude_std', float('inf'))  # default to uniform sampling (if not set via mstd arg)


### PR DESCRIPTION
### What

Two boolean config-string flags don't respect their documented `0` (off) value:

```python
from timm.data.auto_augment import rand_augment_transform, augment_and_mix_transform

rand_augment_transform('rand-m9-n3-inc0')     # docs: inc default 0 (off) -> actually uses the increasing set
augment_and_mix_transform('augmix-m5-w4-b0')  # docs: b default 0 (off)   -> actually builds blended=True
```

### Why

`rand_augment_transform`'s `inc` flag and `augment_and_mix_transform`'s `b` (blended) flag are both documented as `integer (bool) ... default 0`, but they were parsed with `bool(val)` where `val` is the raw string captured from the config section:

```python
elif key == 'inc':
    if bool(val):          # val == '0' for 'inc0', and bool('0') is True
        increasing = True
...
elif key == 'b':
    blended = bool(val)    # same: bool('0') is True
```

Since `bool('0')` is `True` in Python, the documented off value turns the flag **on**. `inc0` and `inc1` both enable the increasing-severity transform set; `b0` and `b1` both select the blended AugMix path (a genuinely different augmentation output). There is no config-string way to explicitly request the off state — only omitting the flag works.

### Fix

Parse as `bool(int(val))`, matching the docstrings and the `int(val)` parsing already used for the other numeric sections (`m`, `n`, `mmax`, `d`, `w`). `0` now disables and `1` enables.

### Tests

Added regression tests in `tests/test_data.py` for both flags, covering the omitted / `'0'` / `'1'` cases. They fail on `main` for the `inc0`/`b0` cases and pass with the fix; `tests/test_data.py` + `tests/test_factory.py` stay green (51 passed).

(The tests pass an explicit `hparams={}` so they're independent of #2747, which fixes an unrelated `hparams=None` crash in the same file.)