### PR TITLE
Add DeepSeek-V4 / V4.1 vision encoder as deepseek_vit

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -57,7 +57,7 @@ FEAT_INTER_FILTERS = [
     'tiny_vit', 'vovnet', 'tresnet', 'rexnet', 'resnetv2', 'repghost', 'repvit', 'pvt_v2', 'nextvit', 'nest',
     'mambaout', 'inception_next', 'inception_v4', 'hgnet', 'gcvit', 'focalnet', 'efficientformer_v2', 'edgenext',
     'davit', 'rdnet', 'convnext', 'pit', 'starnet', 'shvit', 'fasternet', 'swiftformer', 'ghostnet', 'naflexvit',
-    'csatv2', 'cpubone', 'lcnetv2', 'lowformer', 'qwen3_vit'
+    'csatv2', 'cpubone', 'lcnetv2', 'lowformer', 'qwen3_vit', 'deepseek_vit'
 ]
 
 # transformer / hybrid models don't support full set of spatial / feature APIs and/or have spatial output.
@@ -66,7 +66,7 @@ NON_STD_FILTERS = [
     'convit_*', 'levit*', 'visformer*', 'deit*', 'xcit_*', 'crossvit_*', 'beit*', 'aimv2*', 'swiftformer_*',
     'poolformer_*', 'volo_*', 'sequencer2d_*', 'mvitv2*', 'gcvit*', 'efficientformer*', 'sam_hiera*',
     'eva_*', 'flexivit*', 'eva02*', 'samvit_*', 'efficientvit_m*', 'tiny_vit_*', 'hiera_*', 'vitamin*', 'test_vit*',
-    'gemma4_vit*', 'qwen3_vit*',
+    'gemma4_vit*', 'qwen3_vit*', 'deepseek_vit*',
 ]
 NUM_NON_STD = len(NON_STD_FILTERS)
 

--- a/timm/models/__init__.py
+++ b/timm/models/__init__.py
@@ -11,6 +11,7 @@ from .crossvit import *
 from .csatv2 import *
 from .cspnet import *
 from .davit import *
+from .deepseek_vit import *
 from .deit import *
 from .densenet import *
 from .dla import *

