### PR TITLE
Fix inference test-time preprocessing defaults

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -204,7 +204,7 @@ def main():
     _logger.info(
         f'Model {args.model} created, param count: {sum([m.numel() for m in model.parameters()])}')
 
-    data_config = resolve_data_config(vars(args), model=model)
+    data_config = resolve_data_config(vars(args), model=model, use_test_size=not args.use_train_size)
     test_time_pool = False
     if args.test_pool:
         model, test_time_pool = apply_test_time_pool(model, data_config)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,54 @@
+import subprocess
+import sys
+
+import torch
+from PIL import Image
+
+import timm
+from timm.utils import CheckpointSaver
+
+
+def test_inference_defaults_to_registered_test_input_size(tmp_path):
+    data_dir = tmp_path / "images" / "class0"
+    data_dir.mkdir(parents=True)
+    Image.new("RGB", (301, 247), color=(30, 100, 220)).save(data_dir / "sample.png")
+
+    model_name = "resnet10t.c3_in1k"
+    model = timm.create_model(model_name, pretrained=False)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    checkpoint_dir = tmp_path / "checkpoint"
+    checkpoint_dir.mkdir()
+    CheckpointSaver(
+        model=model,
+        optimizer=optimizer,
+        checkpoint_dir=str(checkpoint_dir),
+        recovery_dir=str(checkpoint_dir),
+    ).save_checkpoint(epoch=0)
+
+    results_dir = tmp_path / "results"
+    subprocess.run(
+        [
+            sys.executable,
+            "inference.py",
+            "--data-dir",
+            str(data_dir.parent),
+            "--model",
+            model_name,
+            "--checkpoint",
+            str(checkpoint_dir / "last.pth.tar"),
+            "--device",
+            "cpu",
+            "--workers",
+            "0",
+            "--batch-size",
+            "1",
+            "--results-dir",
+            str(results_dir),
+            "--no-console-results",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert sorted(path.name for path in results_dir.iterdir()) == ["resnet10t.c3_in1k-224.csv"]


### PR DESCRIPTION
## What does this PR do?

`inference.py` currently resolves preprocessing without enabling the registered test configuration. Models with different training and test settings therefore use `input_size` and `crop_pct` during inference instead of `test_input_size` and `test_crop_pct`. For example, `resnet10t.c3_in1k` receives 176×176 inputs with a 0.875 crop ratio instead of its registered 224×224 and 0.95 test settings.

This passes `use_test_size=not args.use_train_size`, matching `validate.py` and `benchmark.py`. Explicit size and crop overrides retain their existing precedence.

## Tests

```text
python -m pytest -q tests/test_inference.py
1 passed

python -m pytest -q tests/test_data.py tests/test_inference.py
20 passed
```
