### PR TITLE
Preserve Vision Transformer classifier device and dtype on reset

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -435,6 +435,28 @@ def test_pruned_efficientnet_in_chans(model_name):
         assert model(torch.randn(1, 1, 32, 32)).shape == (1, 1000)
 
 
+@pytest.mark.base
+@pytest.mark.parametrize('model_cls', [timm.models.VisionTransformer, timm.models.VisionTransformerDistilled])
+def test_vit_reset_classifier_preserves_dtype(model_cls):
+    model = model_cls(
+        img_size=16,
+        patch_size=8,
+        embed_dim=8,
+        depth=1,
+        num_heads=1,
+        mlp_ratio=1,
+        num_classes=3,
+    ).to(dtype=torch.float64)
+
+    model.reset_classifier(0)
+    model.reset_classifier(2)
+
+    classifier = model.get_classifier()
+    classifier = classifier if isinstance(classifier, tuple) else (classifier,)
+    assert all(parameter.dtype == torch.float64 for head in classifier for parameter in head.parameters())
+    assert model(torch.randn(1, 3, 16, 16, dtype=torch.float64)).dtype == torch.float64
+
+
 @pytest.mark.torchscript
 @pytest.mark.timeout(timeout120)
 @pytest.mark.parametrize(

--- a/timm/models/deit.py
+++ b/timm/models/deit.py
@@ -69,9 +69,11 @@ class VisionTransformerDistilled(VisionTransformer):
         return self.head, self.head_dist
 
     def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None):
+        parameter = next(self.parameters())
+        dd = {'device': parameter.device, 'dtype': parameter.dtype}
         self.num_classes = num_classes
-        self.head = nn.Linear(self.embed_dim, num_classes) if num_classes > 0 else nn.Identity()
-        self.head_dist = nn.Linear(self.embed_dim, self.num_classes) if num_classes > 0 else nn.Identity()
+        self.head = nn.Linear(self.embed_dim, num_classes, **dd) if num_classes > 0 else nn.Identity()
+        self.head_dist = nn.Linear(self.embed_dim, self.num_classes, **dd) if num_classes > 0 else nn.Identity()
 
     @torch.jit.ignore
     def set_distilled_training(self, enable=True):

--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -1003,6 +1003,8 @@ class VisionTransformer(nn.Module):
             num_classes: Number of classes for new classifier.
             global_pool: Global pooling type.
         """
+        parameter = next(self.parameters())
+        dd = {'device': parameter.device, 'dtype': parameter.dtype}
         self.num_classes = num_classes
         if global_pool is not None:
             assert global_pool in ('', 'avg', 'avgmax', 'max', 'token', 'map', 'prr')
@@ -1013,7 +1015,7 @@ class VisionTransformer(nn.Module):
             elif global_pool in ('map', 'prr') and self.global_pool != global_pool:
                 assert False, "Cannot currently change attention pooling type in reset_classifier()."
             self.global_pool = global_pool
-        self.head = nn.Linear(self.embed_dim, num_classes) if num_classes > 0 else nn.Identity()
+        self.head = nn.Linear(self.embed_dim, num_classes, **dd) if num_classes > 0 else nn.Identity()
 
     def set_input_size(
             self,


### PR DESCRIPTION
## Summary

Preserve the current device and dtype when resetting the classifier heads of `VisionTransformer` and `VisionTransformerDistilled`.

Both reset paths created replacement linear layers with PyTorch's CPU and float32 defaults. Resetting a model after moving it to another dtype therefore produced a mixed-dtype module and made the next forward pass fail. The reset paths now derive factory arguments from the model's existing parameters before creating either classifier head.

The regression test covers the standard and distilled variants, including rebuilding a classifier after it was disabled with `reset_classifier(0)`. Before this change, both variants rebuilt float32 heads and failed on float64 input.

## Validation

- `py -3.13 -m pytest --disable-plugin-autoload tests/test_models.py::test_vit_reset_classifier_preserves_dtype -q`: 2 passed
- `py -3.13 -m ruff check --ignore E402,F401,F811,F541,E741,F821 timm/models/vision_transformer.py timm/models/deit.py tests/test_models.py`: passed
- `py -3.13 -m py_compile timm/models/vision_transformer.py timm/models/deit.py tests/test_models.py`: passed
- `git diff --check`: passed

## AI assistance

OpenAI Codex was used to audit the code, reproduce the issue, prepare the patch and regression test, run validation, and draft this pull request description.