### PR TITLE
Fix MultiStepLRScheduler decaying one epoch before each milestone

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -281,6 +281,33 @@ class TestMultiStepScheduler:
         scheduler.step(31)
         assert optimizer.param_groups[0]['lr'] == pytest.approx(base_lr * decay_rate ** 3, rel=1e-5)
 
+    def test_multistep_decay_at_milestone_boundary(self):
+        """Decay must take effect AT the milestone epoch, not the epoch before it.
+
+        This matches torch.optim.lr_scheduler.MultiStepLR and timm's own StepLRScheduler, both of
+        which keep the base LR up to milestone - 1 and drop it at the milestone epoch itself.
+        """
+        base_lr = 0.1
+        decay_t = [10, 20, 30]
+        decay_rate = 0.5
+
+        optimizer = _create_optimizer(lr=base_lr)
+        scheduler = MultiStepLRScheduler(optimizer, decay_t=decay_t, decay_rate=decay_rate)
+
+        # epoch just before the first milestone: no decay yet
+        scheduler.step(9)
+        assert optimizer.param_groups[0]['lr'] == pytest.approx(base_lr, rel=1e-5)
+
+        # at the first milestone: the first decay applies
+        scheduler.step(10)
+        assert optimizer.param_groups[0]['lr'] == pytest.approx(base_lr * decay_rate, rel=1e-5)
+
+        # just before / at the second milestone
+        scheduler.step(19)
+        assert optimizer.param_groups[0]['lr'] == pytest.approx(base_lr * decay_rate, rel=1e-5)
+        scheduler.step(20)
+        assert optimizer.param_groups[0]['lr'] == pytest.approx(base_lr * decay_rate ** 2, rel=1e-5)
+
 
 class TestPolyScheduler:
     """Test PolyLRScheduler specific behavior."""

--- a/timm/scheduler/multistep_lr.py
+++ b/timm/scheduler/multistep_lr.py
@@ -51,7 +51,7 @@ class MultiStepLRScheduler(Scheduler):
     def get_curr_decay_steps(self, t):
         # find where in the array t goes,
         # assumes self.decay_t is sorted
-        return bisect.bisect_right(self.decay_t, t + 1)
+        return bisect.bisect_right(self.decay_t, t)
 
     def _get_lr(self, t: int) -> List[float]:
         if t < self.warmup_t:


### PR DESCRIPTION
### What

`MultiStepLRScheduler` applies each milestone decay one epoch too early. With `decay_t=[30, 60]`, `decay_rate=0.1`:

| epoch | timm MultiStep | torch `MultiStepLR` | timm `StepLRScheduler(decay_t=30)` |
|---|---|---|---|
| 29 | **0.1** | 1.0 | 1.0 |
| 30 | 0.1 | 0.1 | 0.1 |
| 59 | **0.01** | 0.1 | 0.1 |
| 60 | 0.01 | 0.01 | 0.01 |

timm drops the LR at epoch 29/59; both references drop it at 30/60.

### Why

```python
def get_curr_decay_steps(self, t):
    return bisect.bisect_right(self.decay_t, t + 1)
```

The `t + 1` counts a milestone as passed one epoch before epoch `t` actually reaches it, so the `decay_rate` exponent increments an epoch early. The correct exponent (number of milestones passed by epoch `t`) is `bisect_right(self.decay_t, t)`:

- `torch.optim.lr_scheduler.MultiStepLR` uses `bisect_right(milestones, last_epoch)` — no `+ 1`.
- timm's own `StepLRScheduler` uses `t // decay_t` — also drops at the milestone epoch, not before.

Both agree the decay should take effect **at** the milestone. The class docstring is empty and no comment explains the `+ 1`; it looks like a plain off-by-one.

### Fix

Drop the `+ 1`. This is a one-epoch behavior change for `multistep` schedules (the decay now lands on the milestone epoch instead of the epoch before it), bringing it in line with `torch`'s `MultiStepLR` and timm's own `StepLRScheduler`.

### Tests

The existing `test_multistep_decay` only steps at epochs away from the milestones (8, 11, 21, 31), which produce the same exponent with or without the `+ 1`, so the boundary was never asserted. Added `test_multistep_decay_at_milestone_boundary` covering `milestone - 1` (base LR) and the milestone epoch (first decay). It fails on `main` and passes with the fix; the full `tests/test_scheduler.py` stays green (53 passed).