### PR TITLE
Preserve caller gradient mode in AsymmetricLossMultiLabel

### DIFF
--- a/timm/loss/asymmetric_loss.py
+++ b/timm/loss/asymmetric_loss.py
@@ -36,15 +36,12 @@ class AsymmetricLossMultiLabel(nn.Module):
 
         # Asymmetric Focusing
         if self.gamma_neg > 0 or self.gamma_pos > 0:
-            if self.disable_torch_grad_focal_loss:
-                torch.set_grad_enabled(False)
-            pt0 = xs_pos * y
-            pt1 = xs_neg * (1 - y)  # pt = p if t > 0 else 1-p
-            pt = pt0 + pt1
-            one_sided_gamma = self.gamma_pos * y + self.gamma_neg * (1 - y)
-            one_sided_w = torch.pow(1 - pt, one_sided_gamma)
-            if self.disable_torch_grad_focal_loss:
-                torch.set_grad_enabled(True)
+            with torch.set_grad_enabled(torch.is_grad_enabled() and not self.disable_torch_grad_focal_loss):
+                pt0 = xs_pos * y
+                pt1 = xs_neg * (1 - y)  # pt = p if t > 0 else 1-p
+                pt = pt0 + pt1
+                one_sided_gamma = self.gamma_pos * y + self.gamma_neg * (1 - y)
+                one_sided_w = torch.pow(1 - pt, one_sided_gamma)
             loss *= one_sided_w
 
         return -loss.sum()


### PR DESCRIPTION
## Summary

When `disable_torch_grad_focal_loss=True`, `AsymmetricLossMultiLabel` temporarily disables gradient tracking while computing the focal weights, but then always restores it with `torch.set_grad_enabled(True)`.

If the loss is called inside an outer `torch.no_grad()` context, this unintentionally enables gradient tracking.

## Fix

The manual gradient-mode toggling was replaced with a scoped `torch.set_grad_enabled(...)` context.

This preserves the caller’s original gradient mode while retaining the intended behavior of `disable_torch_grad_focal_loss`. The default behavior and computed loss values remain unchanged.

## Testing

I did not add a new test because the repository currently contains no dedicated tests for the loss modules. The change is therefore kept limited to the implementation, but I could add any relevant tests maintainers prefer it. 