--- a/timm/models/deepseek_vit.py
+++ b/timm/models/deepseek_vit.py
@@ -1,0 +1,763 @@
+"""DeepSeek Vision Transformer
+
+Vision encoder of the DeepSeek-V4 / V4.1 multimodal models from DeepSeek-AI.
+
+A plain pre-norm ViT with RMSNorm, fused QKV with bias, a bias-free SwiGLU MLP and axial 2D RoPE
+(theta 10000, per-axis frequency blocks, 'half' rotation layout) as the only position encoding --
+there is no learned position embedding, so any patch grid works without resampling. Patches are
+embedded by a linear projection over flattened `14 x 14` pixel patches (loaded here as the
+equivalent Conv2d) and the encoder ends with an RMSNorm over the patch tokens.
+
+Classifier variants wrap the encoder with average pooling, normalization and a linear head. The
+separate `_enc` variants preserve the native VLM projector (the DeepSeek 'aligner'), which
+pixel-unshuffles `3 x 3` patch tokens and maps them to the LLM width via `out_features`.
+Classifiers can also retain this projector with `encoder_pool='align'`; `_align` variants enable it
+by default.
+
+For example, `deepseek_vit_412m.deepseek_v4_1_flash` with `num_classes=45` returns image logits
+(B, 45), while `deepseek_vit_412m_enc.deepseek_v4_1_flash` returns projected tokens
+(B, ceil(H/3)*ceil(W/3), 5120). Encoder checkpoint weights load into the classifier under
+`encoder.*`; its classification head is initialized separately.
+
+Weights are remapped on the fly from the DeepSeek checkpoint shard that holds the vision tower, so
+`pretrained=True` reads the original `deepseek-ai/*` repos with no re-hosting; every non-vision
+(LLM) tensor in that shard is dropped by the checkpoint filter.
+
+Reference: https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash (`inference/vision.py`),
+https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp. Weights are MIT licensed.
+
+Copyright 2026 Yonghye Kwon
+"""
+
+from functools import partial
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from timm.layers import (
+    AttentionRope,
+    DropPath,
+    GluMlp,
+    PatchEmbed,
+    RmsNormFp32,
+    RotaryEmbeddingCat,
+    calculate_drop_path_rates,
+    get_device_dtype,
+    trunc_normal_,
+)
+from ._builder import build_model_with_cfg, resolve_pretrained_cfg
+from ._features import feature_take_indices
+from ._manipulate import checkpoint
+from ._registry import generate_default_cfgs, register_model
+
+__all__ = ['DeepseekVitEncoder', 'DeepseekVitClassifier']
+
+
+class DeepseekVitBlock(nn.Module):
+    """Pre-norm block: RoPE attention (fused QKV w/ bias) and a bias-free packed SwiGLU MLP.
+
+    The reference keeps bias on the attention projections but not on the MLP, which is why this is a
+    local block rather than `EvaBlock` (that one has no MLP bias control).
+    """
+
+    def __init__(
+            self,
+            dim: int,
+            num_heads: int,
+            mlp_ratio: float = 2.75,
+            proj_drop: float = 0.,
+            attn_drop: float = 0.,
+            drop_path: float = 0.,
+            norm_layer: Callable = RmsNormFp32,
+            device=None,
+            dtype=None,
+    ) -> None:
+        dd = {'device': device, 'dtype': dtype}
+        super().__init__()
+        self.norm1 = norm_layer(dim, **dd)
+        self.attn = AttentionRope(
+            dim,
+            num_heads=num_heads,
+            qkv_bias=True,
+            qkv_fused=True,
+            num_prefix_tokens=0,
+            rotate_half=True,
+            proj_bias=True,
+            attn_drop=attn_drop,
+            proj_drop=proj_drop,
+            **dd,
+        )
+        self.drop_path1 = DropPath(drop_path) if drop_path > 0. else nn.Identity()
+
+        self.norm2 = norm_layer(dim, **dd)
+        # packed SwiGLU: one fc1 emitting [gate, up], matching the reference `w1(x).chunk(2, -1)`
+        self.mlp = GluMlp(
+            in_features=dim,
+            hidden_features=int(dim * mlp_ratio) * 2,
+            act_layer=nn.SiLU,
+            gate_last=False,
+            bias=False,
+            drop=proj_drop,
+            **dd,
+        )
+        self.drop_path2 = DropPath(drop_path) if drop_path > 0. else nn.Identity()
+
+    def forward(self, x: torch.Tensor, rope: Optional[torch.Tensor] = None) -> torch.Tensor:
+        x = x + self.drop_path1(self.attn(self.norm1(x), rope=rope))
+        x = x + self.drop_path2(self.mlp(self.norm2(x)))
+        return x
+
+
+class DeepseekVitAligner(nn.Module):
+    """DeepSeek VLM projector ('aligner'): `r x r` pixel-unshuffle of patch tokens, MLP to the LLM width.
+
+    `out_features` is the source LLM hidden size. `pre_logits` returns the activated first projection,
+    before the final one.
+
+    Two details are load-bearing and differ from the more common VLM patch mergers:
+
+    * The unshuffle is channel-major, `(C, kh, kw)` -- the reference builds it with `F.unfold`, whose
+      output channel order is exactly that. Merging as `(kh, kw, C)` instead (the Qwen/Gemma layout)
+      permutes `fc1`'s input while every shape still matches, so the failure is silent: no load error,
+      no exception, just a wrong projection.
+    * A patch grid that is not a multiple of `r` is zero-padded on the bottom/right rather than
+      rejected, so the encoder accepts any input size.
+    """
+
+    def __init__(
+            self,
+            dim: int,
+            downsample_ratio: int = 3,
+            out_features: int = 0,
+            act_layer: Callable = nn.GELU,
+            device=None,
+            dtype=None,
+    ) -> None:
+        dd = {'device': device, 'dtype': dtype}
+        super().__init__()
+        assert out_features > 0, 'the DeepSeek aligner projects to the source LLM width, pass out_features'
+        self.downsample_ratio = downsample_ratio
+        self.hidden_size = dim * downsample_ratio ** 2
+        self.out_features = out_features
+        self.fc1 = nn.Linear(self.hidden_size, out_features, **dd)
+        self.act = act_layer()
+        self.fc2 = nn.Linear(out_features, out_features, **dd)
+
+    def unshuffle(self, x: torch.Tensor) -> torch.Tensor:
+        """(B, H, W, C) -> (B, ceil(H/r) * ceil(W/r), C*r*r), channel-major within each `r x r` block."""
+        B, H, W, C = x.shape
+        r = self.downsample_ratio
+        x = x.permute(0, 3, 1, 2)
+        # pad unconditionally: `if pad:` would be control flow on traced shapes for torch.fx
+        pad_h, pad_w = -H % r, -W % r
+        x = F.pad(x, (0, pad_w, 0, pad_h))
+        h, w = (H + pad_h) // r, (W + pad_w) // r
+        x = x.reshape(B, C, h, r, w, r).permute(0, 2, 4, 1, 3, 5)
+        return x.reshape(B, h * w, C * r * r)
+
+    def forward(self, x: torch.Tensor, pre_logits: bool = False) -> torch.Tensor:
+        x = self.act(self.fc1(self.unshuffle(x)))
+        return x if pre_logits else self.fc2(x)
+
+
+class DeepseekVitEncoder(nn.Module):
+    """DeepSeek-V4 / V4.1 vision encoder.
+
+    `forward_features` returns the final-norm patch tokens as (B, H, W, C) (`output_fmt='NHWC'`,
+    matching the reference `ViT` output up to that flattening). Output of `forward` depends on
+    `global_pool`:
+      * 'align' (default): projector output (B, ceil(H/3)*ceil(W/3), out_features) -- the tokens the
+        LLM consumes
+      * 'avg': mean over patch tokens -> (B, embed_dim)
+      * '': raw patch features -> (B, H, W, embed_dim), identical to forward_features
+    """
+
+    output_fmt: str = 'NHWC'
+
+    def __init__(
+            self,
+            img_size: Union[int, Tuple[int, int]] = 546,
+            patch_size: int = 14,
+            in_chans: int = 3,
+            out_features: int = 0,
+            global_pool: str = 'align',
+            embed_dim: int = 1024,
+            depth: int = 32,
+            num_heads: int = 16,
+            mlp_ratio: float = 2816 / 1024,
+            downsample_ratio: int = 3,
+            rope_temperature: float = 10000.,
+            norm_eps: float = 1e-6,
+            proj_drop_rate: float = 0.,
+            attn_drop_rate: float = 0.,
+            drop_path_rate: float = 0.,
+            device=None,
+            dtype=None,
+    ) -> None:
+        """
+        Args:
+            img_size: Nominal input size, only used for the feature-info reduction / default grid. Any
+                input size divisible by `patch_size` works (RoPE only, and the projector pads).
+            patch_size: Patch size.
+            in_chans: Number of input channels.
+            out_features: Output width of the VLM projector (source LLM hidden size). Required when
+                the projector is enabled, independent of a downstream classifier's number of classes.
+            global_pool: 'align' (projector), 'avg' (mean pool) or '' (raw tokens).
+            embed_dim: Token width.
+            depth: Number of transformer blocks.
+            num_heads: Attention heads.
+            mlp_ratio: MLP hidden / embed_dim.
+            downsample_ratio: Spatial unshuffle factor of the projector.
+            rope_temperature: RoPE base (theta).
+            norm_eps: RMSNorm eps.
+            proj_drop_rate: Dropout on attention / MLP projections.
+            attn_drop_rate: Attention dropout.
+            drop_path_rate: Stochastic depth rate.
+        """
+        super().__init__()
+        dd = {'device': device, 'dtype': dtype}
+        assert global_pool in ('', 'avg', 'align')
+        assert embed_dim % num_heads == 0
+        self.num_classes = 0
+        self.global_pool = global_pool
+        self.num_features = self.head_hidden_size = self.embed_dim = embed_dim
+        self.out_features = out_features
+        self.downsample_ratio = downsample_ratio
+        self.num_prefix_tokens = 0
+        self.feature_dim = -1  # channels-last (B, H, W, C) features
+        self.grad_checkpointing = False
+
+        norm_layer = partial(RmsNormFp32, eps=norm_eps)
+        head_dim = embed_dim // num_heads
+
+        self.patch_embed = PatchEmbed(
+            img_size=img_size,
+            patch_size=patch_size,
+            in_chans=in_chans,
+            embed_dim=embed_dim,
+            bias=True,
+            strict_img_size=False,
+            output_fmt='NHWC',
+            **dd,
+        )
+        r = self.patch_embed.feat_ratio() if hasattr(self.patch_embed, 'feat_ratio') else patch_size
+        # Axial 2D RoPE on integer patch coordinates, head_dim // 4 frequencies per axis laid out as
+        # [h-block, w-block] and tiled for the 'half' rotation -- the DeepSeek vision RoPE layout.
+        self.rope = RotaryEmbeddingCat(
+            dim=head_dim,
+            temperature=rope_temperature,
+            in_pixels=False,
+            feat_shape=None,
+            rotate_half=True,
+            **dd,
+        )
+
+        dpr = calculate_drop_path_rates(drop_path_rate, depth)
+        self.blocks = nn.ModuleList([
+            DeepseekVitBlock(
+                dim=embed_dim,
+                num_heads=num_heads,
+                mlp_ratio=mlp_ratio,
+                proj_drop=proj_drop_rate,
+                attn_drop=attn_drop_rate,
+                drop_path=dpr[i],
+                norm_layer=norm_layer,
+                **dd,
+            )
+            for i in range(depth)
+        ])
+        self.feature_info = [dict(module=f'blocks.{i}', num_chs=embed_dim, reduction=r) for i in range(depth)]
+        self.norm = norm_layer(embed_dim, **dd)
+
+        self.aligner = (
+            DeepseekVitAligner(
+                embed_dim,
+                downsample_ratio=downsample_ratio,
+                out_features=out_features,
+                **dd,
+            )
+            if global_pool == 'align'
+            else None
+        )
+
+        self.init_weights(needs_reset=False)
+
+    @torch.jit.ignore
+    def init_weights(self, needs_reset: bool = True) -> None:
+        """Initialize weights and, after ``to_empty()``, restore parameters and RoPE buffers.
+
+        Args:
+            needs_reset: Reset modules that self-initialize in their constructors. False during construction.
+        """
+        self.apply(partial(self._init_weights, needs_reset=needs_reset))
+
+    def _init_weights(self, m: nn.Module, needs_reset: bool = True) -> None:
+        if isinstance(m, nn.Linear):
+            trunc_normal_(m.weight, std=0.02)
+            if m.bias is not None:
+                nn.init.zeros_(m.bias)
+        elif needs_reset and hasattr(m, 'reset_parameters') and m is not self:
+            m.reset_parameters()
+
+    @torch.jit.ignore
+    def no_weight_decay(self) -> Set[str]:
+        return set()
+
+    @torch.jit.ignore
+    def set_grad_checkpointing(self, enable: bool = True) -> None:
+        self.grad_checkpointing = enable
+
+    @torch.jit.ignore
+    def group_matcher(self, coarse: bool = False) -> Dict[str, Any]:
+        return dict(
+            stem=r'^patch_embed|rope',
+            blocks=[(r'^blocks\.(\d+)', None), (r'^norm|^aligner', (99999,))],
+        )
+
+    def _pos_embed(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Flatten NHWC patches to tokens and build the RoPE table for this grid (no learned pos embed)."""
+        B, H, W, C = x.shape
+        return x.reshape(B, H * W, C), self.rope.get_embed(shape=(H, W))
+
+    def forward_intermediates(
+            self,
+            x: torch.Tensor,
+            indices: Optional[Union[int, List[int]]] = None,
+            return_prefix_tokens: bool = False,
+            norm: bool = False,
+            stop_early: bool = False,
+            output_fmt: str = 'NCHW',
+            intermediates_only: bool = False,
+            output_dict: bool = False,
+    ) -> Union[List[torch.Tensor], Tuple[torch.Tensor, List[torch.Tensor]], Dict[str, Any]]:
+        """Forward features that returns intermediates.
+
+        Args:
+            x: Input image tensor
+            indices: Take last n blocks if int, all if None, select matching indices if sequence
+            return_prefix_tokens: Unused, the model has no prefix tokens.
+            norm: Apply the final encoder norm to the intermediates
+            stop_early: Stop iterating over blocks when last desired intermediate hit
+            output_fmt: Shape of intermediate feature outputs ('NCHW' or 'NLC')
+            intermediates_only: Only return intermediate features
+            output_dict: Return 'image_intermediates' and, unless intermediates_only, 'image_features' in a dict
+        """
+        assert output_fmt in ('NCHW', 'NLC'), 'Output format must be one of NCHW or NLC.'
+        reshape = output_fmt == 'NCHW'
+        intermediates = []
+        take_indices, max_index = feature_take_indices(len(self.blocks), indices)
+
+        x = self.patch_embed(x)
+        B, H, W, _ = x.shape
+        x, rope = self._pos_embed(x)
+
+        if torch.jit.is_scripting() or not stop_early:  # can't slice blocks in torchscript
+            blocks = self.blocks
+        else:
+            blocks = self.blocks[:max_index + 1]
+        for i, blk in enumerate(blocks):
+            if self.grad_checkpointing and not torch.jit.is_scripting():
+                x = checkpoint(blk, x, rope=rope)
+            else:
+                x = blk(x, rope=rope)
+            if i in take_indices:
+                intermediates.append(self.norm(x) if norm else x)
+
+        if reshape:
+            intermediates = [y.reshape(B, H, W, -1).permute(0, 3, 1, 2).contiguous() for y in intermediates]
+
+        if intermediates_only:
+            return {'image_intermediates': intermediates} if output_dict else intermediates
+
+        x = self.norm(x).reshape(B, H, W, -1)
+        return {'image_features': x, 'image_intermediates': intermediates} if output_dict else (x, intermediates)
+
+    def prune_intermediate_layers(
+            self,
+            indices: Union[int, List[int]] = 1,
+            prune_norm: bool = False,
+            prune_head: bool = True,
+    ) -> List[int]:
+        """Prune blocks, the final norm and/or the native projector for intermediate feature extraction."""
+        take_indices, max_index = feature_take_indices(len(self.blocks), indices)
+        self.blocks = self.blocks[:max_index + 1]  # truncate blocks
+        if prune_norm:
+            self.norm = nn.Identity()
+        if prune_head:
+            self.aligner = None
+            self.global_pool = ''
+            self.out_features = 0
+        return take_indices
+
+    def forward_features(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.patch_embed(x)
+        B, H, W, _ = x.shape
+        x, rope = self._pos_embed(x)
+        for blk in self.blocks:
+            if self.grad_checkpointing and not torch.jit.is_scripting():
+                x = checkpoint(blk, x, rope=rope)
+            else:
+                x = blk(x, rope=rope)
+        return self.norm(x).reshape(B, H, W, -1)
+
+    def forward_head(self, x: torch.Tensor, pre_logits: bool = False) -> torch.Tensor:
+        raise NotImplementedError('DeepseekVitEncoder does not support classification use cases.')
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Encode raw patch tokens and apply the configured native pooling/projector."""
+        x = self.forward_features(x)
+        if self.aligner is not None:
+            return self.aligner(x)
+        if self.global_pool == 'avg':
+            x = x.mean(dim=(1, 2))
+        return x
+
+
+class DeepseekVitClassifier(nn.Module):
+    """Classification wrapper: DeepSeek encoder patch tokens -> mean pool -> norm -> linear head.
+
+    `encoder_pool='align'` retains the native VLM projector before classification pooling.
+    `num_classes` controls the classifier independently of `out_features`, the projector's output width.
+    """
+
+    output_fmt: str = 'NHWC'
+
+    def __init__(
+            self,
+            img_size: Union[int, Tuple[int, int]] = 546,
+            patch_size: int = 14,
+            in_chans: int = 3,
+            num_classes: int = 1000,
+            global_pool: str = 'avg',
+            encoder_pool: str = '',
+            out_features: int = 0,
+            embed_dim: int = 1024,
+            depth: int = 32,
+            num_heads: int = 16,
+            mlp_ratio: float = 2816 / 1024,
+            downsample_ratio: int = 3,
+            rope_temperature: float = 10000.,
+            norm_eps: float = 1e-6,
+            final_norm: bool = True,
+            drop_rate: float = 0.,
+            proj_drop_rate: float = 0.,
+            attn_drop_rate: float = 0.,
+            drop_path_rate: float = 0.,
+            device=None,
+            dtype=None,
+    ) -> None:
+        super().__init__()
+        dd = {'device': device, 'dtype': dtype}
+        assert global_pool in ('', 'avg')
+        assert encoder_pool in ('', 'align')
+        self.num_classes = num_classes
+        self.global_pool = global_pool
+        self.encoder_pool = encoder_pool
+        self.encoder = DeepseekVitEncoder(
+            img_size=img_size,
+            patch_size=patch_size,
+            in_chans=in_chans,
+            global_pool=encoder_pool,
+            out_features=out_features,
+            embed_dim=embed_dim,
+            depth=depth,
+            num_heads=num_heads,
+            mlp_ratio=mlp_ratio,
+            downsample_ratio=downsample_ratio,
+            rope_temperature=rope_temperature,
+            norm_eps=norm_eps,
+            proj_drop_rate=proj_drop_rate,
+            attn_drop_rate=attn_drop_rate,
+            drop_path_rate=drop_path_rate,
+            **dd,
+        )
+        self.embed_dim = embed_dim
+        self.num_features = self.head_hidden_size = (
+            self.encoder.aligner.out_features if self.encoder.aligner is not None else embed_dim
+        )
+        self.output_fmt = 'NLC' if encoder_pool == 'align' else 'NHWC'
+        # the encoder already ends in an affine RMSNorm, so the classifier norm is affine-free
+        self.norm = RmsNormFp32(self.num_features, eps=norm_eps, affine=False, **dd) if final_norm else nn.Identity()
+        self.head_drop = nn.Dropout(drop_rate)
+        self.head = nn.Linear(self.num_features, num_classes, **dd) if num_classes > 0 else nn.Identity()
+        self.encoder._init_weights(self.head)
+        self.num_prefix_tokens = 0
+        self.feature_dim = -1
+        self.feature_info = [dict(info, module=f'encoder.{info["module"]}') for info in self.encoder.feature_info]
+
+    @torch.jit.ignore
+    def init_weights(self, needs_reset: bool = True) -> None:
+        """Initialize the encoder and classification head, including after ``to_empty()``."""
+        self.encoder.init_weights(needs_reset=needs_reset)
+        self.encoder._init_weights(self.head, needs_reset=needs_reset)
+
+    @torch.jit.ignore
+    def no_weight_decay(self) -> Set[str]:
+        return {f'encoder.{k}' for k in self.encoder.no_weight_decay()}
+
+    @torch.jit.ignore
+    def group_matcher(self, coarse: bool = False) -> Dict[str, Any]:
+        return dict(
+            stem=r'^encoder\.(?:patch_embed|rope)',
+            blocks=[(r'^encoder\.blocks\.(\d+)', None), (r'^encoder\.(?:norm|aligner)|^norm|^head', (99999,))],
+        )
+
+    @torch.jit.ignore
+    def set_grad_checkpointing(self, enable: bool = True) -> None:
+        self.encoder.set_grad_checkpointing(enable)
+
+    @torch.jit.ignore
+    def get_classifier(self) -> nn.Module:
+        return self.head
+
+    def reset_classifier(self, num_classes: int, global_pool: Optional[str] = None) -> None:
+        self.num_classes = num_classes
+        if global_pool is not None:
+            assert global_pool in ('', 'avg')
+            self.global_pool = global_pool
+        dd = get_device_dtype(self)
+        self.head = nn.Linear(self.num_features, num_classes, **dd) if num_classes > 0 else nn.Identity()
+        self.encoder._init_weights(self.head)
+        self.head.train(self.training)
+
+    def forward_features(self, x: torch.Tensor) -> torch.Tensor:
+        """Pre-classifier features: raw NHWC patches, or projected NLC tokens when encoder_pool='align'."""
+        return self.encoder(x)
+
+    def forward_head(self, x: torch.Tensor, pre_logits: bool = False) -> torch.Tensor:
+        x = x.flatten(1, -2)
+        if self.global_pool == 'avg':
+            x = x.mean(dim=1)
+        x = self.head_drop(self.norm(x))
+        return x if pre_logits else self.head(x)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.forward_head(self.forward_features(x))
+
+    def forward_intermediates(
+            self,
+            x: torch.Tensor,
+            indices: Optional[Union[int, List[int]]] = None,
+            return_prefix_tokens: bool = False,
+            norm: bool = False,
+            stop_early: bool = False,
+            output_fmt: str = 'NCHW',
+            intermediates_only: bool = False,
+            output_dict: bool = False,
+    ) -> Union[List[torch.Tensor], Tuple[torch.Tensor, List[torch.Tensor]], Dict[str, Any]]:
+        """Return backbone intermediates and the configured pre-classifier features.
+
+        ``norm`` applies the encoder's final norm to the intermediates; the classifier's own
+        post-pooling normalization is never applied to patch tokens. The projector, when enabled,
+        applies only to the final features, not the intermediate maps. ``output_dict`` returns
+        'image_intermediates' and, unless ``intermediates_only``, 'image_features'.
+        """
+        x, intermediates = self.encoder.forward_intermediates(
+            x,
+            indices=indices,
+            return_prefix_tokens=return_prefix_tokens,
+            norm=norm,
+            stop_early=stop_early,
+            output_fmt=output_fmt,
+            intermediates_only=False,
+        )
+        if intermediates_only:
+            return {'image_intermediates': intermediates} if output_dict else intermediates
+        if self.encoder.aligner is not None:
+            x = self.encoder.aligner(x)
+        return {'image_features': x, 'image_intermediates': intermediates} if output_dict else (x, intermediates)
+
+    def prune_intermediate_layers(
+            self,
+            indices: Union[int, List[int]] = 1,
+            prune_norm: bool = False,
+            prune_head: bool = True,
+    ) -> List[int]:
+        """Prune encoder blocks and the classifier."""
+        take_indices = self.encoder.prune_intermediate_layers(indices, prune_norm=prune_norm, prune_head=False)
+        if prune_head:
+            self.reset_classifier(0)
+        return take_indices
+
+
+def checkpoint_filter_fn_encoder(
+        state_dict: Dict[str, torch.Tensor],
+        model: DeepseekVitEncoder,
+) -> Dict[str, torch.Tensor]:
+    """Remap `vision.*` / `aligner.*` tensors of a DeepSeek-V4 / V4.1 checkpoint (or shard) to timm keys.
+
+    Every non-vision tensor (the LLM) is dropped, so a raw checkpoint shard can be passed directly.
+
+    The source checkpoint keeps the vision tower under `vision.` / `aligner.` and the LLM at the top
+    level, where `norm.weight` and `head.weight` collide with timm's own names (the shard the
+    pretrained cfgs point at happens to hold no such tensor, but the full checkpoint does). So an
+    unprefixed key is trusted only when the dict has no `vision.` keys at all, i.e. when it is
+    already in timm layout.
+    """
+    from_source = any(k.startswith('vision.') for k in state_dict)
+    out_dict = {}
+    for k, v in state_dict.items():
+        if k.startswith('encoder.'):  # timm classifier checkpoint
+            k = k[len('encoder.'):]
+        elif from_source:
+            if k.startswith('vision.'):
+                k = k[len('vision.'):]
+            elif not k.startswith('aligner.'):
+                continue  # LLM tensors, incl. the image_start/end/newline span embeddings
+        elif not k.startswith(('patch_embed.', 'blocks.', 'norm.', 'aligner.')):
+            continue
+
+        if k.startswith('aligner.'):
+            if model.aligner is None:
+                continue
+            out_dict['aligner.' + k[len('aligner.'):].replace('w1.', 'fc1.').replace('w2.', 'fc2.')] = v
+            continue
+        if k == 'patch_embed.proj.weight' and v.ndim == 2:
+            # the reference embeds patches with a Linear over the flattened (C, pH, pW) patch; that is
+            # exactly a Conv2d kernel of stride=patch_size, so this is a reshape, not an approximation
+            v = v.reshape(v.shape[0], -1, *model.patch_embed.patch_size)
+        k = k.replace('.attn.wqkv.', '.attn.qkv.').replace('.attn.wo.', '.attn.proj.')
+        k = k.replace('.mlp.w1.', '.mlp.fc1.').replace('.mlp.w2.', '.mlp.fc2.')
+        out_dict[k] = v
+    return out_dict
+
+
+def checkpoint_filter_fn_classifier(
+        state_dict: Dict[str, torch.Tensor],
+        model: DeepseekVitClassifier,
+) -> Dict[str, torch.Tensor]:
+    """Load DeepSeek vision / timm encoder weights, or round-trip a fine-tuned classifier checkpoint.
+
+    Bare `norm.` / `head.` keys are the classifier's own only when this is not a source checkpoint --
+    there they are the LLM's final norm and output head (see `checkpoint_filter_fn_encoder`).
+    """
+    from_source = any(k.startswith('vision.') for k in state_dict)
+    local = {} if from_source else {k: v for k, v in state_dict.items() if k.startswith(('norm.', 'head.'))}
+    encoder = checkpoint_filter_fn_encoder({k: v for k, v in state_dict.items() if k not in local}, model.encoder)
+    return {**{f'encoder.{k}': v for k, v in encoder.items()}, **local}
+
+
+def _resolve_deepseek_out_features(variant: str, tag: str) -> int:
+    source_arch = variant.rsplit('_', 1)[0] if variant.endswith(('_enc', '_align')) else variant
+    source_name = f'{source_arch}.{tag}'
+    if source_name not in _SOURCE_CFGS:
+        raise ValueError('Specify out_features for a DeepSeek aligner with a custom pretrained configuration.')
+    return _SOURCE_CFGS[source_name]['out_features']
+
+
+def _create_deepseek_vit_classifier(variant: str, pretrained: bool = False, **kwargs) -> DeepseekVitClassifier:
+    pretrained_cfg = resolve_pretrained_cfg(
+        variant,
+        pretrained_cfg=kwargs.pop('pretrained_cfg', None),
+        pretrained_cfg_overlay=kwargs.pop('pretrained_cfg_overlay', None),
+    )
+    if kwargs.get('encoder_pool') == 'align' and 'out_features' not in kwargs:
+        kwargs['out_features'] = _resolve_deepseek_out_features(variant, pretrained_cfg.tag)
+    out_indices = kwargs.pop('out_indices', 3)
+    return build_model_with_cfg(
+        DeepseekVitClassifier,
+        variant,
+        pretrained,
+        pretrained_cfg=pretrained_cfg,
+        pretrained_filter_fn=checkpoint_filter_fn_classifier,
+        feature_cfg=dict(out_indices=out_indices, feature_cls='getter'),
+        **kwargs,
+    )
+
+
+def _create_deepseek_vit_encoder(variant: str, pretrained: bool = False, **kwargs) -> DeepseekVitEncoder:
+    pretrained_cfg = resolve_pretrained_cfg(
+        variant,
+        pretrained_cfg=kwargs.pop('pretrained_cfg', None),
+        pretrained_cfg_overlay=kwargs.pop('pretrained_cfg_overlay', None),
+    )
+    if 'out_features' not in kwargs:
+        kwargs['out_features'] = _resolve_deepseek_out_features(variant, pretrained_cfg.tag)
+    out_indices = kwargs.pop('out_indices', 3)
+    return build_model_with_cfg(
+        DeepseekVitEncoder,
+        variant,
+        pretrained,
+        pretrained_cfg=pretrained_cfg,
+        pretrained_filter_fn=checkpoint_filter_fn_encoder,
+        feature_cfg=dict(out_indices=out_indices, feature_cls='getter'),
+        kwargs_filter=('num_classes', 'drop_rate'),
+        **kwargs,
+    )
+
+
+def _cfg(url: str = '', **kwargs) -> Dict[str, Any]:
+    return {
+        'url': url,
+        # RoPE-only position encoding: any size divisible by the patch size works, the projector pads
+        # a leftover row/column. The default is the square grid the reference preprocessing produces
+        # at the checkpoint's own `vision_min_pixels`.
+        'input_size': (3, 546, 546),
+        # smallest sensible square grid: 9x9 patches, an exact 3x3 aligner grid with no padding.
+        # Needed because a plain min(size, target) downscale would not land on a multiple of 14.
+        'min_input_size': (3, 126, 126),
+        'pool_size': None,
+        'fixed_input_size': False,
+        'crop_pct': 1.0,
+        'crop_mode': 'squash',
+        'interpolation': 'bicubic',
+        'mean': (0.5, 0.5, 0.5),
+        'std': (0.5, 0.5, 0.5),
+        'num_classes': 0,
+        'license': 'mit',
+        **kwargs,
+    }
+
+
+_SOURCE_CFGS = {
+    # Upstream checkpoints for conversion: shard 1 of each repo holds the whole `vision.*` tower and
+    # `aligner.*`. `out_features` is the LLM hidden size the aligner projects to, independent of any
+    # classifier labels.
+    'deepseek_vit_412m.deepseek_v4_1_flash': _cfg(
+        hf_hub_id='deepseek-ai/DeepSeek-V4.1-Flash',
+        hf_hub_filename='model-00001-of-00048.safetensors',
+        out_features=5120,
+        input_size=(3, 546, 546),  # vision_min_pixels 544^2 -> 39x39 patches
+        origin_url='https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash',
+    ),
+    'deepseek_vit_412m.deepseek_v4_flash_vision_exp': _cfg(
+        hf_hub_id='deepseek-ai/DeepSeek-V4-Flash-Vision-Exp',
+        hf_hub_filename='model-00001-of-00048.safetensors',
+        out_features=4096,
+        input_size=(3, 392, 392),  # vision_min_pixels 384^2 -> 28x28 patches
+        origin_url='https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp',
+    ),
+}
+
+
+default_cfgs = generate_default_cfgs({
+    f'{name.split(".", 1)[0]}{suffix}.{name.split(".", 1)[1]}': dict(
+        ((k, v) for k, v in cfg.items() if k != 'out_features'),
+        first_conv='patch_embed.proj' if suffix == '_enc' else 'encoder.patch_embed.proj',
+        classifier=None if suffix == '_enc' else 'head',
+    )
+    for name, cfg in _SOURCE_CFGS.items()
+    for suffix in ('', '_align', '_enc')
+})
+
+
+@register_model
+def deepseek_vit_412m(pretrained: bool = False, **kwargs) -> DeepseekVitClassifier:
+    """DeepSeek vision classifier, 32 x 1024 (412M w/o projector). Source: DeepSeek-V4 / V4.1."""
+    return _create_deepseek_vit_classifier('deepseek_vit_412m', pretrained=pretrained, **kwargs)
+
+
+@register_model
+def deepseek_vit_412m_align(pretrained: bool = False, **kwargs) -> DeepseekVitClassifier:
+    """DeepSeek vision classifier retaining the native aligner and source LLM projection."""
+    model_args = dict(encoder_pool='align')
+    return _create_deepseek_vit_classifier(
+        'deepseek_vit_412m_align', pretrained=pretrained, **dict(model_args, **kwargs))
+
+
+@register_model
+def deepseek_vit_412m_enc(pretrained: bool = False, **kwargs) -> DeepseekVitEncoder:
+    """DeepSeek native vision encoder with the aligner and source LLM projection."""
+    return _create_deepseek_vit_encoder('deepseek_vit_412m_enc', pretrained=pretrained, **kwargs)


### PR DESCRIPTION
Closes #2772.

Adds the vision encoder of DeepSeek-AI's **DeepSeek-V4.1-Flash** and **DeepSeek-V4-Flash-Vision-Exp** as a standalone `timm` backbone, `deepseek_vit`, loading straight from the released checkpoints (MIT).

## Architecture

Plain pre-norm ViT: RMSNorm, fused QKV with bias, a **bias-free packed SwiGLU** MLP, and a final norm over the patch tokens. Position encoding is **axial 2D RoPE only** (theta 10000, `head_dim // 4` frequencies per axis, `[h | w]` blocks tiled for the 'half' rotation) — there is no learned position embedding, so any patch grid is native and nothing is resampled. Patches are embedded by a `Linear` over flattened `14 x 14` pixels. The VLM projector ("aligner": 3x3 pixel-unshuffle -> `Linear(9C, llm_dim)` -> GELU -> `Linear(llm_dim, llm_dim)`) is included.

The two checkpoints' `inference/vision.py` are byte-identical apart from whitespace: one architecture, two sets of weights, differing only in the width the aligner projects to.

| timm name | embed / depth / heads / MLP | params w/o projector | pretrained tags (source -> aligner width) |
|---|---|---|---|
| `deepseek_vit_412m` | 1024 / 32 / 16 / 2816 | 411.8M | `.deepseek_v4_1_flash` (5120), `.deepseek_v4_flash_vision_exp` (4096) |

With the aligner: 485.3M (V4.1) / 466.4M (V4).

## What's in the PR

**`timm/models/deepseek_vit.py`** (new) — `DeepseekVitEncoder` / `DeepseekVitClassifier`, following the split `qwen3_vit` and `gemma4_vit` settled on. Assembled from existing pieces: `PatchEmbed` (NHWC, non-strict size), `AttentionRope(qkv_fused=True, rotate_half=True, num_prefix_tokens=0)`, `RotaryEmbeddingCat(in_pixels=False, rotate_half=True)`, `GluMlp(act_layer=SiLU, gate_last=False, bias=False)`, `RmsNormFp32`.

* `forward_features` -> final-norm patch tokens as `(B, H, W, C)` (`output_fmt='NHWC'`, `feature_dim=-1`).
* Encoder `global_pool`: `'align'` (default, projector) / `'avg'` / `''`. Classifier `encoder_pool`: `''` (default) or `'align'`; `num_classes` is independent of `out_features`.
* Three registrations: `deepseek_vit_412m` (classifier), `_align` (classifier keeping the native projector), `_enc` (encoder returning projected tokens).
* `forward_intermediates` / `prune_intermediate_layers` / `features_only`, grad checkpointing, torchscript + fx traceable.

The local `DeepseekVitBlock` exists only because the reference keeps bias on the attention projections but **not** on the MLP, and `EvaBlock` has no MLP-bias control. Everything else inside it is a stock `timm` layer.

**`timm/models/__init__.py`** — import. **`tests/test_models.py`** — `deepseek_vit` added to `FEAT_INTER_FILTERS` and `deepseek_vit*` to `NON_STD_FILTERS`.

Pretrained cfgs point at the original DeepSeek repos with `hf_hub_filename` set to shard 1, which holds the whole `vision.*` tower and `aligner.*`, so `pretrained=True` works today with no re-hosting. That shard is 0.97 GB for V4.1 (vision tensors only) but 1.99 GB for V4 (it also carries `embed.weight`), against ~0.93 GB of actual encoder weights — so extracted encoder-only weights re-hosted under `timm/` (as for `gemma4_vit` / `qwen3_vit`) would be the nicer end state. Happy to prepare those.

### Three details that are load-bearing

1. **The aligner unshuffle is channel-major.** The reference builds it with `F.unfold`, whose output channel order is `(C, kh, kw)` — *not* the `(kh, kw, C)` order used by the Qwen and Gemma patch mergers. Getting this wrong permutes `fc1`'s input while every shape still matches: no load error, no exception, just a silently wrong projection. Called out in the docstring so the next person porting a merger does not copy the wrong one.
2. **`patch_embed` is an exact reshape, not an approximation.** The reference `Linear(3*14*14, 1024)` over a flattened `(C, pH, pW)` patch *is* a stride-14 `Conv2d` kernel, so the filter just reshapes. (Contrast `qwen3_vit`, where folding a `Conv3d` needed a float64 sum.)
3. **The source checkpoint's LLM tensors collide with timm names.** The full checkpoint has bare `norm.weight` and `head.weight` (the LLM's). The checkpoint filter trusts an unprefixed key only when the dict has no `vision.` keys at all, i.e. when it is already in timm layout.

