### PR TITLE
Add Qwen-Drive-1.0-4B vision tower as a qwen3_vit pretrained tag

### DIFF
--- a/timm/models/qwen3_vit.py
+++ b/timm/models/qwen3_vit.py
@@ -1,6 +1,7 @@
 """Qwen3 Vision Transformer
 
-Vision encoder of the Qwen3-VL / Qwen3.5 / Qwen3.8 multimodal models from Alibaba Qwen team.
+Vision encoder of the Qwen3-VL / Qwen3.5 / Qwen3.8 multimodal models from Alibaba Qwen team, and of the
+driving-domain Qwen-Drive-1.0 built on that same tower.
 
 A plain pre-norm ViT (SigLIP-2 style widths, GELU-tanh MLP, fused QKV with bias) with two position encodings
 applied together: a learned absolute grid (48x48 for the released models, bilinearly resampled to the input grid
@@ -18,7 +19,8 @@ Weights are native timm remaps of the source VLM vision tensors. The Conv3d patc
 `temporal_patch_size=2` frames is folded into a Conv2d since the image path feeds the same frame twice
 (mathematically identical, verified against the transformers reference).
 
-Reference: https://github.com/QwenLM/Qwen3-VL, transformers `Qwen3VLVisionModel` / `Qwen3_5VisionModel`.
+Reference: https://github.com/QwenLM/Qwen3-VL, https://github.com/QwenLM/Qwen-Drive-1.0,
+transformers `Qwen3VLVisionModel` / `Qwen3_5VisionModel`.
 Weights are released under Apache-2.0 by the Qwen team, except Qwen3.8-Flash-Next (Qwen Community License 1.0).
 
 Copyright 2026 Yonghye Kwon
@@ -551,13 +553,14 @@ def checkpoint_filter_fn_encoder(
         state_dict: Dict[str, torch.Tensor],
         model: Qwen3VitEncoder,
 ) -> Dict[str, torch.Tensor]:
-    """Remap `model.visual.*` tensors of a Qwen3-VL / Qwen3.5 / Qwen3.8 checkpoint (or shard) to timm keys.
+    """Remap `model.visual.*` tensors of a Qwen3-VL / Qwen3.5 / Qwen3.8 / Qwen-Drive checkpoint to timm keys.
 
     Every non-vision tensor (the LLM) is dropped, so a raw VLM shard can be passed directly.
     """
     out_dict = {}
     for k, v in state_dict.items():
-        for prefix in ('model.visual.', 'visual.', 'encoder.'):
+        # `vlm.model.visual.` is Qwen-Drive, which nests the whole VLM under a `vlm.` attribute
+        for prefix in ('vlm.model.visual.', 'model.visual.', 'visual.', 'encoder.'):
             if k.startswith(prefix):
                 k = k[len(prefix) :]
                 break
@@ -744,6 +747,16 @@ _SOURCE_CFGS = {
         out_features=4096,
         origin_url='https://huggingface.co/Qwen/Qwen3-VL-235B-A22B-Instruct',
     ),
+    # Qwen-Drive-1.0: the Qwen3.5-4B tower after driving-domain training. Same architecture and projector width,
+    # but the weights moved (mean |diff| vs Qwen3.5-4B ~2e-5 in early blocks rising to ~3e-4 at the projector),
+    # so it is a distinct tag rather than an alias. Its checkpoint nests the VLM under `vlm.`, and the driving
+    # heads (BEV perception, planning expert) live in separate files -- nothing extra to drop here.
+    'qwen3_vit_306m.qwen_drive_1_0_4b': _cfg(
+        hf_hub_id='Qwen/Qwen-Drive-1.0-4B',
+        hf_hub_filename='model.safetensors',
+        out_features=2560,
+        origin_url='https://huggingface.co/Qwen/Qwen-Drive-1.0-4B',
+    ),
 }
 
 
@@ -775,7 +788,7 @@ def qwen3_vit_88m_merge(pretrained: bool = False, **kwargs) -> Qwen3VitClassifie
 
 @register_model
 def qwen3_vit_306m(pretrained: bool = False, **kwargs) -> Qwen3VitClassifier:
