### PR TITLE
Fix ParseKwargs crash on a --model-kwargs value containing '=' or a non-literal

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,200 +1,36 @@
-from torch.nn.modules.batchnorm import BatchNorm2d
-from torchvision.ops.misc import FrozenBatchNorm2d
+import argparse
 
-import timm
-import pytest
-from timm.utils.model import freeze, unfreeze
-from timm.utils.model import ActivationStatsHook
-from timm.utils.model import extract_spp_stats
-
-from timm.utils.model import _freeze_unfreeze
-from timm.utils.model import avg_sq_ch_mean, avg_ch_var, avg_ch_var_residual
-from timm.utils.model import reparameterize_model
-from timm.utils.model import get_state_dict
-from timm.utils.metrics import AverageMeter
-
-def test_average_meter_zero_count():
-    # update with n=0 on a fresh meter (count == 0) must not raise ZeroDivisionError
-    meter = AverageMeter()
-    meter.update(1.0, n=0)
-    assert meter.avg == 0
+from timm.utils.misc import ParseKwargs
 
 
-def test_freeze_unfreeze():
-    model = timm.create_model('resnet18')
-
-    # Freeze all
-    freeze(model)
-    # Check top level module
-    assert model.fc.weight.requires_grad == False
-    # Check submodule
-    assert model.layer1[0].conv1.weight.requires_grad == False
-    # Check BN
-    assert isinstance(model.layer1[0].bn1, FrozenBatchNorm2d)
-
-    # Unfreeze all
-    unfreeze(model)
-    # Check top level module
-    assert model.fc.weight.requires_grad == True
-    # Check submodule
-    assert model.layer1[0].conv1.weight.requires_grad == True
-    # Check BN
-    assert isinstance(model.layer1[0].bn1, BatchNorm2d)
-
-    # Freeze some
-    freeze(model, ['layer1', 'layer2.0'])
-    # Check frozen
-    assert model.layer1[0].conv1.weight.requires_grad == False
-    assert isinstance(model.layer1[0].bn1, FrozenBatchNorm2d)
-    assert model.layer2[0].conv1.weight.requires_grad == False
-    # Check not frozen
-    assert model.layer3[0].conv1.weight.requires_grad == True
-    assert isinstance(model.layer3[0].bn1, BatchNorm2d)
-    assert model.layer2[1].conv1.weight.requires_grad == True
-
-    # Unfreeze some
-    unfreeze(model, ['layer1', 'layer2.0'])
-    # Check not frozen
-    assert model.layer1[0].conv1.weight.requires_grad == True
-    assert isinstance(model.layer1[0].bn1, BatchNorm2d)
-    assert model.layer2[0].conv1.weight.requires_grad == True
-
-    # Freeze/unfreeze BN
-    # From root
-    freeze(model, ['layer1.0.bn1'])
-    assert isinstance(model.layer1[0].bn1, FrozenBatchNorm2d)
-    unfreeze(model, ['layer1.0.bn1'])
-    assert isinstance(model.layer1[0].bn1, BatchNorm2d)
-    # From direct parent
-    freeze(model.layer1[0], ['bn1'])
-    assert isinstance(model.layer1[0].bn1, FrozenBatchNorm2d)    
-    unfreeze(model.layer1[0], ['bn1'])
-    assert isinstance(model.layer1[0].bn1, BatchNorm2d)
-
-def test_activation_stats_hook_validation():
-    model = timm.create_model('resnet18')
-    
-    def test_hook(model, input, output):
-        return output.mean().item()
-    
-    # Test error case with mismatched lengths
-    with pytest.raises(ValueError, match="Please provide `hook_fns` for each `hook_fn_locs`"):
-        ActivationStatsHook(
-            model,
-            hook_fn_locs=['layer1.0.conv1', 'layer1.0.conv2'],
-            hook_fns=[test_hook]
-        )
+def _parse_model_kwargs(tokens):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--model-kwargs', nargs='*', default={}, action=ParseKwargs)
+    args = parser.parse_args(['--model-kwargs'] + tokens)
+    return args.model_kwargs
 
 
-def test_extract_spp_stats():
-    model = timm.create_model('resnet18')
-    
-    def test_hook(model, input, output):
-        return output.mean().item()
-    
-    stats = extract_spp_stats(
-        model,
-        hook_fn_locs=['layer1.0.conv1'],
-        hook_fns=[test_hook],
-        input_shape=[2, 3, 32, 32]
-    )
-    
-    assert isinstance(stats, dict)
-    assert test_hook.__name__ in stats
-    assert isinstance(stats[test_hook.__name__], list)
-    assert len(stats[test_hook.__name__]) > 0
-
-def test_freeze_unfreeze_bn_root():
-    import torch.nn as nn
-    from timm.layers import BatchNormAct2d
-    
-    # Create batch norm layers
-    bn = nn.BatchNorm2d(10)
-    bn_act = BatchNormAct2d(10)
-    
-    # Test with BatchNorm2d as root
-    with pytest.raises(AssertionError):
-        _freeze_unfreeze(bn, mode="freeze")
-    
-    # Test with BatchNormAct2d as root
-    with pytest.raises(AssertionError):
-        _freeze_unfreeze(bn_act, mode="freeze")
+def test_parse_kwargs_literal_values():
+    assert _parse_model_kwargs(['depth=12', 'drop_rate=0.1', 'pretrained=True']) == {
+        'depth': 12,
+        'drop_rate': 0.1,
+        'pretrained': True,
+    }
 
 
-def test_activation_stats_functions():
-    import torch
-    
-    # Create sample input tensor [batch, channels, height, width]
-    x = torch.randn(2, 3, 4, 4)
-    
-    # Test avg_sq_ch_mean
-    result1 = avg_sq_ch_mean(None, None, x)
-    assert isinstance(result1, float)
-    
-    # Test avg_ch_var
-    result2 = avg_ch_var(None, None, x)
-    assert isinstance(result2, float)
-    
-    # Test avg_ch_var_residual
-    result3 = avg_ch_var_residual(None, None, x)
-    assert isinstance(result3, float)
+def test_parse_kwargs_value_with_equals():
+    # A value that itself contains '=' must split only on the first '=' and be
+    # kept verbatim. Before, split('=') raised "too many values to unpack", and
+    # the literal_eval fallback only caught ValueError so 'size=large' (invalid
+    # syntax) still raised SyntaxError.
+    assert _parse_model_kwargs(['note=size=large', 'url=http://h/p?a=1&b=2']) == {
+        'note': 'size=large',
+        'url': 'http://h/p?a=1&b=2',
+    }
 
 
-def test_reparameterize_model():
-    import torch.nn as nn
-    
-    class FusableModule(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.conv = nn.Conv2d(3, 3, 1)
-        
-        def fuse(self):
-            return nn.Identity()
-    
-    class ModelWithFusable(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.fusable = FusableModule()
-            self.normal = nn.Linear(10, 10)
-    
-    model = ModelWithFusable()
-    
-    # Test with inplace=False (should create a copy)
-    new_model = reparameterize_model(model, inplace=False)
-    assert isinstance(new_model.fusable, nn.Identity)
-    assert isinstance(model.fusable, FusableModule)  # Original unchanged
-    
-    # Test with inplace=True
-    reparameterize_model(model, inplace=True)
-    assert isinstance(model.fusable, nn.Identity)
-
-
-def test_get_state_dict_custom_unwrap():
-    import torch.nn as nn
-    
-    class CustomModel(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.linear = nn.Linear(10, 10)
-    
-    model = CustomModel()
-    
-    def custom_unwrap(m):
-        return m
-    
-    state_dict = get_state_dict(model, unwrap_fn=custom_unwrap)
-    assert 'linear.weight' in state_dict
-    assert 'linear.bias' in state_dict
-
-
-def test_freeze_unfreeze_string_input():
-    model = timm.create_model('resnet18')
-    
-    # Test with string input
-    _freeze_unfreeze(model, 'layer1', mode='freeze')
-    assert model.layer1[0].conv1.weight.requires_grad == False
-    
-    # Test unfreezing with string input
-    _freeze_unfreeze(model, 'layer1', mode='unfreeze')
-    assert model.layer1[0].conv1.weight.requires_grad == True
-
+def test_parse_kwargs_non_literal_falls_back_to_string():
+    assert _parse_model_kwargs(['act=nn.GELU', 'cfg={"a": 1}']) == {
+        'act': 'nn.GELU',
+        'cfg': {'a': 1},
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,204 @@
-import argparse
+from torch.nn.modules.batchnorm import BatchNorm2d
+from torchvision.ops.misc import FrozenBatchNorm2d
 
+import timm
+import pytest
+from timm.utils.model import freeze, unfreeze
+from timm.utils.model import ActivationStatsHook
+from timm.utils.model import extract_spp_stats
+
+from timm.utils.model import _freeze_unfreeze
+from timm.utils.model import avg_sq_ch_mean, avg_ch_var, avg_ch_var_residual
+from timm.utils.model import reparameterize_model
+from timm.utils.model import get_state_dict
+from timm.utils.metrics import AverageMeter
+import argparse
 from timm.utils.misc import ParseKwargs
+
+def test_average_meter_zero_count():
+    # update with n=0 on a fresh meter (count == 0) must not raise ZeroDivisionError
+    meter = AverageMeter()
+    meter.update(1.0, n=0)
+    assert meter.avg == 0
+
+
+def test_freeze_unfreeze():
+    model = timm.create_model('resnet18')
+
+    # Freeze all
+    freeze(model)
+    # Check top level module
+    assert model.fc.weight.requires_grad == False
+    # Check submodule
+    assert model.layer1[0].conv1.weight.requires_grad == False
+    # Check BN
+    assert isinstance(model.layer1[0].bn1, FrozenBatchNorm2d)
+
+    # Unfreeze all
+    unfreeze(model)
+    # Check top level module
+    assert model.fc.weight.requires_grad == True
+    # Check submodule
+    assert model.layer1[0].conv1.weight.requires_grad == True
+    # Check BN
+    assert isinstance(model.layer1[0].bn1, BatchNorm2d)
+
+    # Freeze some
+    freeze(model, ['layer1', 'layer2.0'])
+    # Check frozen
+    assert model.layer1[0].conv1.weight.requires_grad == False
+    assert isinstance(model.layer1[0].bn1, FrozenBatchNorm2d)
+    assert model.layer2[0].conv1.weight.requires_grad == False
+    # Check not frozen
+    assert model.layer3[0].conv1.weight.requires_grad == True
+    assert isinstance(model.layer3[0].bn1, BatchNorm2d)
+    assert model.layer2[1].conv1.weight.requires_grad == True
+
+    # Unfreeze some
+    unfreeze(model, ['layer1', 'layer2.0'])
+    # Check not frozen
+    assert model.layer1[0].conv1.weight.requires_grad == True
+    assert isinstance(model.layer1[0].bn1, BatchNorm2d)
+    assert model.layer2[0].conv1.weight.requires_grad == True
+
+    # Freeze/unfreeze BN
+    # From root
+    freeze(model, ['layer1.0.bn1'])
+    assert isinstance(model.layer1[0].bn1, FrozenBatchNorm2d)
+    unfreeze(model, ['layer1.0.bn1'])
+    assert isinstance(model.layer1[0].bn1, BatchNorm2d)
+    # From direct parent
+    freeze(model.layer1[0], ['bn1'])
+    assert isinstance(model.layer1[0].bn1, FrozenBatchNorm2d)    
+    unfreeze(model.layer1[0], ['bn1'])
+    assert isinstance(model.layer1[0].bn1, BatchNorm2d)
+
+def test_activation_stats_hook_validation():
+    model = timm.create_model('resnet18')
+    
+    def test_hook(model, input, output):
+        return output.mean().item()
+    
+    # Test error case with mismatched lengths
+    with pytest.raises(ValueError, match="Please provide `hook_fns` for each `hook_fn_locs`"):
+        ActivationStatsHook(
+            model,
+            hook_fn_locs=['layer1.0.conv1', 'layer1.0.conv2'],
+            hook_fns=[test_hook]
+        )
+
+
+def test_extract_spp_stats():
+    model = timm.create_model('resnet18')
+    
+    def test_hook(model, input, output):
+        return output.mean().item()
+    
+    stats = extract_spp_stats(
+        model,
+        hook_fn_locs=['layer1.0.conv1'],
+        hook_fns=[test_hook],
+        input_shape=[2, 3, 32, 32]
+    )
+    
+    assert isinstance(stats, dict)
+    assert test_hook.__name__ in stats
+    assert isinstance(stats[test_hook.__name__], list)
+    assert len(stats[test_hook.__name__]) > 0
+
+def test_freeze_unfreeze_bn_root():
+    import torch.nn as nn
+    from timm.layers import BatchNormAct2d
+    
+    # Create batch norm layers
+    bn = nn.BatchNorm2d(10)
+    bn_act = BatchNormAct2d(10)
+    
+    # Test with BatchNorm2d as root
+    with pytest.raises(AssertionError):
+        _freeze_unfreeze(bn, mode="freeze")
+    
+    # Test with BatchNormAct2d as root
+    with pytest.raises(AssertionError):
+        _freeze_unfreeze(bn_act, mode="freeze")
+
+
+def test_activation_stats_functions():
+    import torch
+    
+    # Create sample input tensor [batch, channels, height, width]
+    x = torch.randn(2, 3, 4, 4)
+    
+    # Test avg_sq_ch_mean
+    result1 = avg_sq_ch_mean(None, None, x)
+    assert isinstance(result1, float)
+    
+    # Test avg_ch_var
+    result2 = avg_ch_var(None, None, x)
+    assert isinstance(result2, float)
+    
+    # Test avg_ch_var_residual
+    result3 = avg_ch_var_residual(None, None, x)
+    assert isinstance(result3, float)
+
+
+def test_reparameterize_model():
+    import torch.nn as nn
+    
+    class FusableModule(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(3, 3, 1)
+        
+        def fuse(self):
+            return nn.Identity()
+    
+    class ModelWithFusable(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fusable = FusableModule()
+            self.normal = nn.Linear(10, 10)
+    
+    model = ModelWithFusable()
+    
+    # Test with inplace=False (should create a copy)
+    new_model = reparameterize_model(model, inplace=False)
+    assert isinstance(new_model.fusable, nn.Identity)
+    assert isinstance(model.fusable, FusableModule)  # Original unchanged
+    
+    # Test with inplace=True
+    reparameterize_model(model, inplace=True)
+    assert isinstance(model.fusable, nn.Identity)
+
+
+def test_get_state_dict_custom_unwrap():
+    import torch.nn as nn
+    
+    class CustomModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(10, 10)
+    
+    model = CustomModel()
+    
+    def custom_unwrap(m):
+        return m
+    
+    state_dict = get_state_dict(model, unwrap_fn=custom_unwrap)
+    assert 'linear.weight' in state_dict
+    assert 'linear.bias' in state_dict
+
+
+def test_freeze_unfreeze_string_input():
+    model = timm.create_model('resnet18')
+    
+    # Test with string input
+    _freeze_unfreeze(model, 'layer1', mode='freeze')
+    assert model.layer1[0].conv1.weight.requires_grad == False
+    
+    # Test unfreezing with string input
+    _freeze_unfreeze(model, 'layer1', mode='unfreeze')
+    assert model.layer1[0].conv1.weight.requires_grad == True
 
 
 def _parse_model_kwargs(tokens):

--- a/timm/utils/misc.py
+++ b/timm/utils/misc.py
@@ -26,9 +26,9 @@ class ParseKwargs(argparse.Action):
         for value in values:
             if not value:
                 continue
-            key, value = value.split('=')
+            key, value = value.split('=', 1)
             try:
                 kw[key] = ast.literal_eval(value)
-            except ValueError:
+            except (ValueError, SyntaxError):
                 kw[key] = str(value)  # fallback to string (avoid need to escape on command line)
         setattr(namespace, self.dest, kw)


### PR DESCRIPTION
## What

`ParseKwargs` (used by `--model-kwargs` / `--opt-kwargs` in the train/validate scripts) crashes on some valid inputs:

```
$ python -c "import argparse; from timm.utils.misc import ParseKwargs; \
  p=argparse.ArgumentParser(); p.add_argument('--model-kwargs', nargs='*', default={}, action=ParseKwargs); \
  print(p.parse_args(['--model-kwargs','note=size=large']))"
ValueError: too many values to unpack (expected 2)
```

Two issues in the same spot:

1. `key, value = value.split('=')` splits on **every** `=`, so any value containing an `=` (e.g. `note=size=large`, or a URL with a query string) raises *too many values to unpack*.
2. The `literal_eval` fallback only catches `ValueError`. A value that isn't a valid Python literal but *is* invalid syntax (like `size=large`) raises `SyntaxError`, which isn't caught, so it crashes instead of falling back to a string.

## Fix

- Split on the first `=` only (`split('=', 1)`).
- Catch `SyntaxError` as well as `ValueError` in the string fallback.

Both are minimal and the only `key=value` parser in the tree (`grep` confirms `misc.py:29` is the sole `.split('=')`).

## After

```
note=size=large            -> {'note': 'size=large'}
url=http://h/p?a=1&b=2     -> {'url': 'http://h/p?a=1&b=2'}
depth=12 act=nn.GELU       -> {'depth': 12, 'act': 'nn.GELU'}
cfg={"a": 1}               -> {'cfg': {'a': 1}}
```

Existing literal parsing (ints, floats, bools, dicts) is unchanged.

## Tests

Added `tests/test_utils.py` covering literal values, a value containing `=`, and the non-literal string fallback. The `note=size=large` case fails on `main` (both bugs) and passes here.
