### PR TITLE
Add Sapiens2 (Meta human-centric ViT) to Eva: GQA, attn-only LayerScale, 5 model defs

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -77,14 +77,15 @@ if 'GITHUB_ACTIONS' in os.environ:
         '*efficientnet_l2*', '*resnext101_32x48d', '*in21k', '*152x4_bitm', '*101x3_bitm', '*50x3_bitm',
         '*nfnet_f3*', '*nfnet_f4*', '*nfnet_f5*', '*nfnet_f6*', '*nfnet_f7*', '*efficientnetv2_xl*',
         '*resnetrs350*', '*resnetrs420*', 'xcit_large_24_p8*', '*huge*', '*giant*', '*gigantic*',
-        '*enormous*', 'maxvit_xlarge*', 'regnet*1280', 'regnet*2560', '*_1b_*', '*_3b_*', '*_7b_*']
-    NON_STD_EXCLUDE_FILTERS = ['*huge*', '*giant*',  '*gigantic*', '*enormous*', '*_1b_*', '*_3b_*', '*_7b_*']
+        '*enormous*', 'maxvit_xlarge*', 'regnet*1280', 'regnet*2560', '*_1b_*', '*_3b_*', '*_5b_*', '*_7b_*']
+    NON_STD_EXCLUDE_FILTERS = [
+        '*huge*', '*giant*',  '*gigantic*', '*enormous*', '*_1b_*', '*_3b_*', '*_5b_*', '*_7b_*']
 else:
