### PR TITLE
Fix OptimizerRegistry.create_optimizer crash on layer_decay without an explicit min scale

### DIFF
--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -635,6 +635,26 @@ def test_param_groups_layer_decay_with_min():
         assert group['lr_scale'] >= 0.5
 
 
+def test_registry_create_optimizer_layer_decay_default_min_scale():
+    # The registry create_optimizer must handle layer_decay when the min scale is left at its
+    # default: it used to default layer_decay_min_scale to None, which crashed in
+    # param_groups_layer_decay's max(min_scale, ...). create_optimizer_v2 passed 0.0 and was fine.
+    from timm.optim._optim_factory import default_registry
+
+    model = torch.nn.Sequential(
+        torch.nn.Linear(10, 5),
+        torch.nn.ReLU(),
+        torch.nn.Linear(5, 2),
+    )
+    optimizer = default_registry.create_optimizer(
+        model, 'adamw', lr=1e-3, weight_decay=0.05, layer_decay=0.75,
+    )
+    assert len(optimizer.param_groups) > 0
+    for group in optimizer.param_groups:
+        assert 'lr_scale' in group
+        assert 0.0 <= group['lr_scale'] <= 1.0
+
+
 def test_param_groups_layer_decay_with_matcher():
     class ModelWithMatcher(torch.nn.Module):
         def __init__(self):

--- a/timm/optim/_optim_factory.py
+++ b/timm/optim/_optim_factory.py
@@ -237,7 +237,7 @@ class OptimizerRegistry:
             fallback_list: Collection[str] = (),
             fallback_no_weight_decay: bool = False,
             layer_decay: Optional[float] = None,
-            layer_decay_min_scale: Optional[float] = None,
+            layer_decay_min_scale: float = 0.0,
             layer_decay_no_opt_scale: Optional[float] = None,
             param_group_fn: Optional[Callable[[nn.Module], ParamsT]] = None,
             **kwargs: Any,


### PR DESCRIPTION
### What

Minor, but a hard crash: calling the registry's `create_optimizer` with `layer_decay` set and the min scale left at its default raises a `TypeError`.

```python
from timm.optim._optim_factory import default_registry
model = torch.nn.Sequential(torch.nn.Linear(10, 5), torch.nn.ReLU(), torch.nn.Linear(5, 2))

default_registry.create_optimizer(model, 'adamw', lr=1e-3, weight_decay=0.05, layer_decay=0.75)
# TypeError: '>' not supported between instances of 'float' and 'NoneType'
```

The common entry point `create_optimizer_v2` is **not** affected — it passes `0.0`.

### Why

`OptimizerRegistry.create_optimizer` defaults `layer_decay_min_scale` to `None` and forwards it unguarded as `min_scale` into `param_groups_layer_decay`, whose scale line is:

```python
layer_scales = list(max(min_scale, layer_decay ** (layer_max - i)) for i in range(num_layers))
```

`max(None, <float>)` raises in Python 3. Both `create_optimizer_v2` (`layer_decay_min_scale: float = 0.0`) and `param_groups_layer_decay` itself (`min_scale: float = 0.`) already default this to `0.0`; only the registry method defaulted it to `None`.

### Fix

Default `layer_decay_min_scale` to `0.0` in the registry method, matching its siblings. `0.0` is a no-op clamp (the scales are already `>= 0`), so this only removes the crash — it doesn't change behavior for callers that passed a value.

`layer_decay_no_opt_scale` keeps its `Optional[float] = None` default on purpose: it's consumed behind a truthiness guard (`if no_opt_scale and ...`), so `None` is safe there. Verified that the same call with only `no_opt_scale` still crashes on `min_scale`, confirming `min_scale` is the sole culprit.

### Tests

Added `test_registry_create_optimizer_layer_decay_default_min_scale`, which builds layer-decay param groups through the registry path with the min scale omitted. It fails on `main` (the `TypeError`) and passes with the fix; the related layer-decay/param-group tests stay green.