### PR TITLE
Fix metric-less CheckpointSaver history tracking

### DIFF
--- a/tests/test_checkpoint_saver.py
+++ b/tests/test_checkpoint_saver.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import torch
+
+from timm.utils.checkpoint_saver import CheckpointSaver
+
+
+def _create_saver(checkpoint_dir: Path, max_history: int = 2) -> CheckpointSaver:
+    model = torch.nn.Linear(2, 1)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    return CheckpointSaver(
+        model,
+        optimizer,
+        checkpoint_dir=str(checkpoint_dir),
+        max_history=max_history,
+    )
+
+
+def test_save_checkpoint_without_metric_retains_latest_history(tmp_path: Path):
+    saver = _create_saver(tmp_path)
+
+    for epoch in range(3):
+        assert saver.save_checkpoint(epoch) == (None, None)
+
+    assert [(Path(path).name, metric) for path, metric in saver.checkpoint_files] == [
+        ('checkpoint-2.pth.tar', None),
+        ('checkpoint-1.pth.tar', None),
+    ]
+    assert not (tmp_path / 'checkpoint-0.pth.tar').exists()
+    assert (tmp_path / 'checkpoint-1.pth.tar').exists()
+    assert (tmp_path / 'checkpoint-2.pth.tar').exists()
+
+
+def test_save_checkpoint_replaces_unranked_history_with_ranked(tmp_path: Path):
+    saver = _create_saver(tmp_path)
+
+    saver.save_checkpoint(0, metric=0.8)
+    saver.save_checkpoint(1)
+    assert saver.save_checkpoint(2, metric=0.9) == (0.9, 2)
+
+    assert [metric for _, metric in saver.checkpoint_files] == [0.9, 0.8]
+    assert not (tmp_path / 'checkpoint-1.pth.tar').exists()

--- a/tests/test_checkpoint_saver.py
+++ b/tests/test_checkpoint_saver.py
@@ -5,7 +5,7 @@ import torch
 from timm.utils.checkpoint_saver import CheckpointSaver
 
 
-def _create_saver(checkpoint_dir: Path, max_history: int = 2) -> CheckpointSaver:
+def _create_saver(checkpoint_dir: Path, max_history: int = 2, decreasing: bool = False) -> CheckpointSaver:
     model = torch.nn.Linear(2, 1)
     optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
     return CheckpointSaver(
@@ -13,6 +13,7 @@ def _create_saver(checkpoint_dir: Path, max_history: int = 2) -> CheckpointSaver
         optimizer,
         checkpoint_dir=str(checkpoint_dir),
         max_history=max_history,
+        decreasing=decreasing,
     )
 
 
@@ -40,3 +41,19 @@ def test_save_checkpoint_replaces_unranked_history_with_ranked(tmp_path: Path):
 
     assert [metric for _, metric in saver.checkpoint_files] == [0.9, 0.8]
     assert not (tmp_path / 'checkpoint-1.pth.tar').exists()
+
+
+def test_save_checkpoint_does_not_replace_ranked_history_with_unranked(tmp_path: Path):
+    for decreasing, ranked_metrics in ((False, (0.9, 0.8)), (True, (0.1, 0.2))):
+        checkpoint_dir = tmp_path / str(decreasing)
+        checkpoint_dir.mkdir()
+        saver = _create_saver(checkpoint_dir, decreasing=decreasing)
+
+        for epoch, metric in enumerate(ranked_metrics):
+            saver.save_checkpoint(epoch, metric=metric)
+
+        assert saver.save_checkpoint(2) == (ranked_metrics[0], 0)
+        assert [metric for _, metric in saver.checkpoint_files] == list(ranked_metrics)
+        assert (checkpoint_dir / 'checkpoint-0.pth.tar').exists()
+        assert (checkpoint_dir / 'checkpoint-1.pth.tar').exists()
+        assert not (checkpoint_dir / 'checkpoint-2.pth.tar').exists()

--- a/timm/utils/checkpoint_saver.py
+++ b/timm/utils/checkpoint_saver.py
@@ -134,6 +134,7 @@ class CheckpointSaver:
         if (
             len(self.checkpoint_files) < self.max_history
             or metric is None
+            or worst_file[1] is None
             or self.cmp(metric, worst_file[1])
         ):
             if len(self.checkpoint_files) >= self.max_history:
@@ -142,12 +143,16 @@ class CheckpointSaver:
             save_path = os.path.join(self.checkpoint_dir, filename)
             self._duplicate(last_save_path, save_path)
 
-            self.checkpoint_files.append((save_path, metric))
-            self.checkpoint_files = sorted(
-                self.checkpoint_files,
+            # Keep unranked checkpoints after ranked ones, newest first, so history trimming remains deterministic.
+            self.checkpoint_files.insert(0, (save_path, metric))
+            ranked_files = [checkpoint for checkpoint in self.checkpoint_files if checkpoint[1] is not None]
+            unranked_files = [checkpoint for checkpoint in self.checkpoint_files if checkpoint[1] is None]
+            ranked_files = sorted(
+                ranked_files,
                 key=lambda x: x[1],
                 reverse=not self.decreasing  # sort in descending order if a lower metric is not better
             )
+            self.checkpoint_files = ranked_files + unranked_files
 
             checkpoints_str = "Current checkpoints:\n"
             for c in self.checkpoint_files:

--- a/timm/utils/checkpoint_saver.py
+++ b/timm/utils/checkpoint_saver.py
@@ -133,9 +133,8 @@ class CheckpointSaver:
         worst_file = self.checkpoint_files[-1] if self.checkpoint_files else None
         if (
             len(self.checkpoint_files) < self.max_history
-            or metric is None
             or worst_file[1] is None
-            or self.cmp(metric, worst_file[1])
+            or (metric is not None and self.cmp(metric, worst_file[1]))
         ):
             if len(self.checkpoint_files) >= self.max_history:
                 self._cleanup_checkpoints(1)


### PR DESCRIPTION
## Summary

- allow `CheckpointSaver` to retain repeated checkpoints when `metric` is omitted
- keep ranked checkpoints ordered by metric and unranked checkpoints ordered by recency
- replace an unranked history entry when a later ranked checkpoint arrives
- preserve a full ranked history when a later checkpoint has no metric

## Problem

`save_checkpoint` accepts `metric=None`, but the second metric-less save raises `TypeError` while sorting two `None` values. This also leaves mixed ranked and unranked histories unable to compare a later numeric metric with the trailing `None` entry.

The updated history ordering keeps ranked entries first and treats unranked entries as lower priority. Stable insertion at the front of the unranked group preserves the newest metric-less checkpoints when history is trimmed. A metric-less checkpoint enters a full history only when it can replace another unranked entry, so it cannot evict a ranked checkpoint.

## Validation

- Pristine `main` at `a6940450` reproduces `TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'` on the second metric-less save.
- The full-ranked-history regression fails on the previous PR head because an unranked save replaces the worst ranked checkpoint.
- `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; py -3.13 -m pytest tests/test_checkpoint_saver.py -q` (3 passed)
- `py -3.13 -m py_compile timm/utils/checkpoint_saver.py tests/test_checkpoint_saver.py` (passed)
- `git diff --check origin/main...HEAD` (passed)

AI assistance disclosure: AI-assisted development tools were used during investigation and implementation. The reported tests were run against the final diff.
