### PR TITLE
Fix PlateauLRScheduler state restoration

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -368,10 +368,10 @@ class TestStateDict:
     def test_plateau_state_dict_save_load(self):
         """Test PlateauLRScheduler state dict save/load."""
         optimizer = _create_optimizer()
-        scheduler = PlateauLRScheduler(optimizer)
+        scheduler = PlateauLRScheduler(optimizer, patience_t=2, decay_rate=0.5)
 
-        # Step a few times
-        for epoch in range(5):
+        # Leave the scheduler just before its next decay.
+        for epoch in range(1, 4):
             scheduler.step(epoch, metric=1.0)
 
         # Save state
@@ -380,11 +380,15 @@ class TestStateDict:
 
         # Create new scheduler and load state
         optimizer2 = _create_optimizer()
-        scheduler2 = PlateauLRScheduler(optimizer2)
+        scheduler2 = PlateauLRScheduler(optimizer2, patience_t=2, decay_rate=0.5)
         scheduler2.load_state_dict(state_dict)
 
         # State should be restored
         assert scheduler2.state_dict() == state_dict
+
+        scheduler.step(4, metric=1.0)
+        scheduler2.step(4, metric=1.0)
+        assert optimizer2.param_groups[0]['lr'] == optimizer.param_groups[0]['lr']
 
 
 class TestStepUpdate:

--- a/timm/scheduler/plateau_lr.py
+++ b/timm/scheduler/plateau_lr.py
@@ -62,15 +62,10 @@ class PlateauLRScheduler(Scheduler):
         self.restore_lr = None
 
     def state_dict(self) -> Dict[str, Any]:
-        return {
-            'best': self.lr_scheduler.best,
-            'last_epoch': self.lr_scheduler.last_epoch,
-        }
+        return self.lr_scheduler.state_dict()
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
-        self.lr_scheduler.best = state_dict['best']
-        if 'last_epoch' in state_dict:
-            self.lr_scheduler.last_epoch = state_dict['last_epoch']
+        self.lr_scheduler.load_state_dict(state_dict)
 
     # override the base class step fn completely
     def step(self, epoch: int, metric: Optional[float] = None) -> None:


### PR DESCRIPTION
## Summary

`PlateauLRScheduler.state_dict()` currently saves only `best` and `last_epoch`, which drops `ReduceLROnPlateau` progress such as `num_bad_epochs` and `cooldown_counter`. Restoring the scheduler from that state can therefore produce a different learning-rate schedule than uninterrupted scheduling.

Addresses the scheduler-state restoration gap discussed in #871. This PR updates `PlateauLRScheduler` serialization only and does not change the training script checkpoint plumbing.

## Changes

- Delegate `state_dict()` and `load_state_dict()` to the wrapped `ReduceLROnPlateau` scheduler so its complete state is preserved.
- Extend the existing scheduler state test to compare continued scheduling between uninterrupted and restored instances.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 py -3.13 -m pytest tests/test_scheduler.py -q` (51 passed)
- `ruff check timm/scheduler/plateau_lr.py` (passed)
- `git diff --check` (passed)

## AI assistance disclosure

AI-assisted development tools were used during investigation and implementation. The reported tests were run against the final diff.