-    EXCLUDE_FILTERS = ['*enormous*', '*_7b_*']
-    NON_STD_EXCLUDE_FILTERS = ['*gigantic*', '*enormous*', '*_3b_*', '*_7b_*']
+    EXCLUDE_FILTERS = ['*enormous*', '*_5b_*', '*_7b_*']
+    NON_STD_EXCLUDE_FILTERS = ['*gigantic*', '*enormous*', '*_3b_*', '*_5b_*', '*_7b_*']
 
 EXCLUDE_JIT_FILTERS = [
-    'hiera_*', '*naflex*', '*_7b_*', 'hrnet*', 'dpn*', 'densenet*', 'selecsls*',
+    'hiera_*', '*naflex*', '*_5b_*', '*_7b_*', 'hrnet*', 'dpn*', 'densenet*', 'selecsls*',
     # gemma4_vit shares NaFlex's ``Union[Tensor, Dict[str, Tensor]]`` forward signature,
     # which TorchScript cannot narrow (``Unknown type name 'dict'``).
     'gemma4_vit*',

--- a/timm/layers/attention.py
+++ b/timm/layers/attention.py
@@ -152,6 +152,7 @@ class AttentionRope(nn.Module):
      * QK normalization option
      * Attention output (scale) normalization
      * Fused or unfused QKV projection support
+     * Grouped-query attention (fewer K/V heads than Q heads) via `num_kv_heads`
     """
     fused_attn: torch.jit.Final[bool]
 
@@ -172,6 +173,7 @@ class AttentionRope(nn.Module):
             proj_bias: bool = True,
             rotate_half: bool = False,
             gated: bool = False,
+            num_kv_heads: Optional[int] = None,
             device=None,
             dtype=None,
     ):
@@ -193,6 +195,9 @@ class AttentionRope(nn.Module):
             scale_norm: Enable normalization (scaling) of attention output with norm_layer
             proj_bias: Whether to use bias in the output projection
             rotate_half: Use 'half' ROPE layout instead of default 'interleaved'
+            gated: Add a sigmoid gate on the attention output (before projection)
+            num_kv_heads: Number of key/value heads for grouped-query attention. None or equal to
+                num_heads gives standard multi-head attention. Requires qkv_fused=False.
         """
         super().__init__()
         dd = {'device': device, 'dtype': dtype}
@@ -203,23 +208,29 @@ class AttentionRope(nn.Module):
             head_dim = dim // num_heads
         if scale_norm or qk_norm:
             assert norm_layer is not None, 'norm_layer must be provided if qk_norm or scale_norm is True'
+        num_kv_heads = num_kv_heads or num_heads
+        assert num_heads % num_kv_heads == 0, 'num_heads must be divisible by num_kv_heads'
 
         self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.num_kv_groups = num_heads // num_kv_heads
         self.head_dim = head_dim
         self.attn_dim = head_dim * num_heads
+        self.kv_dim = head_dim * num_kv_heads
         self.scale = head_dim ** -0.5
         self.num_prefix_tokens = num_prefix_tokens
         self.fused_attn = use_fused_attn()
         self.rotate_half = rotate_half
 
         if qkv_fused:
+            assert self.num_kv_groups == 1, 'fused qkv projection does not support grouped-query attention'
             self.qkv = nn.Linear(dim, self.attn_dim * 3, bias=qkv_bias, **dd)
             self.q_proj = self.k_proj = self.v_proj = None
         else:
             self.qkv = None
             self.q_proj = nn.Linear(dim, self.attn_dim, bias=qkv_bias, **dd)
-            self.k_proj = nn.Linear(dim, self.attn_dim, bias=qkv_bias, **dd)
-            self.v_proj = nn.Linear(dim, self.attn_dim, bias=qkv_bias, **dd)
+            self.k_proj = nn.Linear(dim, self.kv_dim, bias=qkv_bias, **dd)
+            self.v_proj = nn.Linear(dim, self.kv_dim, bias=qkv_bias, **dd)
 
         self.q_norm = norm_layer(head_dim, **dd) if qk_norm else nn.Identity()
         self.k_norm = norm_layer(head_dim, **dd) if qk_norm else nn.Identity()
@@ -256,8 +267,8 @@ class AttentionRope(nn.Module):
             q, k, v = qkv.unbind(0)  # B, num_heads, N, head_dim
         else:
             q = self.q_proj(x).reshape(B, N, self.num_heads, self.head_dim).transpose(1, 2)
-            k = self.k_proj(x).reshape(B, N, self.num_heads, self.head_dim).transpose(1, 2)
-            v = self.v_proj(x).reshape(B, N, self.num_heads, self.head_dim).transpose(1, 2)
+            k = self.k_proj(x).reshape(B, N, self.num_kv_heads, self.head_dim).transpose(1, 2)
+            v = self.v_proj(x).reshape(B, N, self.num_kv_heads, self.head_dim).transpose(1, 2)
 
         q, k = self.q_norm(q), self.k_norm(k)
 
@@ -266,6 +277,13 @@ class AttentionRope(nn.Module):
             half = getattr(self, 'rotate_half', False)
             q = torch.cat([q[:, :, :npt, :], apply_rot_embed_cat(q[:, :, npt:, :], rope, half=half)], dim=2).type_as(v)
             k = torch.cat([k[:, :, :npt, :], apply_rot_embed_cat(k[:, :, npt:, :], rope, half=half)], dim=2).type_as(v)
+
+        if self.num_kv_groups > 1:
+            # Expand K/V heads to match Q heads for grouped-query attention. Done after norm + rope so the
+            # (cheaper) per-kv-head ops run once. repeat_interleave keeps the group -> head mapping identical
+            # to reference impls that tile kv heads (head h uses kv head h // num_kv_groups).
+            k = k.repeat_interleave(self.num_kv_groups, dim=1)
+            v = v.repeat_interleave(self.num_kv_groups, dim=1)
 
         if self.fused_attn:
             x = F.scaled_dot_product_attention(

--- a/timm/models/eva.py
+++ b/timm/models/eva.py
@@ -9,6 +9,7 @@ This file contains a number of ViT variants the utilise ROPE position embeddings
  * ROPE-ViT from Naver AI (https://arxiv.org/abs/2403.13298)
  * DINOv3 from META AI Research (https://arxiv.org/abs/2508.10104)
  * LingBot-Vision from Robbyant (https://arxiv.org/abs/2607.05247)
+ * Sapiens2 human-centric ViT from Meta (https://arxiv.org/abs/2604.21681)
 
 @article{EVA,
   title={EVA: Exploring the Limits of Masked Visual Representation Learning at Scale},
@@ -64,9 +65,19 @@ EVA-02: A Visual Representation for Neon Genesis - https://arxiv.org/abs/2303.11
   year={2026}
 }
 
+@article{khirodkarsapiens2,
+  title={Sapiens2},
+  author={Khirodkar, Rawal and Wen, He and Martinez, Julieta and Dong, Yuan and Su, Zhaoen and Saito, Shunsuke},
+  journal={arXiv preprint arXiv:2604.21681},
+  year={2026}
+}
+
 DINOv3 code was a modification of existing EVA model and support modules, so licensed under Apache-2.0 like timm.
 Weights from META remain under DINOv3 License (https://ai.meta.com/resources/models-and-libraries/dinov3-license/).
 LingBot-Vision code and weights are released under Apache-2.0 (https://github.com/robbyant/lingbot-vision).
+Sapiens2 support was likewise built on the existing EVA / DINOv3 modules (GQA + attn-only LayerScale added), no code
+was taken from the Meta release, so it is Apache-2.0 like timm. Weights from META remain under the Sapiens2 License
+(https://github.com/facebookresearch/sapiens2/blob/main/LICENSE.md).
 
 Modifications by / Copyright 2023 Ross Wightman, original copyrights below
 """
@@ -89,6 +100,7 @@ from timm.layers import (
     GluMlp,
     SwiGLU,
     LayerNorm,
+    RmsNorm,
     DropPath, calculate_drop_path_rates,
     PatchDropoutWithIndices,
     create_rope_embed,
@@ -299,10 +311,13 @@ class EvaBlock(nn.Module):
             attn_type: str = 'eva',
             rotate_half: bool = False,
             gated_attn: bool = False,
+            qk_norm: bool = False,
+            num_kv_heads: Optional[int] = None,
             proj_drop: float = 0.,
             attn_drop: float = 0.,
             drop_path: float = 0.,
             init_values: Optional[float] = None,
+            mlp_layer_scale: bool = True,
             act_layer: Callable = nn.GELU,
             norm_layer: Callable = LayerNorm,
             attn_head_dim: Optional[int] = None,
@@ -323,10 +338,14 @@ class EvaBlock(nn.Module):
             scale_attn_inner: Whether to use normalization within the attention mechanism
             num_prefix_tokens: Number of tokens at the beginning of the sequence (class tokens, etc.)
             attn_type: Type of attention module to use ('eva' or 'rope')
+            qk_norm: Apply norm_layer to query and key (per head) before attention
+            num_kv_heads: Number of key/value heads for grouped-query attention (attn_type='rope' only),
+                None = same as num_heads
             proj_drop: Dropout rate for projection layers
             attn_drop: Dropout rate for attention matrix
             drop_path: Stochastic depth rate
             init_values: Initial value for LayerScale, None = no LayerScale
+            mlp_layer_scale: Apply LayerScale to the MLP branch too (False = attention branch only)
             act_layer: Activation layer constructor
             norm_layer: Normalization layer constructor
             attn_head_dim: Dimension of each attention head (if None, computed as dim // num_heads)
@@ -335,7 +354,14 @@ class EvaBlock(nn.Module):
         super().__init__()
 
         self.norm1 = norm_layer(dim, **dd)
-        attn_cls = AttentionRope if attn_type == 'rope' else EvaAttention
+        attn_kwargs = {}
+        if attn_type == 'rope':
+            attn_cls = AttentionRope
+            attn_kwargs['num_kv_heads'] = num_kv_heads
+        else:
+            assert num_kv_heads is None or num_kv_heads == num_heads, \
+                'grouped-query attention (num_kv_heads) is only supported with attn_type="rope"'
+            attn_cls = EvaAttention
         self.attn = attn_cls(
             dim,
             num_heads=num_heads,
@@ -346,9 +372,11 @@ class EvaBlock(nn.Module):
             proj_drop=proj_drop,
             attn_head_dim=attn_head_dim,
             norm_layer=norm_layer,
+            qk_norm=qk_norm,
             scale_norm=scale_attn_inner,
             rotate_half=rotate_half,
             gated=gated_attn,
+            **attn_kwargs,
             **dd,
         )
         self.init_values = init_values
@@ -388,7 +416,8 @@ class EvaBlock(nn.Module):
                 drop=proj_drop,
                 **dd,
             )
-        self.gamma_2 = nn.Parameter(torch.empty(dim, **dd)) if init_values is not None else None
+        use_mlp_ls = init_values is not None and mlp_layer_scale
+        self.gamma_2 = nn.Parameter(torch.empty(dim, **dd)) if use_mlp_ls else None
         self.drop_path2 = DropPath(drop_path) if drop_path > 0. else nn.Identity()
 
         # TODO: skip init when on meta device when safe to do so
@@ -398,6 +427,7 @@ class EvaBlock(nn.Module):
         """Initialize parameters."""
         if self.gamma_1 is not None:
             nn.init.constant_(self.gamma_1, self.init_values)
+        if self.gamma_2 is not None:
             nn.init.constant_(self.gamma_2, self.init_values)
 
     def forward(
@@ -407,12 +437,14 @@ class EvaBlock(nn.Module):
             attn_mask: Optional[torch.Tensor] = None,
             is_causal: bool = False,
     ) -> torch.Tensor:
-        if self.gamma_1 is None:
-            x = x + self.drop_path1(self.attn(self.norm1(x), rope=rope, attn_mask=attn_mask, is_causal=is_causal))
-            x = x + self.drop_path2(self.mlp(self.norm2(x)))
-        else:
-            x = x + self.drop_path1(self.gamma_1 * self.attn(self.norm1(x), rope=rope, attn_mask=attn_mask, is_causal=is_causal))
-            x = x + self.drop_path2(self.gamma_2 * self.mlp(self.norm2(x)))
+        x_attn = self.attn(self.norm1(x), rope=rope, attn_mask=attn_mask, is_causal=is_causal)
+        if self.gamma_1 is not None:
+            x_attn = self.gamma_1 * x_attn
+        x = x + self.drop_path1(x_attn)
+        x_mlp = self.mlp(self.norm2(x))
+        if self.gamma_2 is not None:
+            x_mlp = self.gamma_2 * x_mlp
+        x = x + self.drop_path2(x_mlp)
         return x
 
 
@@ -552,8 +584,10 @@ class Eva(nn.Module):
             embed_dim: int = 768,
             depth: int = 12,
             num_heads: int = 12,
+            num_kv_heads: Optional[Union[int, Tuple[int, ...]]] = None,
             qkv_bias: bool = True,
             qkv_fused: bool = True,
+            qk_norm: bool = False,
             mlp_ratio: float = 4.,
             swiglu_mlp: bool = False,
             swiglu_align_to: int = 0,
@@ -568,6 +602,7 @@ class Eva(nn.Module):
             drop_path_rate: float = 0.,
             norm_layer: Callable = LayerNorm,
             init_values: Optional[float] = None,
+            mlp_layer_scale: bool = True,
             class_token: bool = True,
             num_reg_tokens: int = 0,
             no_embed_class: bool = False,
@@ -578,6 +613,9 @@ class Eva(nn.Module):
             rope_grid_indexing: str = 'ij',
             rope_temperature: float = 10000.,
             rope_rotate_half: bool = False,
+            rope_shift_coords: Optional[float] = None,
+            rope_jitter_coords: Optional[float] = None,
+            rope_rescale_coords: Optional[float] = None,
             use_post_norm: bool = False,
             use_pre_transformer_norm: bool = False,
             use_post_transformer_norm: Optional[bool] = None,
@@ -602,8 +640,11 @@ class Eva(nn.Module):
             embed_dim: Embedding dimension for tokens
             depth: Number of transformer blocks
             num_heads: Number of attention heads
+            num_kv_heads: Number of key/value heads for grouped-query attention (requires attn_type='rope' and
+                qkv_fused=False). An int applies to all blocks, a sequence gives a per-block value. None = num_heads.
             qkv_bias: Enable bias for query, key, value projections
             qkv_fused: Use a single projection for query, key, value
+            qk_norm: Apply norm_layer to query and key (per head) before attention
             mlp_ratio: Ratio of mlp hidden dim to embedding dim
             swiglu_mlp: Use SwiGLU activation in MLP
             scale_mlp: Apply scaling normalization in MLP (normformer style)
@@ -617,6 +658,7 @@ class Eva(nn.Module):
             drop_path_rate: Stochastic depth rate
             norm_layer: Normalization layer constructor
             init_values: Initial layer-scale values
+            mlp_layer_scale: Apply layer-scale to the MLP branch too (False = attention branch only)
             class_token: Use class token
             num_reg_tokens: Number of additional learnable 'register' tokens to add to the sequence
             no_embed_class: Don't include position embeddings for class (or reg) tokens
@@ -627,6 +669,9 @@ class Eva(nn.Module):
             rope_grid_indexing: Indexing mode for rotary position embeddings ('ij' or 'xy')
             rope_temperature: Temperature parameter for ROPE frequency computation
             rope_rotate_half: Use half rotation layout (rotate D/2 dims), else use interleaved rotation layout
+            rope_shift_coords: Train-time RoPE coordinate shift augmentation, uniform in [-s, s] (rope_type='dinov3')
+            rope_jitter_coords: Train-time RoPE per-axis log-uniform scale augmentation in [1/J, J] (rope_type='dinov3')
+            rope_rescale_coords: Train-time RoPE shared log-uniform scale augmentation in [1/R, R] (rope_type='dinov3')
             use_post_norm: Use post-norm transformer block type
             use_pre_transformer_norm: Use normalization layer before transformer blocks
             use_post_transformer_norm: Use normalization layer after transformer blocks
@@ -712,6 +757,13 @@ class Eva(nn.Module):
                     grid_offset=rope_grid_offset,
                     ref_feat_shape=ref_feat_shape,
                 ))
+            elif rope_type == 'dinov3':
+                rope_kwargs.update(dict(
+                    grid_offset=rope_grid_offset,
+                    shift_coords=rope_shift_coords,
+                    jitter_coords=rope_jitter_coords,
+                    rescale_coords=rope_rescale_coords,
+                ))
 
             self.rope = create_rope_embed(rope_type=rope_type, **rope_kwargs)
         else:
@@ -719,8 +771,23 @@ class Eva(nn.Module):
 
         self.norm_pre = norm_layer(embed_dim, **dd) if activate_pre_norm else nn.Identity()
 
+        # per-block kv heads (grouped-query attention), None -> standard MHA in every block
+        if num_kv_heads is None or isinstance(num_kv_heads, int):
+            num_kv_heads = (num_kv_heads,) * depth
+        assert len(num_kv_heads) == depth, 'num_kv_heads sequence must have one entry per block'
+
         dpr = calculate_drop_path_rates(drop_path_rate, depth)  # stochastic depth decay rule
         block_fn = EvaBlockPostNorm if use_post_norm else EvaBlock
+        if use_post_norm:
+            # these options are only implemented for the pre-norm block, fail loudly instead of ignoring them
+            assert not qk_norm and mlp_layer_scale and all(h is None for h in num_kv_heads), \
+                'qk_norm, num_kv_heads and mlp_layer_scale=False are not supported with use_post_norm'
+
+        def _block_kwargs(i: int) -> Dict[str, Any]:
+            if use_post_norm:
+                return {}
+            return dict(qk_norm=qk_norm, mlp_layer_scale=mlp_layer_scale, num_kv_heads=num_kv_heads[i])
+
         self.blocks = nn.ModuleList([
             block_fn(
                 dim=embed_dim,
@@ -740,6 +807,7 @@ class Eva(nn.Module):
                 drop_path=dpr[i],
                 norm_layer=norm_layer,
                 init_values=init_values,
+                **_block_kwargs(i),
                 **dd,
             )
             for i in range(depth)])
@@ -1216,7 +1284,9 @@ def checkpoint_filter_fn(
     else:
         prefix = ''
 
-    dinov3_weights = 'storage_tokens' in state_dict
+    # Sapiens2 (Meta) checkpoints share the DINOv3 register naming but use their own attn / ffn / norm names
+    sapiens2_weights = 'blocks.0.attn.wq.weight' in state_dict and 'blocks.0.ffn.w12.weight' in state_dict
+    dinov3_weights = 'storage_tokens' in state_dict and not sapiens2_weights
     mim_weights = not dinov3_weights and prefix + 'mask_token' in state_dict
     no_qkv = prefix + 'blocks.0.attn.q_proj.weight' in state_dict
 
@@ -1231,7 +1301,23 @@ def checkpoint_filter_fn(
             # fixed embedding no need to load buffer from checkpoint
             continue
 
-        if dinov3_weights:
+        if sapiens2_weights:
+            if k == 'mask_token':
+                # pretrain only
+                continue
+            k = k.replace('storage_tokens', 'reg_token')
+            k = k.replace('patch_embed.projection.', 'patch_embed.proj.')
+            k = k.replace('attn.wq.', 'attn.q_proj.')
+            k = k.replace('attn.wk.', 'attn.k_proj.')
+            k = k.replace('attn.wv.', 'attn.v_proj.')
+            k = k.replace('attn.gamma.weight', 'gamma_1')  # LayerScale lives inside attn in the original, attn only
+            k = k.replace('.ffn.', '.mlp.')  # w12 / w3 remapped to fc1 / fc2 below
+            k = k.replace('.ln1.', '.norm1.')
+            k = k.replace('.ln2.', '.norm2.')
+            if k.startswith('ln1.'):
+                k = 'norm.' + k[len('ln1.'):]  # final norm
+
+        elif dinov3_weights:
             if any([k.endswith(f) for f in ['.periods', '.bias_mask', 'mask_token']]):
                 # discard unused/non-persistent/pretrain only params
                 continue
@@ -1433,6 +1519,33 @@ def _lingbot_cfg(url: str = '', **kwargs) -> Dict[str, Any]:
         'license': 'apache-2.0', 'origin_url': 'https://github.com/robbyant/lingbot-vision',
         'paper_ids': 'arXiv:2607.05247', **kwargs
     }
+
+
+def _sapiens2_cfg(url: str = '', **kwargs) -> Dict[str, Any]:
+    """Generate default configuration for Sapiens2 models.
+
+    Sapiens2 is trained at a portrait 1024x768 (HxW) resolution with ImageNet mean/std and bilinear resize
+    (no center crop). The original uses CLS-token pooling; timm defaults to avg pooling for the Eva
+    architecture, pass global_pool='token' at model creation to match upstream.
+
+    Args:
+        url: Model weights URL.
+        **kwargs: Additional configuration parameters.
+
+    Returns:
+        Model configuration dictionary.
+    """
+    return {
+        'url': url,
+        'num_classes': 0, 'input_size': (3, 1024, 768), 'pool_size': None,
+        'crop_pct': 1.0, 'crop_mode': 'squash', 'interpolation': 'bilinear', 'fixed_input_size': False,
+        'min_input_size': (3, 256, 192),
+        'mean': IMAGENET_DEFAULT_MEAN, 'std': IMAGENET_DEFAULT_STD,
+        'first_conv': 'patch_embed.proj', 'classifier': 'head',
+        'license': 'sapiens2-license', 'origin_url': 'https://github.com/facebookresearch/sapiens2',
+        'paper_ids': 'arXiv:2604.21681', **kwargs
+    }
+
 
 default_cfgs = generate_default_cfgs({
 
@@ -1858,6 +1971,31 @@ default_cfgs = generate_default_cfgs({
     ),
     'vit_giant_patch16_lingbot.robbyant': _lingbot_cfg(
         hf_hub_id='belfner/vit_giant_patch16_lingbot.robbyant',
+    ),
+
+    # Sapiens2 weights are under the Sapiens2 License (use restrictions, same-license redistribution), please see
+    # https://github.com/facebookresearch/sapiens2/blob/main/LICENSE.md
+    # Loaded straight from the original Meta checkpoints (`model.safetensors` there is the original layout,
+    # remapped by checkpoint_filter_fn), so nothing is redistributed by timm.
+    'vit_base_patch16_sapiens2.fb': _sapiens2_cfg(
+        hf_hub_id='facebook/sapiens2-pretrain-0.1b',
+        hf_hub_filename='model.safetensors',
+    ),
+    'vit_large_patch16_sapiens2.fb': _sapiens2_cfg(
+        hf_hub_id='facebook/sapiens2-pretrain-0.4b',
+        hf_hub_filename='model.safetensors',
+    ),
+    'vit_huge_patch16_sapiens2.fb': _sapiens2_cfg(
+        hf_hub_id='facebook/sapiens2-pretrain-0.8b',
+        hf_hub_filename='model.safetensors',
+    ),
+    'vit_giant_patch16_sapiens2.fb': _sapiens2_cfg(
+        hf_hub_id='facebook/sapiens2-pretrain-1b',
+        hf_hub_filename='model.safetensors',
+    ),
+    'vit_5b_patch16_sapiens2.fb': _sapiens2_cfg(
+        hf_hub_id='facebook/sapiens2-pretrain-5b',
+        hf_hub_filename='model.safetensors',
     ),
 
 })
@@ -3260,4 +3398,106 @@ def vit_giant_patch16_lingbot(pretrained: bool = False, **kwargs) -> Eva:
     )
 
     model = _create_eva('vit_giant_patch16_lingbot', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
+
+
+def _sapiens2_args(
+        embed_dim: int,
+        depth: int,
+        num_heads: int,
+        num_kv_heads: int,
+        num_full_attn_blocks: int = 8,
+) -> Dict[str, Any]:
+    """Shared Sapiens2 model args.
+
+    Sapiens2 uses grouped-query attention in the middle of the network only: the first and last
+    `num_full_attn_blocks` blocks keep full multi-head attention, everything in between uses `num_kv_heads`
+    key/value heads. Models with depth <= 2 * num_full_attn_blocks (0.1B) end up with no GQA blocks at all.
+
+    NOTE: the RoPE sin/cos tables are computed in float32 here (as in the transformers port). The Meta reference
+    code defaults to computing them in bfloat16; that quantizes the patch coordinates and shifts outputs by
+    ~1e-3 mean abs (0.4B, 1024x768) relative to the float32 tables. Results measured against the fp32-RoPE
+    reference agree to fp32 kernel noise (~1e-6 max abs).
+    """
+    kv_heads = tuple(
+        num_heads if (i < num_full_attn_blocks or i >= depth - num_full_attn_blocks) else num_kv_heads
+        for i in range(depth)
+    )
+    return dict(
+        img_size=(1024, 768),
+        patch_size=16,
+        dynamic_img_size=True,
+        embed_dim=embed_dim,
+        depth=depth,
+        num_heads=num_heads,
+        num_kv_heads=kv_heads,
+        attn_type='rope',
+        qkv_fused=False,
+        qkv_bias=True,  # q, k and v all carry a bias in Sapiens2 (unlike EVA's zero k-bias)
+        qk_norm=True,
+        # global_pool='token',  # upstream pools the CLS token; default here is 'avg', pass via kwargs or --gp
+        swiglu_mlp=True,
+        mlp_ratio=4.,
+        init_values=1.0,  # layer-scale on the attention branch only
+        mlp_layer_scale=False,
+        rope_type='dinov3',
+        rope_temperature=100,
+        rope_rotate_half=True,
+        rope_rescale_coords=2.0,  # train-time coordinate aug used upstream, no effect at eval
+        use_rot_pos_emb=True,
+        use_abs_pos_emb=False,
+        class_token=True,
+        num_reg_tokens=8,
+        use_fc_norm=False,
+        norm_layer=partial(RmsNorm, eps=1e-6),
+    )
+
+
+@register_model
+def vit_base_patch16_sapiens2(pretrained: bool = False, **kwargs) -> Eva:
+    """Sapiens2-0.1B (B/16) https://arxiv.org/abs/2604.21681
+    NOTE: Pass global_pool='token' to use CLS-token pooling (matches upstream Sapiens2).
+    """
+    model_args = _sapiens2_args(embed_dim=768, depth=12, num_heads=12, num_kv_heads=6)
+    model = _create_eva('vit_base_patch16_sapiens2', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
+
+
+@register_model
+def vit_large_patch16_sapiens2(pretrained: bool = False, **kwargs) -> Eva:
+    """Sapiens2-0.4B (L/16) https://arxiv.org/abs/2604.21681
+    NOTE: Pass global_pool='token' to use CLS-token pooling (matches upstream Sapiens2).
+    """
+    model_args = _sapiens2_args(embed_dim=1024, depth=24, num_heads=16, num_kv_heads=8)
+    model = _create_eva('vit_large_patch16_sapiens2', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
+
+
+@register_model
+def vit_huge_patch16_sapiens2(pretrained: bool = False, **kwargs) -> Eva:
+    """Sapiens2-0.8B (H/16) https://arxiv.org/abs/2604.21681
+    NOTE: Pass global_pool='token' to use CLS-token pooling (matches upstream Sapiens2).
+    """
+    model_args = _sapiens2_args(embed_dim=1280, depth=32, num_heads=16, num_kv_heads=8)
+    model = _create_eva('vit_huge_patch16_sapiens2', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
+
+
+@register_model
+def vit_giant_patch16_sapiens2(pretrained: bool = False, **kwargs) -> Eva:
+    """Sapiens2-1B (g/16, 1536 wide x 40 deep like ViT-g) https://arxiv.org/abs/2604.21681
+    NOTE: Pass global_pool='token' to use CLS-token pooling (matches upstream Sapiens2).
+    """
+    model_args = _sapiens2_args(embed_dim=1536, depth=40, num_heads=24, num_kv_heads=12)
+    model = _create_eva('vit_giant_patch16_sapiens2', pretrained=pretrained, **dict(model_args, **kwargs))
+    return model
+
+
+@register_model
+def vit_5b_patch16_sapiens2(pretrained: bool = False, **kwargs) -> Eva:
+    """Sapiens2-5B (2432 wide x 56 deep) https://arxiv.org/abs/2604.21681
+    NOTE: Pass global_pool='token' to use CLS-token pooling (matches upstream Sapiens2).
+    """
+    model_args = _sapiens2_args(embed_dim=2432, depth=56, num_heads=32, num_kv_heads=16)
+    model = _create_eva('vit_5b_patch16_sapiens2', pretrained=pretrained, **dict(model_args, **kwargs))
     return model


### PR DESCRIPTION
Closes #2762 (see also #2597).

Adds Meta's **Sapiens2** human-centric ViT backbones (https://github.com/facebookresearch/sapiens2, arXiv:2604.21681) on top of the existing `Eva` / DINOv3 code path, plus the two small building blocks they need.

## What's added

**`timm/layers/attention.py`**
- `AttentionRope`: new `num_kv_heads` option for grouped-query attention (unfused Q/K/V only). K/V are expanded with `repeat_interleave` after QK-norm + RoPE so the per-kv-head work is done once; the head -> kv-head mapping (`h // groups`) matches the reference implementations.

**`timm/models/eva.py`**
- `EvaBlock`: pass-through `qk_norm`, `num_kv_heads` (rope attention only), and `mlp_layer_scale=False` to put LayerScale on the attention branch only (Sapiens2 has `gamma` inside attn and none on the FFN). `gamma_1` / `gamma_2` handling refactored so either can be `None`; existing models are unaffected (verified below).
- `Eva`: `num_kv_heads` (int or per-block sequence), `qk_norm`, `mlp_layer_scale`, and the DINOv3 RoPE coordinate augs (`rope_shift_coords` / `rope_jitter_coords` / `rope_rescale_coords`) that were previously noted as "haven't added to interface". Options are asserted off for the post-norm block, which doesn't implement them.
- `checkpoint_filter_fn`: remap of the original Meta checkpoint layout (`blocks.N.attn.wq/wk/wv`, `attn.gamma.weight` -> `gamma_1`, `ffn.w12/w3` -> packed `GluMlp` `fc1/fc2`, `ln1/ln2` -> `norm1/norm2`, top-level `ln1` -> `norm`, `storage_tokens` -> `reg_token`, `patch_embed.projection` -> `patch_embed.proj`, `rope_embed.periods` dropped). Detection is by key names so DINOv3 checkpoints (which share `storage_tokens`) still take the DINOv3 branch (verified below).
- `_sapiens2_cfg` + 5 model entrypoints:

| timm name | Sapiens2 | params | embed / depth / heads | KV heads in blocks 8..depth-9 |
|---|---|---|---|---|
| `vit_base_patch16_sapiens2` | 0.1B | 114.0M | 768 / 12 / 12 | (no GQA blocks) |
| `vit_large_patch16_sapiens2` | 0.4B | 395.5M | 1024 / 24 / 16 | 8 |
| `vit_huge_patch16_sapiens2` | 0.8B | 814.3M | 1280 / 32 / 16 | 8 |
| `vit_giant_patch16_sapiens2` | 1B | 1455.5M | 1536 / 40 / 24 | 12 |
| `vit_5b_patch16_sapiens2` | 5B | 5066.9M | 2432 / 56 / 32 | 16 |

  Shared config: patch16, native 1024x768 (`dynamic_img_size=True`, `min_input_size` 256x192 for tests), cls + 8 register tokens, no abs pos embed, `rope_type='dinov3'` (theta 100, half layout, `rescale_coords=2.0` train aug), RMSNorm eps 1e-6 incl. QK-norm, unfused QKV with bias on all three, packed SwiGLU (ratio 4), LayerScale init 1.0 on attention only, final RMSNorm. Pooling defaults to `avg` like the other Eva models; pass `global_pool='token'` to match upstream CLS pooling (noted in the docstrings, same as the DINOv3 entrypoints).

**`tests/test_models.py`**: `*_5b_*` added to the large-model exclude lists alongside `*_7b_*`.

The hierarchical 4K variant (`use_tokenizer=True`) is not included.

## License

Implementation is built from the existing `timm` modules with no code taken from the Meta release, so it stays Apache-2.0 (same approach as DINOv3, documented in the module docstring). Pretrained cfgs carry `license='sapiens2-license'` and load directly from the original `facebook/sapiens2-pretrain-{0.1b,0.4b,0.8b,1b,5b}` repos via `hf_hub_filename='model.safetensors'` (that file is the original Meta layout; transformers remaps it on load the same way), so timm redistributes nothing and `pretrained=True` works as-is. Happy to switch the cfgs to `hf_hub_id='timm/'` if you'd rather re-host like DINOv3.

## Verification

**Sapiens2 numerics** — timm vs. two references on the released weights, random inputs, batch 2. `max_abs` / `mean_abs` over all normalized output tokens (`forward_features` vs. reference last hidden state incl. final norm), cosine similarity 1.000000000 in every fp32 row:

| model | case | timm vs transformers | timm vs Meta (fp32 RoPE) | transformers vs Meta (fp32 RoPE) | timm vs Meta (bf16 RoPE, Meta default) |
|---|---|---|---|---|---|
| 0.1b `vit_base_patch16_sapiens2` | fp32 1024x768 cuda | 2.4e-06 / 6.1e-08 | 2.1e-06 / 6.0e-08 | 2.1e-06 / 6.1e-08 | 1.7e-02 / 2.4e-04 |
| 0.1b `vit_base_patch16_sapiens2` | fp32 512x384 cuda | 1.8e-06 / 5.2e-08 | 1.5e-06 / 5.3e-08 | 1.8e-06 / 5.5e-08 | 1.1e-02 / 2.1e-04 |
| 0.1b `vit_base_patch16_sapiens2` | fp32 256x192 cuda | 2.6e-06 / 6.9e-08 | 1.4e-06 / 6.5e-08 | 2.2e-06 / 7.0e-08 | 8.0e-03 / 1.7e-04 |
| 0.1b `vit_base_patch16_sapiens2` | fp64 256x192 cpu | 8.6e-07 / 2.0e-08 | 8.4e-08 / 2.2e-09 | 8.7e-07 / 2.0e-08 | 8.0e-03 / 1.7e-04 |
| 0.4b `vit_large_patch16_sapiens2` | fp32 1024x768 cuda | 2.6e-06 / 6.7e-08 | 5.0e-06 / 6.2e-08 | 3.8e-06 / 6.4e-08 | 1.5e-02 / 3.0e-04 |
| 0.4b `vit_large_patch16_sapiens2` | fp32 512x384 cuda | 1.7e-06 / 5.0e-08 | 1.9e-06 / 4.8e-08 | 1.4e-06 / 4.8e-08 | 1.0e-02 / 1.8e-04 |
| 0.4b `vit_large_patch16_sapiens2` | fp32 256x192 cuda | 3.1e-06 / 1.2e-07 | 2.7e-06 / 1.1e-07 | 3.3e-06 / 1.2e-07 | 7.3e-03 / 1.8e-04 |
| 0.4b `vit_large_patch16_sapiens2` | fp64 256x192 cpu | 6.1e-07 / 1.7e-08 | 1.1e-07 / 2.5e-09 | 6.0e-07 / 1.7e-08 | 7.3e-03 / 1.8e-04 |
| 0.8b `vit_huge_patch16_sapiens2` | fp32 1024x768 cuda | 5.5e-05 / 5.9e-07 | 1.1e-05 / 4.1e-07 | 5.3e-05 / 5.9e-07 | 1.0e-01 / 1.9e-03 |
| 0.8b `vit_huge_patch16_sapiens2` | fp32 512x384 cuda | 2.7e-05 / 3.7e-07 | 1.3e-05 / 3.5e-07 | 2.3e-05 / 3.8e-07 | 1.2e-01 / 1.5e-03 |
| 0.8b `vit_huge_patch16_sapiens2` | fp32 256x192 cuda | 1.8e-05 / 6.1e-07 | 2.0e-05 / 5.5e-07 | 1.8e-05 / 6.1e-07 | 5.4e-02 / 1.2e-03 |
| 0.8b `vit_huge_patch16_sapiens2` | fp64 256x192 cpu | 6.7e-06 / 1.0e-07 | 1.0e-06 / 1.9e-08 | 6.6e-06 / 1.0e-07 | 5.4e-02 / 1.2e-03 |
| 1b `vit_giant_patch16_sapiens2` | fp32 1024x768 cuda | 9.5e-06 / 3.8e-08 | 9.3e-06 / 3.6e-08 | 8.6e-06 / 3.7e-08 | 2.4e-01 / 2.2e-04 |
| 1b `vit_giant_patch16_sapiens2` | fp32 512x384 cuda | 9.1e-06 / 3.4e-08 | 1.4e-05 / 3.3e-08 | 1.3e-05 / 3.4e-08 | 8.2e-02 / 2.0e-04 |
| 1b `vit_giant_patch16_sapiens2` | fp32 256x192 cuda | 1.3e-05 / 5.2e-08 | 9.5e-06 / 4.7e-08 | 1.5e-05 / 5.2e-08 | 4.7e-02 / 1.2e-04 |
| 1b `vit_giant_patch16_sapiens2` | fp64 256x192 cpu | 2.7e-06 / 8.0e-09 | 7.0e-07 / 1.4e-09 | 2.6e-06 / 7.9e-09 | 4.7e-02 / 1.2e-04 |
| 5b `vit_5b_patch16_sapiens2` | fp32 512x384 cpu | 1.7e-05 / 2.4e-08 | 0.0e+00 / 0.0e+00 | 1.7e-05 / 2.4e-08 | 3.2e-01 / 3.5e-04 |
| 5b `vit_5b_patch16_sapiens2` | fp32 256x192 cpu | 6.7e-06 / 3.2e-08 | 0.0e+00 / 0.0e+00 | 6.7e-06 / 3.2e-08 | 1.2e-01 / 2.2e-04 |

Same-table float64 check (both models fed one float64 RoPE table, CPU, 256x192, batch 2):

| model | timm vs Meta, fp64, identical RoPE table |
|---|---|
| 0.1B | max_abs = 0.0 |
| 0.4B | max_abs = 0.0 |
| 0.8B | max_abs = 0.0 |
| 1B | max_abs = 0.0 |
| 5B | max_abs = 0.0 |

(5B was compared on CPU; there timm vs Meta is bit-exact even in plain fp32, the non-zero fp32 rows above come from CUDA kernel selection differences.)


Parameter counts match the checkpoint tensor totals exactly for every size, and every size loads strictly (all checkpoint tensors consumed, none missing).

**Bit-exactness.** In float64 the residual timm vs. Meta gap (~1e-7) is entirely the RoPE table: all implementations (timm, transformers, Meta) build the sin/cos tables in float32 regardless of model dtype (the two fp32-built tables differ from a float64-built one by ~2e-7). Feeding timm and the Meta reference the *same* float64 table and running both in float64 gives **`max_abs = 0.0` on every size tested (0.1B, 0.4B, 0.8B, 1B, 5B)** — the transformer stacks are bit-identical, including the GQA blocks.

One fidelity note: the Meta standalone code defaults to **bfloat16** RoPE tables (`pos_embed_rope_dtype="bf16"`), which quantizes the patch coordinates. Against that default both timm and the transformers port differ by ~1e-4..2e-3 mean abs (last column). This PR follows the transformers port and the timm DINOv3 port (fp32 tables); flagging it in case you'd rather expose a rope dtype option.

**Regression on existing Eva models** — every `module='eva'` model except `*_7b_*` (61 models: random init with fixed seeds, CPU, `use_deterministic_algorithms`) plus pretrained `vit_small_patch16_dinov3{,_qkvb}.lvd1689m` (exercises the modified `checkpoint_filter_fn` branch selection), snapshotted on `upstream/main` (a23518b6) and on this branch: **61 / 61 bit-identical** in state_dict hash, `forward_features` and `forward_head` outputs.

**Tests**
- `pytest tests/test_models.py -k sapiens2`: 31 passed, 7 skipped (the 5 `test_model_load_pretrained` cases pass with the `facebook/*` hub ids; they download the original checkpoints).
- torchscript / fx / forward / backward tests for `eva02_tiny_patch14_224`, `eva_giant_patch14_224`, `vit_small_patch16_rope_224`, `vit_small_patch16_rope_mixed_224`, `vit_small_patch16_dinov3`, `vit_pe_core_tiny_patch16_384`: 47 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
