### PR TITLE
Fix SGDW foreach path applying weight decay once per (device, dtype) group

### DIFF
--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -761,3 +761,24 @@ def test_csgdw(optimizer):
         lambda params: create_optimizer_v2(params, optimizer, lr=5e-4)
     )
     _test_model(optimizer, dict(lr=5e-4))
+
+
+def test_sgdw_multi_tensor_weight_decay_matches_single_tensor():
+    # The foreach path groups params by (device, dtype) and iterates the groups. Decoupled weight
+    # decay must be applied to each group's params, otherwise params spanning more than one partition
+    # (e.g. mixed dtypes) are decayed once per partition instead of once. Compare foreach against the
+    # single-tensor reference with two dtypes so there are two partitions.
+    from timm.optim.sgdw import SGDW
+
+    def run(foreach):
+        p32 = Parameter(torch.tensor([1.0, 2.0], dtype=torch.float32))
+        p64 = Parameter(torch.tensor([1.0, 2.0], dtype=torch.float64))
+        for p in (p32, p64):
+            p.grad = torch.ones_like(p)
+        SGDW([p32, p64], lr=0.1, momentum=0.0, weight_decay=0.5, foreach=foreach).step()
+        return p32.detach().clone(), p64.detach().clone()
+
+    multi32, multi64 = run(True)
+    single32, single64 = run(False)
+    torch.testing.assert_close(multi32, single32)
+    torch.testing.assert_close(multi64, single64)

--- a/timm/optim/sgdw.py
+++ b/timm/optim/sgdw.py
@@ -265,7 +265,7 @@ def _multi_tensor_sgdw(
             device_grads = torch._foreach_neg(device_grads)
 
         wd_scale = lr if max_lr is None else lr ** 2 / max_lr
-        torch._foreach_mul_(params, 1. - wd_scale * weight_decay)
+        torch._foreach_mul_(device_params, 1. - wd_scale * weight_decay)
 
         if momentum != 0:
             bufs = []


### PR DESCRIPTION
### What

`SGDW`'s multi-tensor (`foreach=True`) path applies decoupled weight decay once per `(device, dtype)` partition instead of once per step. When the parameters passed to the optimizer span more than one partition — e.g. mixed dtypes, or multiple devices — each parameter is decayed `N` times (`N` = number of partitions):

```python
import torch
from timm.optim.sgdw import SGDW

def run(foreach):
    p32 = torch.nn.Parameter(torch.tensor([1.0]))                        # float32
    p64 = torch.nn.Parameter(torch.tensor([1.0], dtype=torch.float64))   # float64
    for p in (p32, p64): p.grad = torch.zeros_like(p)
    SGDW([p32, p64], lr=1.0, momentum=0.0, weight_decay=0.1, foreach=foreach).step()
    return p32.item(), p64.item()

run(True)   # (0.81, 0.81)  -> decayed twice: 0.9**2   (WRONG)
run(False)  # (0.90, 0.90)  -> decayed once           (correct)
```

### Why

`_multi_tensor_sgdw` groups the tensors and iterates the groups:

```python
for ((device_params, device_grads, device_momentum_buffer_list), indices) in grouped_tensors.values():
    ...
    torch._foreach_mul_(params, 1. - wd_scale * weight_decay)   # <- full list, once per group
```

Every other tensor op in the loop operates on this group's `device_params` / `device_grads` — only the weight-decay line used the full `params` list, so it re-runs on every parameter once per partition. This diverges from the single-tensor path (`_single_tensor_sgdw` decays each param exactly once) and from PyTorch's own `_multi_tensor_sgd`, which applies its per-param ops to `device_params` inside the grouped loop.

It went uncaught because every existing SGDW/`csgdw` test uses single-dtype params on one device — a single partition, where `params == device_params` and the bug is masked.

### Fix

Apply the decay to `device_params`, matching every other op in the loop and the single-tensor reference. One-token change.

### Tests

Adds `test_sgdw_multi_tensor_weight_decay_matches_single_tensor`, which compares the `foreach` and single-tensor paths with two dtypes (two partitions). It fails on `main` and passes with the fix. Full `tests/test_optim.py` has no new failures (the two pre-existing failures — `test_kron[kron]` torch.compile/inductor on this platform, and the `csgdp` full-run convergence flake — reproduce identically on clean `main`).