### PR TITLE
Ensure `PatchEmbed` classes do not return view tensor

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -10,6 +10,8 @@ from timm.layers import (
     ClNormMlpClassifierHead,
     MultiQueryAttentionV2,
     NormMlpClassifierHead,
+    PatchEmbed,
+    PatchEmbedWithSize,
     PatchEmbedInterpolator,
     RotAttentionPool2d,
     create_act_layer,
@@ -419,3 +421,13 @@ def test_attn2d(bias, expand_first, head_first, attn_mask):
     o2 = attn(x, mask)
     
     assert torch.allclose(o1, o2, atol=1e-5), f"{torch.abs(o1 - o2).max()}"
+
+
+@pytest.mark.parametrize("pe_class", [PatchEmbed, PatchEmbedWithSize])
+def test_patchembed_return_view_tensor(pe_class):
+    pe = pe_class(224, 16, 3, 512)
+    x = torch.randn(1, 3, 224, 224)
+    out = pe(x)
+    if isinstance(out, tuple):
+        out = out[0]
+    assert out._base is None, f"{pe.__class__.__name__} should not return a view tensor."

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,5 +1,7 @@
 import pytest
 import torch
+import torch.distributed as dist
+from torch.distributed.fsdp import fully_shard
 import torch.nn as nn
 
 import timm.layers.fast_norm as fast_norm
@@ -25,6 +27,7 @@ from timm.layers import (
 
 import importlib
 import os
+import tempfile
 
 torch_backend = os.environ.get('TORCH_BACKEND')
 if torch_backend is not None:
@@ -424,10 +427,21 @@ def test_attn2d(bias, expand_first, head_first, attn_mask):
 
 
 @pytest.mark.parametrize("pe_class", [PatchEmbed, PatchEmbedWithSize])
-def test_patchembed_return_view_tensor(pe_class):
+@pytest.mark.parametrize("device", [torch.device("cpu"), torch.device("cuda")])
+def test_patchembed_return_view_tensor(pe_class, device):
+    tmp_file = tempfile.NamedTemporaryFile(delete=True).name
+    dist.init_process_group(
+        backend=torch.distributed.get_default_backend_for_device(device),
+        init_method=f"file://{tmp_file}",
+        world_size=1,
+        rank=0,
+        device_id=device.index,
+    )
     pe = pe_class(224, 16, 3, 512)
-    x = torch.randn(1, 3, 224, 224)
+    fully_shard(pe)
+    x = torch.randn(1, 3, 224, 224, device=device)
     out = pe(x)
     if isinstance(out, tuple):
         out = out[0]
+    dist.destroy_process_group()
     assert out._base is None, f"{pe.__class__.__name__} should not return a view tensor."

--- a/timm/layers/patch_embed.py
+++ b/timm/layers/patch_embed.py
@@ -15,6 +15,7 @@ from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 import torch
 from torch import nn as nn
 import torch.nn.functional as F
+from torch.distributed.fsdp import FSDPModule
 
 from .format import Format, nchw_to
 from .helpers import to_2tuple
@@ -135,10 +136,12 @@ class PatchEmbed(nn.Module):
             x = F.pad(x, (0, pad_w, 0, pad_h))
         x = self.proj(x)
         if self.flatten:
-            x = x.flatten(2).transpose(1, 2).contiguous()  # NCHW -> NLC
+            x = x.flatten(2).transpose(1, 2)  # NCHW -> NLC
         elif self.output_fmt != Format.NCHW:
             x = nchw_to(x, self.output_fmt)
         x = self.norm(x)
+        if isinstance(self, FSDPModule):
+            return x.clone()
         return x
 
 
@@ -182,10 +185,12 @@ class PatchEmbedWithSize(PatchEmbed):
         x = self.proj(x)
         feat_size = x.shape[-2:]
         if self.flatten:
-            x = x.flatten(2).transpose(1, 2).contiguous()  # NCHW -> NLC
+            x = x.flatten(2).transpose(1, 2)  # NCHW -> NLC
         elif self.output_fmt != Format.NCHW:
             x = nchw_to(x, self.output_fmt)
         x = self.norm(x)
+        if isinstance(self, FSDPModule):
+            return x.clone(), feat_size
         return x, feat_size
 
 

--- a/timm/layers/patch_embed.py
+++ b/timm/layers/patch_embed.py
@@ -135,7 +135,7 @@ class PatchEmbed(nn.Module):
             x = F.pad(x, (0, pad_w, 0, pad_h))
         x = self.proj(x)
         if self.flatten:
-            x = x.flatten(2).transpose(1, 2)  # NCHW -> NLC
+            x = x.flatten(2).transpose(1, 2).contiguous()  # NCHW -> NLC
         elif self.output_fmt != Format.NCHW:
             x = nchw_to(x, self.output_fmt)
         x = self.norm(x)
@@ -182,7 +182,7 @@ class PatchEmbedWithSize(PatchEmbed):
         x = self.proj(x)
         feat_size = x.shape[-2:]
         if self.flatten:
-            x = x.flatten(2).transpose(1, 2)  # NCHW -> NLC
+            x = x.flatten(2).transpose(1, 2).contiguous()  # NCHW -> NLC
         elif self.output_fmt != Format.NCHW:
             x = nchw_to(x, self.output_fmt)
         x = self.norm(x)


### PR DESCRIPTION
## Summary

fix https://github.com/huggingface/pytorch-image-models/issues/2766

This PR fixes a PatchEmbed output issue that can trigger PyTorch FSDP2 warnings when a fully-sharded module returns a non-owning view tensor.

The root cause is the NCHW -> NLC conversion path in PatchEmbed, where `flatten(2).transpose(1, 2)` produces a view rather than a contiguous tensor. Under FSDP2, returning such a view from a sharded module can trigger warnings like:

“FSDP2-wrapped module returned a view tensor”

This is not a semantic correctness issue in the common case, but it is unsafe for FSDP2 and can break assumptions around pre-backward hooks / all-gather behavior.

## Changes

Ensure the output of `PatchEmbed` and `PatchEmbedWithSize` is materialized as a contiguous tensor before returning it.
Add a regression test to assert that the patch embedding output does not return a view tensor (`_base is None`).
This keeps the module behavior unchanged for callers while avoiding FSDP2 warnings caused by view outputs.

## Validation

Verified locally with:

```shell
$ uv run pytest tests/test_layers.py 
======================================= test session starts =======================================
platform linux -- Python 3.14.7, pytest-9.1.1, pluggy-1.6.0
rootdir: ~/Documents/myrepos/pytorch-image-models
configfile: pyproject.toml
collected 46 items                                                                                                                                                                                                                            

tests/test_layers.py ..............................................                                                                                                                                                                     [100%]

======================================== 46 passed in 4.92s ========================================
```