-    """Qwen3.5 vision classifier, 24 x 1024 (306M w/o projector). Source: Qwen3.5-2B / 4B."""
+    """Qwen3.5 vision classifier, 24 x 1024 (306M w/o projector). Source: Qwen3.5-2B / 4B, Qwen-Drive-1.0-4B."""
     model_args = dict(embed_dim=1024, depth=24, num_heads=16, mlp_ratio=4.0)
     return _create_qwen3_vit_classifier('qwen3_vit_306m', pretrained=pretrained, **dict(model_args, **kwargs))
 


### PR DESCRIPTION
Closes #2773.

Adds the vision tower of [**Qwen-Drive-1.0-4B**](https://huggingface.co/Qwen/Qwen-Drive-1.0-4B) (Apache-2.0) as a pretrained tag on the `qwen3_vit` models from #2765.

Qwen-Drive-1.0 is Qwen's autonomous-driving VLM: it keeps the Qwen3.5-4B architecture unchanged and bolts on a BEV perception head (3D detection, semantic occupancy, map segmentation) and a flow-matching planning expert. So the tower is *already* `qwen3_vit_306m` — depth 24, width 1024, 16 heads, MLP 4096, patch 16, merge 2, temporal patch 2, 48×48 learned pos embed, projector to 2560, mean/std 0.5. No new model def, no forward-path change.

## Why a tag and not an alias

The model card says `base_model: Qwen/Qwen3.5-4B`, but the staged driving training moved the tower. Tensor-by-tensor against `Qwen/Qwen3.5-4B`:

| tensor | max abs diff | mean abs diff |
|---|---|---|
| `pos_embed.weight` | 3.1e-2 | 3.6e-4 |
| `patch_embed.proj.weight` | 1.2e-4 | 1.7e-5 |
| `blocks.0.attn.qkv.weight` | 2.7e-4 | 1.8e-5 |
| `blocks.12.mlp.linear_fc1.weight` | 6.4e-4 | 7.8e-5 |
| `blocks.23.attn.proj.weight` | 2.0e-3 | 1.6e-4 |
| `merger.linear_fc2.weight` | 2.0e-3 | 2.7e-4 |

Nothing is bit-identical and the drift grows with depth and into the projector — a fine-tune, not a re-upload. A driving-domain ViT that kept its general VQA ability is a genuinely different feature extractor to have around.

## The diff

1. `checkpoint_filter_fn_encoder` learns one more prefix, `vlm.model.visual.` — Qwen-Drive nests the whole VLM under a `vlm.` attribute. Everything after that (Conv3d→Conv2d fold, `pos_embed` reshape, `merger.linear_fc*` rename, dropping the LLM) is untouched.
2. One `_SOURCE_CFGS` entry, which generates the usual three tags: `qwen3_vit_306m.qwen_drive_1_0_4b`, `_merge`, `_enc`.

The perception and planning heads live in separate files in the repo (`perception/`, `planner-sft/`, `planner-rl/`) and are out of scope — they're BEV/trajectory modules, not image backbones. The top-level `model.safetensors` holds only the VLM, so there is nothing extra to filter out beyond the LLM the filter already drops.

## Verification

Same protocol as #2765. Reference is transformers 5.16.1 `Qwen3_5VisionModel` built from Qwen-Drive's own `vision_config` and loaded from the same tensors; timm gets a plain NCHW image, the reference gets the `Qwen2VLImageProcessor` patchify of that same image, and patch tokens are compared after undoing the reference's spatial-merge token ordering.

**Load** — `qwen3_vit_306m_enc.qwen_drive_1_0_4b`:

```
[load] timm strict load OK | params=332,727,808 out_features=2560 grid=48
[load] classifier variant strict load OK | params=305,463,303 num_classes=7
[load] encoder<->classifier shared tensors bit-identical: True (291 tensors)
[load] reference params=333,514,240 timm=332,727,808 equal_after_conv3d_fold=True
```

**Numerics** (batch 2, `cos` over the flattened tensors in fp64):

| run | patch tokens max_abs / mean_abs | projector out max_abs / mean_abs | cos |
|---|---|---|---|
| fp32 768×768 cuda | 1.82e-1 / 1.55e-5 (ref \|max\| 2633) | 1.21e-4 / 5.36e-7 (ref \|max\| 6.92) | 1.000000000 |
| fp32 512×384 cuda | 2.86e-2 / 1.13e-5 (ref \|max\| 1813) | 6.39e-5 / 4.09e-7 | 1.000000000 |
| fp32 256×192 cuda | 1.39e-2 / 9.21e-6 (ref \|max\| 1876) | 3.29e-5 / 3.39e-7 | 1.000000000 |
| fp32 256×192 cpu | 1.30e-2 / 9.29e-6 | 2.48e-5 / 2.65e-7 | 1.000000000 |
| fp64 256×192 cpu | 8.00e-4 / 6.74e-7 | 1.41e-6 / 2.25e-8 | 1.000000000 |
| fp64 768×768 cpu | 9.97e-4 / 1.54e-7 (ref \|max\| 2633) | 1.16e-6 / 4.68e-9 | 1.000000000 |

For fp64 the reference's internal fp32 casts in `apply_rotary_pos_emb_vision` (they exist for bf16 runs) are lifted, so the comparison measures the implementation rather than a downcast.

**fp64 with the reference's own RoPE table**, native 48×48 grid so neither side interpolates the pos embed — this isolates the transformer from the two independently-built RoPE tables (which themselves differ by 2.97e-8):

```
patch tokens   max_abs=1.286e-10  mean_abs=1.337e-14   (ref |max| 2578.08)
projector out  max_abs=9.104e-14  mean_abs=3.981e-16   (ref |max| 6.81)
```

That is the fp64 noise floor — same bar #2765 landed at.

**No regression.** Dumped outputs for every `qwen3_vit` arch on `upstream/main` and on this branch: 3 tags loaded from real checkpoints (`qwen3_vit_88m_enc.qwen3_5_0_8b`, `qwen3_vit_88m.qwen3_5_0_8b`, `qwen3_vit_416m_enc.qwen3_8_27b`) plus 9 random-init models covering all nine registered archs.

```
tags: baseline 36, patched 39
  removed : none
  added   : ['qwen3_vit_306m.qwen_drive_1_0_4b', 'qwen3_vit_306m_enc.qwen_drive_1_0_4b',
             'qwen3_vit_306m_merge.qwen_drive_1_0_4b']
outputs: 12 compared, bit-identical=12, differing=0
RESULT: PASS
```

**Tests.** `pytest tests/test_models.py -k qwen` under CI conditions (`GITHUB_ACTIONS=1`): **58 passed, 47 skipped**.

Run locally without that env var, three tests fail — and they are the expected ones:

```
FAILED test_model_load_pretrained[1-qwen3_vit_306m.qwen_drive_1_0_4b]
FAILED test_model_load_pretrained[1-qwen3_vit_306m_enc.qwen_drive_1_0_4b]
FAILED test_model_load_pretrained[1-qwen3_vit_306m_merge.qwen_drive_1_0_4b]
3 failed, 111 passed, 39 skipped
```

all `401` on `https://huggingface.co/timm/qwen3_vit_306m*.qwen_drive_1_0_4b/resolve/main/model.safetensors` — the re-hosted repos don't exist yet. `test_model_load_pretrained` is guarded by `if 'GITHUB_ACTIONS' not in os.environ`, so CI is unaffected, but **this tag needs the same convert-and-upload step the other `qwen3_vit` tags got** before it works end to end. The `_SOURCE_CFGS` entry carries exactly what `conversion.json` records (`source_repo`, `source_filename`), so it should drop straight into the existing pipeline. Happy to hand over the converted encoder-only safetensors if that saves a step — the source is a single 9.1 GB file, so the extract matters more here than for the sharded VLMs.

To cover what that skipped test would have checked, I ran the same calls against the local source checkpoint, including a re-save into timm's own key layout and reload (the path a re-hosted artifact takes):

```
qwen3_vit_306m.qwen_drive_1_0_4b        out=(1, 1024)      timm-layout round-trip identical=True  in_chans=1 (1, 5)/(1, 1024) finite=True
qwen3_vit_306m_merge.qwen_drive_1_0_4b  out=(1, 2560)      timm-layout round-trip identical=True  in_chans=1 (1, 5)/(1, 2560) finite=True
qwen3_vit_306m_enc.qwen_drive_1_0_4b    out=(1, 48, 2560)  timm-layout round-trip identical=True  in_chans=1 (1, 48, 2560)/(1, 48, 2560) finite=True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