`min_input_size=(3, 126, 126)` is set because the test suite's 384 / 128 / 96 targets are not multiples of 14; 126 is a 9x9 patch grid and an exact 3x3 aligner grid.

## Verification

Against the released `inference/vision.py` (`ViT` + `Aligner`) with the same weights. Scripts and JSON outputs available on request.

**float64, fully isolated** — one shared float64 RoPE table (timm builds its table in float32), and both sides' RMSNorm/rotary left in the tensor dtype. This matters: **the reference hardcodes `x.float()` in both `RMSNorm` and `apply_rotary`**, and `RmsNormFp32` mirrors it, so an "fp64" run is otherwise still bounded by fp32. The noise floor is the same timm model run with the unfused attention path.

| checkpoint | grid | vs reference | timm noise floor |
|---|---|---|---|
| V4.1-Flash | 39x39 | **2.22e-16** | 2.22e-16 |
| V4.1-Flash | 11x7 (padded) | **1.11e-16** | 2.22e-16 |
| V4-Flash-Vision-Exp | 39x39 | **5.55e-16** | 6.11e-16 |
| V4-Flash-Vision-Exp | 11x7 (padded) | **5.00e-16** | 3.89e-16 |

Exact — at or below the noise floor, for both aligned and zero-padded grids.

**float32, real image** (`inference/examples/images/carrots.jpeg` at 546x546, aligner output, `|ref|` ~0.8 / ~0.64). Cross-implementation error is at or below each implementation's *own* fp32-vs-float64 error, so fp32 precision is the limit, not the port:

