### PR TITLE
Support non-RGB pretrained input channel transfer

### DIFF
--- a/hfdocs/source/quickstart.mdx
+++ b/hfdocs/source/quickstart.mdx
@@ -74,6 +74,50 @@ You can finetune any of the pre-trained models just by changing the classifier (
 
 To fine-tune on your own dataset, you have to write a PyTorch training loop or adapt `timm`'s [training script](training_script) to use your dataset.
 
+## Adapt Pretrained Weights to Different Input Channels
+
+Set `in_chans` to the number of channels your model will receive. For a non-RGB
+checkpoint, its pretrained configuration's `input_size[0]` must describe the
+**source checkpoint's** channel count. For example, to use two stacked 13-band
+images with a matching 13-band ResNet-18 checkpoint:
+
+```py
+model = timm.create_model(
+    'resnet18',
+    pretrained=True,
+    in_chans=26,
+    num_classes=10,
+    pretrained_cfg_overlay={
+        'file': 'path/to/your_13_band_resnet18.pth',
+        'input_size': (13, 224, 224),
+        'num_classes': 10,
+    },
+)
+```
+
+This example requires your own checkpoint with the matching architecture and
+source class count. Input convolution weights are repeated or truncated in
+channel order, then multiplied by the source-to-target channel ratio. Thus a
+13-to-26 conversion repeats the weights twice and scales them by 1/2; repeated
+copies of the same frame preserve the input convolution's response. A 13-to-11
+conversion keeps the first 11 channels and scales by 13/11. Matching channel
+counts load unchanged. Conversion to one channel sums the source-channel weights.
+
+For direct weight conversion, specify the same source information explicitly:
+
+```py
+from timm.models import adapt_input_conv
+
+temporal_weights = adapt_input_conv(26, pretrained_weights, base_chans=13)
+```
+
+`base_chans` describes physical image channels, which can differ from a
+space-to-depth stem's convolution input dimension. The existing RGB default and
+space-to-depth grayscale conversion remain supported; other space-to-depth
+channel conversions still use the unsupported-format fallback during loading.
+Band-specific selection, semantic band matching, and normalization are not
+inferred: arrange the bands and preprocessing for your sensor and task.
+
 ## Use a Pretrained Model for Feature Extraction
 
 Without modifying the network, one can call model.forward_features(input) on any model instead of the usual model(input). This will bypass the head classifier and global pooling for networks.

--- a/tests/test_input_conv.py
+++ b/tests/test_input_conv.py
@@ -1,0 +1,174 @@
+import pytest
+import torch
+from torch import nn
+
+from timm.models._builder import load_pretrained
+from timm.models._manipulate import adapt_input_conv
+
+
+def _weights(channels, dtype=torch.float32):
+    return torch.arange(2 * channels * 3 * 3, dtype=dtype).reshape(2, channels, 3, 3) / 100
+
+
+def _reference_channels(weight, source_channels, target_channels):
+    if target_channels == source_channels:
+        return weight.clone()
+    if target_channels == 1:
+        return weight.sum(dim=1, keepdim=True)
+    return torch.stack([
+        weight[:, channel % source_channels] * (source_channels / target_channels)
+        for channel in range(target_channels)
+    ], dim=1)
+
+
+@pytest.mark.parametrize('source,target', [(13, 13), (13, 26), (13, 52), (13, 11), (11, 13), (13, 3), (13, 1)])
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float16, torch.bfloat16])
+def test_adapt_non_rgb_input_conv(source, target, dtype):
+    weight = _weights(source, dtype=dtype)
+    original = weight.clone()
+
+    result = adapt_input_conv(target, weight, base_chans=source)
+
+    expected = _reference_channels(original.float(), source, target).to(dtype)
+    torch.testing.assert_close(result, expected)
+    torch.testing.assert_close(weight, original, rtol=0, atol=0)
+    assert result.dtype == dtype
+
+
+@pytest.mark.parametrize('base_channels', [3, 13])
+def test_space_to_depth_grayscale_preserves_spatial_groups(base_channels):
+    weight = _weights(base_channels * 4)
+    expected = torch.stack([
+        weight[:, offset:offset + base_channels].sum(dim=1)
+        for offset in range(0, base_channels * 4, base_channels)
+    ], dim=1)
+
+    result = adapt_input_conv(1, weight, base_chans=base_channels)
+
+    torch.testing.assert_close(result, expected)
+
+
+@pytest.mark.parametrize('target', [1, 2, 3, 4, 6])
+def test_default_rgb_conversion_is_preserved(target):
+    weight = _weights(3)
+    original = weight.clone()
+
+    result = adapt_input_conv(target, weight)
+
+    torch.testing.assert_close(result, _reference_channels(original, 3, target))
+    torch.testing.assert_close(weight, original, rtol=0, atol=0)
+
+
+def test_matching_channel_count_preserves_double_precision():
+    weight = _weights(13, dtype=torch.float64)
+
+    result = adapt_input_conv(13, weight, base_chans=13)
+
+    torch.testing.assert_close(result, weight, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize('target,source', [(0, 13), (13, 0), (-1, 13), (13, -1)])
+def test_channel_counts_must_be_positive(target, source):
+    with pytest.raises(ValueError, match='positive'):
+        adapt_input_conv(target, _weights(13), base_chans=source)
+
+
+class _SensorModel(nn.Module):
+    def __init__(self, channels, second_stem=False, linear_stem=False):
+        super().__init__()
+        self.stem = nn.Linear(channels, 2, bias=False) if linear_stem else nn.Conv2d(channels, 2, 3, bias=False)
+        if second_stem:
+            self.other_stem = nn.Conv2d(channels, 2, 3, bias=False)
+        self.head = nn.Linear(2, 2)
+
+
+def _load_sensor_model(source_channels, target_channels, second_stem=False, linear_stem=False, input_size=True):
+    source = _SensorModel(source_channels, second_stem, linear_stem)
+    with torch.no_grad():
+        for index, parameter in enumerate(source.parameters()):
+            parameter.copy_(torch.arange(parameter.numel()).reshape(parameter.shape) / 100 + index)
+    target = _SensorModel(target_channels, second_stem, linear_stem)
+    original_target = {key: value.clone() for key, value in target.state_dict().items()}
+    state_dict = {key: value.clone() for key, value in source.state_dict().items()}
+    cfg = {
+        'state_dict': state_dict,
+        'first_conv': ('stem', 'other_stem') if second_stem else 'stem',
+        'classifier': 'head',
+        'num_classes': 2,
+    }
+    if input_size:
+        cfg['input_size'] = (source_channels, 8, 8)
+    load_pretrained(target, cfg, num_classes=2, in_chans=target_channels)
+    return source, target, original_target, state_dict
+
+
+@pytest.mark.parametrize('source_channels,target_channels', [
+    (13, 13), (13, 26), (13, 52), (13, 11), (11, 13), (13, 3), (13, 1), (3, 1), (3, 6),
+])
+@pytest.mark.parametrize('second_stem', [False, True])
+def test_load_pretrained_uses_source_channel_metadata(source_channels, target_channels, second_stem):
+    source, target, _, _ = _load_sensor_model(source_channels, target_channels, second_stem)
+    stem_names = ['stem', 'other_stem'] if second_stem else ['stem']
+    for name in stem_names:
+        source_weight = getattr(source, name).weight
+        expected = _reference_channels(source_weight, source_channels, target_channels)
+        torch.testing.assert_close(getattr(target, name).weight, expected)
+    torch.testing.assert_close(target.head.weight, source.head.weight, rtol=0, atol=0)
+    torch.testing.assert_close(target.head.bias, source.head.bias, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize('frames', [2, 4])
+def test_temporal_stacking_preserves_response_to_repeated_frames(frames):
+    source, target, _, _ = _load_sensor_model(13, 13 * frames)
+    image = torch.linspace(-1, 1, 13 * 8 * 8).reshape(1, 13, 8, 8)
+
+    actual = target.stem(image.repeat(1, frames, 1, 1))
+    expected = source.stem(image)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_grayscale_matches_repeating_one_band_for_every_pretrained_channel():
+    source, target, _, _ = _load_sensor_model(13, 1)
+    image = torch.linspace(-1, 1, 8 * 8).reshape(1, 1, 8, 8)
+
+    torch.testing.assert_close(target.stem(image), source.stem(image.repeat(1, 13, 1, 1)))
+
+
+def test_missing_source_metadata_retains_rgb_default():
+    source, target, _, _ = _load_sensor_model(3, 6, input_size=False)
+    torch.testing.assert_close(target.stem.weight, _reference_channels(source.stem.weight, 3, 6))
+
+
+def test_unsupported_non_rgb_linear_stem_keeps_existing_fallback():
+    source, target, original, _ = _load_sensor_model(13, 3, linear_stem=True)
+    torch.testing.assert_close(target.stem.weight, original['stem.weight'], rtol=0, atol=0)
+    torch.testing.assert_close(target.head.weight, source.head.weight, rtol=0, atol=0)
+
+
+def test_non_grayscale_space_to_depth_conversion_remains_explicitly_unsupported():
+    with pytest.raises(NotImplementedError):
+        adapt_input_conv(26, _weights(52), base_chans=13)
+
+
+@pytest.mark.parametrize('frames', [1, 2])
+def test_create_model_transfers_multispectral_checkpoint(frames):
+    import timm
+
+    source = timm.create_model('resnet18', pretrained=False, in_chans=13, num_classes=2).eval()
+    cfg = dict(
+        source.pretrained_cfg,
+        state_dict=source.state_dict(),
+        input_size=(13, 32, 32),
+        num_classes=2,
+    )
+    target = timm.create_model(
+        'resnet18', pretrained=True, in_chans=13 * frames, num_classes=2, pretrained_cfg=cfg,
+    ).eval()
+
+    for name, weight in source.state_dict().items():
+        expected = _reference_channels(weight, 13, 13 * frames) if name == 'conv1.weight' else weight
+        torch.testing.assert_close(target.state_dict()[name], expected, rtol=0, atol=0)
+    image = torch.linspace(-1, 1, 13 * 32 * 32).reshape(1, 13, 32, 32)
+    with torch.no_grad():
+        torch.testing.assert_close(target(image.repeat(1, frames, 1, 1)), source(image))

--- a/timm/models/_builder.py
+++ b/timm/models/_builder.py
@@ -245,15 +245,18 @@ def load_pretrained(
             state_dict = filter_fn(state_dict)
 
     input_convs = pretrained_cfg.get('first_conv', None)
-    if input_convs is not None and in_chans != 3:
+    pretrained_in_chans = (pretrained_cfg.get('input_size') or (3,))[0]
+    if input_convs is not None and in_chans != pretrained_in_chans:
         if isinstance(input_convs, str):
             input_convs = (input_convs,)
         for input_conv_name in input_convs:
             weight_name = input_conv_name + '.weight'
             try:
-                state_dict[weight_name] = adapt_input_conv(in_chans, state_dict[weight_name])
+                state_dict[weight_name] = adapt_input_conv(
+                    in_chans, state_dict[weight_name], base_chans=pretrained_in_chans)
                 _logger.info(
-                    f'Converted input conv {input_conv_name} pretrained weights from 3 to {in_chans} channel(s)')
+                    f'Converted input conv {input_conv_name} pretrained weights '
+                    f'from {pretrained_in_chans} to {in_chans} channel(s)')
             except NotImplementedError as e:
                 del state_dict[weight_name]
                 strict = False

--- a/timm/models/_manipulate.py
+++ b/timm/models/_manipulate.py
@@ -286,9 +286,26 @@ def checkpoint_seq(
     return x
 
 
-def adapt_input_conv(in_chans: int, conv_weight: Tensor) -> Tensor:
-    conv_type = conv_weight.dtype
-    conv_weight = conv_weight.float()  # Some weights are in torch.half, ensure it's float for sum on CPU
+def adapt_input_conv(in_chans: int, conv_weight: Tensor, base_chans: int = 3) -> Tensor:
+    """Adapt pretrained input convolution weights to a different channel count.
+
+    Args:
+        in_chans: Number of input channels for the target model.
+        conv_weight: Pretrained Conv2d weights in OIHW layout.
+        base_chans: Number of physical input channels used for pretraining. This
+            can differ from the weight's input dimension for space-to-depth stems.
+
+    Returns:
+        Weights with repeated/truncated channels scaled by ``base_chans / in_chans``.
+        Single-channel inputs instead sum the source channels, preserving separate
+        spatial groups for space-to-depth stems. Matching channel counts are unchanged.
+
+    Raises:
+        ValueError: If either channel count is not positive.
+        NotImplementedError: If the weight format cannot be adapted.
+    """
+    if in_chans < 1 or base_chans < 1:
+        raise ValueError('Input and base channel counts must be positive.')
     if conv_weight.ndim != 4:
         # Non-Conv2d first-conv weight (e.g., Linear patch embed in NaFlexVit /
         # Gemma4Vit). Can't infer the (C, P, P) factorization from shape alone,
@@ -297,23 +314,27 @@ def adapt_input_conv(in_chans: int, conv_weight: Tensor) -> Tensor:
             f'adapt_input_conv only supports 4D Conv2d weights; got ndim={conv_weight.ndim}.'
         )
     O, I, J, K = conv_weight.shape
+    if in_chans == base_chans:
+        return conv_weight
+    conv_type = conv_weight.dtype
+    conv_weight = conv_weight.float()  # Some weights are in torch.half, ensure it's float for sum on CPU
     if in_chans == 1:
-        if I > 3:
-            assert conv_weight.shape[1] % 3 == 0
+        if I > base_chans:
+            assert I % base_chans == 0
             # For models with space2depth stems
-            conv_weight = conv_weight.reshape(O, I // 3, 3, J, K)
+            conv_weight = conv_weight.reshape(O, I // base_chans, base_chans, J, K)
             conv_weight = conv_weight.sum(dim=2, keepdim=False)
         else:
             conv_weight = conv_weight.sum(dim=1, keepdim=True)
-    elif in_chans != 3:
-        if I != 3:
+    else:
+        if I != base_chans:
             raise NotImplementedError('Weight format not supported by conversion.')
         else:
             # NOTE this strategy should be better than random init, but there could be other combinations of
-            # the original RGB input layer weights that'd work better for specific cases.
-            repeat = int(math.ceil(in_chans / 3))
+            # the original input layer weights that'd work better for specific cases.
+            repeat = int(math.ceil(in_chans / base_chans))
             conv_weight = conv_weight.repeat(1, repeat, 1, 1)[:, :in_chans, :, :]
-            conv_weight *= (3 / float(in_chans))
+            conv_weight *= (base_chans / float(in_chans))
     conv_weight = conv_weight.to(conv_type)
     return conv_weight
 


### PR DESCRIPTION
## Summary

Pretrained input-convolution conversion currently assumes three source channels. For a 13-band checkpoint, requesting the same 13 channels or a 26-channel temporal stack can discard the pretrained stem and leave it randomly initialized; requesting three channels can instead reach a state-dict shape mismatch.

This change uses the source checkpoint's `pretrained_cfg.input_size[0]` when loading weights and adds a backward-compatible `base_chans=3` argument to `adapt_input_conv`. It addresses the multispectral and temporal-stacking workflow in #2445, including the distinction between physical image channels and space-to-depth convolution dimensions discussed there.

- Matching source/target channel counts load without conversion.
- Other supported Conv2d stems repeat or truncate channels and scale by the source-to-target channel ratio. For example, 13 to 26 channels repeats the weights twice and scales by 1/2.
- Grayscale conversion sums physical source channels while preserving space-to-depth groups.
- The RGB default and existing unsupported-format fallback remain available. The loader handles single and multiple input stems.
- The quickstart documents a complete non-RGB checkpoint-loading example and the channel metadata contract.

This is an initialization strategy, not semantic band matching. Sensor band ordering and normalization remain the caller's responsibility. Repeating an identical frame preserves the original convolution response; no downstream accuracy improvement is claimed.

## Validation

- The initial regression suite produced 42 failures and 10 passes against the previous implementation.
- The final input-conversion and existing checkpoint suites pass: **72 passed** (59 new conversion/loading cases and 13 existing checkpoint cases).
- Cases cover 13-to-13/26/52/11/3/1 and 11-to-13 transfer, fp32/fp16/bf16 weights, exact no-op preservation, source tensor immutability, RGB compatibility, space-to-depth grayscale conversion, dual stems, and unsupported linear stems.
- Two full ResNet-18 `create_model(pretrained=True, ...)` tests verify every transferred state-dict tensor and forward-output equivalence for identical repeated frames. They use local synthetic checkpoints and do not download model weights.
- An independent file-checkpoint smoke test verifies `pretrained_cfg_overlay['file']`, defaulting to the source's 13 channels, and 13-to-26 full-model output equivalence.
- `git diff --check` passes. The full model matrix and documentation build were not run.

```bash
python -m pytest tests/test_input_conv.py tests/test_checkpoint_loading.py -q
```

Developed with AI assistance; regression failures and the validation above were run locally.
