### PR TITLE
Fix SAME padding for dilated max pooling

### DIFF
--- a/tests/test_layers_pool.py
+++ b/tests/test_layers_pool.py
@@ -12,6 +12,39 @@ if torch_backend is not None:
 torch_device = os.environ.get('TORCH_DEVICE', 'cpu')
 
 
+@pytest.mark.parametrize('api', ['functional', 'module', 'factory'])
+@pytest.mark.parametrize('input_size,kernel_size,stride,dilation,padding', [
+    ((5, 7), (3, 3), (2, 2), (1, 1), (1, 1, 1, 1)),
+    ((5, 7), (3, 3), (2, 2), (2, 2), (2, 2, 2, 2)),
+    ((6, 7), (2, 3), (2, 3), (3, 2), (2, 2, 1, 1)),
+    ((2, 3), (3, 2), (2, 2), (2, 3), (1, 2, 1, 2)),
+])
+def test_max_pool2d_same_dilation(api, input_size, kernel_size, stride, dilation, padding):
+    """Dilated SAME pooling preserves output size and matches explicitly padded pooling."""
+    from timm.layers.pool2d_same import MaxPool2dSame, create_pool2d, max_pool2d_same
+
+    # Negative inputs also verify that padded values cannot become maxima at the borders.
+    height, width = input_size
+    x = -torch.arange(1, height * width + 1, device=torch_device, dtype=torch.float32).reshape(1, 1, height, width)
+    expected = torch.nn.functional.max_pool2d(
+        torch.nn.functional.pad(x, padding, value=-float('inf')),
+        kernel_size,
+        stride,
+        dilation=dilation,
+    )
+
+    if api == 'functional':
+        actual = max_pool2d_same(x, kernel_size, stride, dilation=dilation)
+    elif api == 'module':
+        actual = MaxPool2dSame(kernel_size, stride, dilation=dilation)(x)
+    else:
+        actual = create_pool2d('max', kernel_size, stride, padding='same', dilation=dilation)(x)
+
+    expected_shape = ((height + stride[0] - 1) // stride[0], (width + stride[1] - 1) // stride[1])
+    assert actual.shape[-2:] == expected_shape
+    torch.testing.assert_close(actual, expected)
+
+
 # Adaptive Avg/Max Pooling Tests
 
 class TestAdaptiveAvgMaxPool:

--- a/timm/layers/pool2d_same.py
+++ b/timm/layers/pool2d_same.py
@@ -55,7 +55,7 @@ def max_pool2d_same(
         dilation: List[int] = (1, 1),
         ceil_mode: bool = False,
 ):
-    x = pad_same(x, kernel_size, stride, value=-float('inf'))
+    x = pad_same(x, kernel_size, stride, dilation, value=-float('inf'))
     return F.max_pool2d(x, kernel_size, stride, (0, 0), dilation, ceil_mode)
 
 
@@ -77,7 +77,7 @@ class MaxPool2dSame(nn.MaxPool2d):
         super().__init__(kernel_size, stride, (0, 0), dilation, ceil_mode)
 
     def forward(self, x):
-        x = pad_same(x, self.kernel_size, self.stride, value=-float('inf'))
+        x = pad_same(x, self.kernel_size, self.stride, self.dilation, value=-float('inf'))
         return F.max_pool2d(x, self.kernel_size, self.stride, (0, 0), self.dilation, self.ceil_mode)
 
 


### PR DESCRIPTION
`max_pool2d_same` and `MaxPool2dSame` apply dilation during max pooling but omit it when computing the preceding SAME padding. With a 5 x 7 input, kernel size 3, stride 2, and dilation 2, the result has spatial shape 2 x 3 instead of 3 x 4. Smaller inputs can raise an output-size error.

This forwards dilation to the existing `pad_same` helper in both paths. Regression tests cover the functional API, module, and `create_pool2d(..., padding='same')`, including asymmetric padding, different dilation values on each axis, small inputs, and unchanged unit dilation. Expected values use explicitly padded PyTorch max pooling; negative inputs check border handling.

Validation (CPU, Python 3.13.5, PyTorch 2.10.0):

- Before the fix: `python -m pytest tests/test_layers_pool.py -k max_pool2d_same_dilation -q` — 9 failed, 3 passed.
- After the fix: `python -m pytest tests/test_layers_pool.py -q` — 102 passed, with 31 existing TorchScript deprecation warnings.
- Scalar dilation smoke checks passed for module/factory paths in eager and TorchScript execution.
- `git diff --check` passed.

Full model tests and GPU tests were not run. No pretrained weights were needed.

AI assistance: Codex helped identify the issue, implement the fix and regression tests, and review the changes. The reported local checks were executed.