| checkpoint | timm vs ref (max / mean) | timm's own fp32 err | reference's own fp32 err | cos |
|---|---|---|---|---|
| V4.1-Flash | 1.30e-5 / 1.83e-7 | 9.82e-6 | 1.17e-5 | 1.00000000 |
| V4-Flash-Vision-Exp | 2.85e-4 / 1.18e-6 | 5.65e-4 | 2.97e-4 | 0.99999999 |

(V4-Flash-Vision-Exp is the numerically touchier of the two in fp32 — that is a property of the weights, visible in the reference on its own.)

**bfloat16** (the checkpoints' own dtype), same image: cos 0.99900 (V4.1) / 0.99940 (V4) vs the reference run in bf16.

**Weight loading**: for both tags, `pretrained=True` yields all 263 tensors bit-identical to the source shard, strict load, no missing or unexpected keys. Round-trips checked for encoder -> encoder, source -> classifier (with and without the aligner), and classifier -> classifier.

**Regression**: no shared module is touched — the diff outside the new file is one import line and two test-filter entries — so no existing model can change. `pytest tests/test_models.py -k deepseek` is green (30 passed, 6 skipped; the 6 are `test_model_default_cfgs_non_std`, which skips any model whose nominal input size exceeds 320, as it does for `qwen3_vit` and `gemma4_vit`). That test's body was run separately at `min_input_size` for all 6 registered entries and passes. CUDA forward/backward checked in fp32 and bf16.

## Scope

Not included: the image preprocessing (the reference picks an aspect-preserving grid under a token budget and pads with gray), the LLM-side image span embeddings (`image_start` / `image_end` / `image_newline` / `image_pad`), and video input. The default cfg uses `crop_mode='squash'` with mean/std 0.5, which matches the reference normalization but not its dynamic sizing; `input_size` per tag is the square grid the reference preprocessing produces at that checkpoint's own `vision_min_pixels` (546x546 for V4.1, 392x392 for V4).
